### PR TITLE
Add Infomaniak DNS provider

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,6 +37,7 @@ body:
         - DNS Made Easy
         - Gandi LiveDNS
         - GoDaddy
+        - Infomaniak DNS
         - Google Cloud DNS
         - TransIP DNS
         - Other

--- a/src/Acmebot.App.Tests/Acmebot.App.Tests.csproj
+++ b/src/Acmebot.App.Tests/Acmebot.App.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Acmebot.App\Acmebot.App.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Acmebot.App.Tests/InfomaniakProviderTests.cs
+++ b/src/Acmebot.App.Tests/InfomaniakProviderTests.cs
@@ -1,0 +1,271 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+using Acmebot.App.Providers;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+/// <summary>
+/// Tests for InfomaniakProvider using a fake HTTP handler — no real domain required.
+/// Each test enqueues mock JSON responses matching the Infomaniak REST API v1 format.
+/// </summary>
+public sealed class InfomaniakProviderTests
+{
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /// <summary>Builds a fake 200 response with an Infomaniak-style success envelope.</summary>
+    private static HttpResponseMessage OkJson(object data)
+    {
+        var payload = JsonSerializer.Serialize(new { result = "success", data });
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json")
+        };
+    }
+
+    /// <summary>Builds a fake 200 response with an empty data array.</summary>
+    private static HttpResponseMessage OkEmpty() => OkJson(Array.Empty<object>());
+
+    /// <summary>Creates a provider backed by the given recording handler.</summary>
+    private static (InfomaniakProvider Provider, RecordingHandler Handler) CreateProvider()
+    {
+        var handler = new RecordingHandler();
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.infomaniak.com/1/") };
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
+        return (new InfomaniakProvider(http), handler);
+    }
+
+    // -------------------------------------------------------------------------
+    // ListZonesAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ListZonesAsync_ReturnsMappedZones()
+    {
+        var (provider, handler) = CreateProvider();
+
+        handler.Enqueue(_ => OkJson(new[]
+        {
+            new { id = 1, customer_name = "example.com" },
+            new { id = 2, customer_name = "other.net" }
+        }));
+
+        var zones = await provider.ListZonesAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, zones.Count);
+        Assert.Equal("1", zones[0].Id);
+        Assert.Equal("example.com", zones[0].Name);
+        Assert.Equal("2", zones[1].Id);
+        Assert.Equal("other.net", zones[1].Name);
+    }
+
+    [Fact]
+    public async Task ListZonesAsync_EmptyResponse_ReturnsEmptyList()
+    {
+        var (provider, handler) = CreateProvider();
+        handler.Enqueue(_ => OkEmpty());
+
+        var zones = await provider.ListZonesAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(zones);
+    }
+
+    [Fact]
+    public async Task ListZonesAsync_RequestHasBearerToken()
+    {
+        var (provider, handler) = CreateProvider();
+        handler.Enqueue(_ => OkEmpty());
+
+        await provider.ListZonesAsync(TestContext.Current.CancellationToken);
+
+        var req = Assert.Single(handler.Requests);
+        Assert.True(req.Headers.TryGetValue("Authorization", out var auth));
+        Assert.Equal("Bearer test-token", auth[0]);
+    }
+
+    // -------------------------------------------------------------------------
+    // CreateTxtRecordAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateTxtRecordAsync_SendsOneRequestPerValue()
+    {
+        var (provider, handler) = CreateProvider();
+
+        // Two values → two POST requests
+        handler.Enqueue(_ => OkJson(new { id = "r1" }));
+        handler.Enqueue(_ => OkJson(new { id = "r2" }));
+
+        var zone = new DnsZone(provider) { Id = "42", Name = "example.com" };
+
+        await provider.CreateTxtRecordAsync(
+            zone,
+            "_acme-challenge",
+            ["token-a", "token-b"],
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.All(handler.Requests, r => Assert.Equal(HttpMethod.Post, r.Method));
+    }
+
+    [Fact]
+    public async Task CreateTxtRecordAsync_PostBodyContainsExpectedFields()
+    {
+        var (provider, handler) = CreateProvider();
+        handler.Enqueue(_ => OkJson(new { id = "r1" }));
+
+        var zone = new DnsZone(provider) { Id = "42", Name = "example.com" };
+
+        await provider.CreateTxtRecordAsync(
+            zone,
+            "_acme-challenge",
+            ["my-token"],
+            TestContext.Current.CancellationToken);
+
+        var req = Assert.Single(handler.Requests);
+        var body = JsonDocument.Parse(req.Content!);
+
+        Assert.Equal("TXT", body.RootElement.GetProperty("type").GetString());
+        Assert.Equal("_acme-challenge", body.RootElement.GetProperty("source").GetString());
+        Assert.Equal("my-token", body.RootElement.GetProperty("target").GetString());
+        Assert.Equal(60, body.RootElement.GetProperty("ttl").GetInt32());
+    }
+
+    // -------------------------------------------------------------------------
+    // DeleteTxtRecordAsync
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task DeleteTxtRecordAsync_DeletesEachRecord()
+    {
+        var (provider, handler) = CreateProvider();
+
+        // First: list records → two results
+        handler.Enqueue(_ => OkJson(new[]
+        {
+            new { id = "r1", source = "_acme-challenge", target = "token-a" },
+            new { id = "r2", source = "_acme-challenge", target = "token-b" }
+        }));
+
+        // Then: two DELETE requests
+        handler.Enqueue(_ => OkJson(new { }));
+        handler.Enqueue(_ => OkJson(new { }));
+
+        var zone = new DnsZone(provider) { Id = "42", Name = "example.com" };
+
+        await provider.DeleteTxtRecordAsync(
+            zone,
+            "_acme-challenge",
+            TestContext.Current.CancellationToken);
+
+        var deletes = handler.Requests.Where(r => r.Method == HttpMethod.Delete).ToList();
+        Assert.Equal(2, deletes.Count);
+        Assert.Contains(deletes, r => r.RequestUri!.ToString().EndsWith("/r1"));
+        Assert.Contains(deletes, r => r.RequestUri!.ToString().EndsWith("/r2"));
+    }
+
+    [Fact]
+    public async Task DeleteTxtRecordAsync_NoRecords_SendsNoDeleteRequest()
+    {
+        var (provider, handler) = CreateProvider();
+        handler.Enqueue(_ => OkEmpty()); // list returns nothing
+
+        var zone = new DnsZone(provider) { Id = "42", Name = "example.com" };
+
+        await provider.DeleteTxtRecordAsync(
+            zone,
+            "_acme-challenge",
+            TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(handler.Requests, r => r.Method == HttpMethod.Delete);
+    }
+
+    [Fact]
+    public async Task DeleteTxtRecordAsync_404OnDelete_IsIgnored()
+    {
+        var (provider, handler) = CreateProvider();
+
+        handler.Enqueue(_ => OkJson(new[]
+        {
+            new { id = "r1", source = "_acme-challenge", target = "token-a" }
+        }));
+
+        // Simulate a 404 — should not throw
+        handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        var zone = new DnsZone(provider) { Id = "42", Name = "example.com" };
+
+        await provider.DeleteTxtRecordAsync(
+            zone,
+            "_acme-challenge",
+            TestContext.Current.CancellationToken);
+
+        // If we reach here without exception, the test passes
+    }
+
+    // -------------------------------------------------------------------------
+    // Provider metadata
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Name_IsInfomaniak()
+    {
+        var (provider, _) = CreateProvider();
+        Assert.Equal("Infomaniak", provider.Name);
+    }
+
+    [Fact]
+    public void PropagationDelay_IsPositive()
+    {
+        var (provider, _) = CreateProvider();
+        Assert.True(provider.PropagationDelay > TimeSpan.Zero);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal recording handler (mirrors Acmebot.Acme.Tests.RecordingHandler)
+// ---------------------------------------------------------------------------
+
+internal sealed class RecordingHandler : HttpMessageHandler
+{
+    private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> _responses = new();
+
+    public List<RecordedRequest> Requests { get; } = [];
+
+    /// <summary>Enqueue a response factory that will be dequeued on the next HTTP call.</summary>
+    public void Enqueue(Func<HttpRequestMessage, HttpResponseMessage> factory)
+        => _responses.Enqueue(factory);
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Requests.Add(await RecordedRequest.CreateAsync(request, cancellationToken));
+
+        return _responses.TryDequeue(out var factory)
+            ? factory(request)
+            : throw new InvalidOperationException("No response was configured for this HTTP request.");
+    }
+}
+
+/// <summary>Snapshot of an outgoing HTTP request for assertion purposes.</summary>
+internal sealed record RecordedRequest(
+    HttpMethod Method,
+    Uri? RequestUri,
+    IReadOnlyDictionary<string, IReadOnlyList<string>> Headers,
+    string? Content)
+{
+    public static async Task<RecordedRequest> CreateAsync(HttpRequestMessage req, CancellationToken ct) =>
+        new(
+            req.Method,
+            req.RequestUri,
+            req.Headers.ToDictionary(
+                h => h.Key,
+                h => (IReadOnlyList<string>)h.Value.ToArray(),
+                StringComparer.OrdinalIgnoreCase),
+            req.Content is null ? null : await req.Content.ReadAsStringAsync(ct));
+}

--- a/src/Acmebot.App/Acmebot.App.csproj
+++ b/src/Acmebot.App/Acmebot.App.csproj
@@ -37,6 +37,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Acmebot.App.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="wwwroot\**">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Acmebot.App/Options/AcmebotOptions.cs
+++ b/src/Acmebot.App/Options/AcmebotOptions.cs
@@ -50,6 +50,8 @@ public class AcmebotOptions
 
     public GoogleDnsOptions? GoogleDns { get; set; }
 
+    public InfomaniakOptions? Infomaniak { get; set; }
+
     public IonosDnsOptions? IonosDns { get; set; }
 
     public Route53Options? Route53 { get; set; }

--- a/src/Acmebot.App/Options/InfomaniakOptions.cs
+++ b/src/Acmebot.App/Options/InfomaniakOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace Acmebot.App.Options;
+
+/// <summary>
+/// Configuration options for the Infomaniak DNS provider.
+/// Requires an API token generated from the Infomaniak Manager with the "domain" scope.
+/// </summary>
+public class InfomaniakOptions
+{
+    /// <summary>OAuth2 Bearer token with DNS management permissions.</summary>
+    public required string ApiToken { get; set; }
+}

--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -130,6 +130,7 @@ builder.Services.AddSingleton<IEnumerable<IDnsProvider>>(provider =>
     dnsProviders.TryAdd(options.GandiLiveDns, o => new GandiLiveDnsProvider(o));
     dnsProviders.TryAdd(options.GoDaddy, o => new GoDaddyProvider(o));
     dnsProviders.TryAdd(options.GoogleDns, o => new GoogleDnsProvider(o));
+    dnsProviders.TryAdd(options.Infomaniak, o => new InfomaniakProvider(o));
     dnsProviders.TryAdd(options.IonosDns, o => new IonosDnsProvider(o));
     dnsProviders.TryAdd(options.Route53, o => new Route53Provider(o));
     dnsProviders.TryAdd(options.TransIp, o => new TransIpProvider(options, o, credential));

--- a/src/Acmebot.App/Providers/InfomaniakProvider.cs
+++ b/src/Acmebot.App/Providers/InfomaniakProvider.cs
@@ -1,0 +1,140 @@
+﻿using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+using Acmebot.App.Options;
+
+namespace Acmebot.App.Providers;
+
+/// <summary>
+/// DNS provider for Infomaniak using the REST API v1.
+/// Docs: https://developer.infomaniak.com/
+/// Requires an API token with the "domain" scope.
+/// </summary>
+public class InfomaniakProvider : IDnsProvider
+{
+    public InfomaniakProvider(InfomaniakOptions options)
+    {
+        var http = new HttpClient { BaseAddress = new Uri("https://api.infomaniak.com/1/") };
+        http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.ApiToken);
+        _client = new InfomaniakClient(http);
+    }
+
+    /// <summary>Internal constructor for unit tests — inject a pre-configured HttpClient.</summary>
+    internal InfomaniakProvider(HttpClient httpClient)
+    {
+        _client = new InfomaniakClient(httpClient);
+    }
+
+    private readonly InfomaniakClient _client;
+
+    public string Name => "Infomaniak";
+
+    /// <summary>Infomaniak DNS propagation is typically fast.</summary>
+    public TimeSpan PropagationDelay => TimeSpan.FromSeconds(30);
+
+    /// <summary>Returns all DNS zones available for the configured token.</summary>
+    public async Task<IReadOnlyList<DnsZone>> ListZonesAsync(CancellationToken cancellationToken = default)
+    {
+        var zones = await _client.ListZonesAsync(cancellationToken);
+
+        return zones
+            .Select(z => new DnsZone(this) { Id = z.Id.ToString(), Name = z.CustomerName })
+            .ToList();
+    }
+
+    /// <summary>Creates one TXT record per value for the ACME DNS-01 challenge.</summary>
+    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
+    {
+        foreach (var value in values)
+        {
+            await _client.CreateRecordAsync(zone.Id, relativeRecordName, value, cancellationToken);
+        }
+    }
+
+    /// <summary>Deletes all TXT records matching the challenge record name.</summary>
+    public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
+    {
+        var records = await _client.ListRecordsAsync(zone.Id, relativeRecordName, cancellationToken);
+
+        foreach (var record in records)
+        {
+            try
+            {
+                await _client.DeleteRecordAsync(zone.Id, record.Id, cancellationToken);
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                // Record already deleted — safe to ignore
+            }
+        }
+    }
+
+    /// <summary>HTTP client wrapper for the Infomaniak DNS API.</summary>
+    private class InfomaniakClient(HttpClient http)
+    {
+        private readonly HttpClient _http = http;
+
+        /// <summary>GET /1/zone — returns all DNS zones accessible with the token.</summary>
+        public async Task<IReadOnlyList<Zone>> ListZonesAsync(CancellationToken cancellationToken = default)
+        {
+            var response = await _http.GetFromJsonAsync<ApiResponse<Zone[]>>("zone", cancellationToken);
+            return response?.Data ?? [];
+        }
+
+        /// <summary>GET /1/zone/{zoneId}/record — returns TXT records matching the given source.</summary>
+        public async Task<IReadOnlyList<Record>> ListRecordsAsync(string zoneId, string source, CancellationToken cancellationToken = default)
+        {
+            var response = await _http.GetFromJsonAsync<ApiResponse<Record[]>>($"zone/{zoneId}/record?type=TXT&source={source}", cancellationToken);
+            return response?.Data ?? [];
+        }
+
+        /// <summary>POST /1/zone/{zoneId}/record — creates a TXT record for the ACME challenge.</summary>
+        public async Task CreateRecordAsync(string zoneId, string source, string target, CancellationToken cancellationToken = default)
+        {
+            var body = new { type = "TXT", source, target, ttl = 60 };
+            var response = await _http.PostAsJsonAsync($"zone/{zoneId}/record", body, cancellationToken);
+            response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>DELETE /1/zone/{zoneId}/record/{recordId} — removes a specific DNS record.</summary>
+        public async Task DeleteRecordAsync(string zoneId, string recordId, CancellationToken cancellationToken = default)
+        {
+            var response = await _http.DeleteAsync($"zone/{zoneId}/record/{recordId}", cancellationToken);
+            response.EnsureSuccessStatusCode();
+        }
+    }
+
+    internal class ApiResponse<T>
+    {
+        [JsonPropertyName("result")]
+        public string? Result { get; set; }
+
+        [JsonPropertyName("data")]
+        public T? Data { get; set; }
+    }
+
+    internal class Zone
+    {
+        [JsonPropertyName("id")]
+        public required int Id { get; set; }
+
+        /// <summary>Domain name as returned by Infomaniak (e.g. "example.com").</summary>
+        [JsonPropertyName("customer_name")]
+        public required string CustomerName { get; set; }
+    }
+
+    internal class Record
+    {
+        [JsonPropertyName("id")]
+        public required string Id { get; set; }
+
+        [JsonPropertyName("source")]
+        public required string Source { get; set; }
+
+        [JsonPropertyName("target")]
+        public required string Target { get; set; }
+    }
+}

--- a/src/Acmebot.slnx
+++ b/src/Acmebot.slnx
@@ -2,4 +2,5 @@
   <Project Path="Acmebot.Acme.Tests/Acmebot.Acme.Tests.csproj" />
   <Project Path="Acmebot.Acme/Acmebot.Acme.csproj" Id="c532397c-d225-4b1d-8b80-4b63ce03eef5" />
   <Project Path="Acmebot.App/Acmebot.App.csproj" />
+  <Project Path="Acmebot.App.Tests/Acmebot.App.Tests.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

- Add `InfomaniakProvider` implementing `IDnsProvider` via the Infomaniak REST API v1
- Add `InfomaniakOptions` with a single `ApiToken` property (OAuth2 Bearer, scope: `domain`)
- Register the provider in `Program.cs` and `AcmebotOptions`
- Add `Acmebot.App.Tests` project with 10 unit tests (mock HTTP handler, no real domain required)
- Add Infomaniak DNS to the bug report template dropdown

## Related Issue

- Closes #

## What Changed

- `src/Acmebot.App/Providers/InfomaniakProvider.cs` — new provider (functions ≤ 30 lines, fully documented)
- `src/Acmebot.App/Options/InfomaniakOptions.cs` — new options class
- `src/Acmebot.App/Options/AcmebotOptions.cs` — added `InfomaniakOptions? Infomaniak`
- `src/Acmebot.App/Program.cs` — registered with `TryAdd`
- `src/Acmebot.App/Acmebot.App.csproj` — added `InternalsVisibleTo` for test project
- `src/Acmebot.App.Tests/` — new test project (xunit v3, `RecordingHandler` pattern)
- `.github/ISSUE_TEMPLATE/bug_report.yml` — added Infomaniak DNS to provider dropdown

## Validation

- [x] `dotnet build -c Release ./src`
- [x] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./src`
- [x] `az bicep build -f ./deploy/azuredeploy.bicep`
- [x] Documentation updated if needed

## Notes

- API base URL: `https://api.infomaniak.com/1/`
- Auth: OAuth2 Bearer token (generated from Infomaniak Manager)
- Propagation delay: 30 seconds
- Wiki documentation update (provider configuration page) to be done separately by maintainers