### PR TITLE
Add UnitedDomains provider

### DIFF
--- a/src/Acmebot.App/Options/AcmebotOptions.cs
+++ b/src/Acmebot.App/Options/AcmebotOptions.cs
@@ -55,4 +55,6 @@ public class AcmebotOptions
     public Route53Options? Route53 { get; set; }
 
     public TransIpOptions? TransIp { get; set; }
+
+    public UnitedDomainsOptions? UnitedDomains { get; set; }
 }

--- a/src/Acmebot.App/Options/UnitedDomainsOptions.cs
+++ b/src/Acmebot.App/Options/UnitedDomainsOptions.cs
@@ -1,0 +1,6 @@
+namespace Acmebot.App.Options;
+
+public class UnitedDomainsOptions
+{
+    public required string ApiKey { get; set; }
+}

--- a/src/Acmebot.App/Options/UnitedDomainsOptions.cs
+++ b/src/Acmebot.App/Options/UnitedDomainsOptions.cs
@@ -1,4 +1,4 @@
-namespace Acmebot.App.Options;
+﻿namespace Acmebot.App.Options;
 
 public class UnitedDomainsOptions
 {

--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -138,6 +138,7 @@ builder.Services.AddSingleton<IEnumerable<IDnsProvider>>(provider =>
     dnsProviders.TryAdd(options.IonosDns, o => new IonosDnsProvider(o));
     dnsProviders.TryAdd(options.Route53, o => new Route53Provider(o));
     dnsProviders.TryAdd(options.TransIp, o => new TransIpProvider(options, o, credential));
+    dnsProviders.TryAdd(options.UnitedDomains, o => new UnitedDomainsProvider(o));
 
     if (dnsProviders.Count == 0)
     {

--- a/src/Acmebot.App/Providers/UnitedDomainsProvider.cs
+++ b/src/Acmebot.App/Providers/UnitedDomainsProvider.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+using Acmebot.App.Options;
+
+namespace Acmebot.App.Providers;
+
+public class UnitedDomainsProvider(UnitedDomainsOptions options) : IDnsProvider
+{
+    private readonly UnitedDomainsClient _client = new(options.ApiKey);
+
+    public string Name => "UnitedDomains";
+
+    public TimeSpan PropagationDelay => TimeSpan.FromSeconds(60);
+
+    public async Task<IReadOnlyList<DnsZone>> ListZonesAsync(CancellationToken cancellationToken = default)
+    {
+        var zones = await _client.ListZonesAsync(cancellationToken);
+
+        return zones.Select(z => new DnsZone(this) { Id = z.Id, Name = z.Name }).ToList();
+    }
+
+    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
+    {
+        var recordName = $"{relativeRecordName}.{zone.Name}";
+
+        var records = values.Select(v => new RecordParam
+        {
+            Name = recordName,
+            Type = "TXT",
+            Content = v,
+            Ttl = 60
+        }).ToArray();
+
+        await _client.CreateRecordsAsync(zone.Id, records, cancellationToken);
+    }
+
+    public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
+    {
+        var recordName = $"{relativeRecordName}.{zone.Name}";
+
+        var zoneDetail = await _client.GetZoneAsync(zone.Id, recordName, "TXT", cancellationToken);
+
+        foreach (var record in zoneDetail.Records ?? [])
+        {
+            try
+            {
+                await _client.DeleteRecordAsync(zone.Id, record.Id, cancellationToken);
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                // ignored
+            }
+        }
+    }
+
+    private class UnitedDomainsClient
+    {
+        public UnitedDomainsClient(string apiKey)
+        {
+            _httpClient = new HttpClient
+            {
+                BaseAddress = new Uri("https://dnsapi.united-domains.de/dns/")
+            };
+
+            _httpClient.DefaultRequestHeaders.Add("X-API-Key", apiKey);
+        }
+
+        private readonly HttpClient _httpClient;
+
+        public async Task<IReadOnlyList<Zone>> ListZonesAsync(CancellationToken cancellationToken = default)
+        {
+            var result = await _httpClient.GetFromJsonAsync<Zone[]>("v1/zones", cancellationToken);
+
+            return result ?? [];
+        }
+
+        public async Task<CustomerZone> GetZoneAsync(string zoneId, string recordName, string recordType, CancellationToken cancellationToken = default)
+        {
+            var result = await _httpClient.GetFromJsonAsync<CustomerZone>(
+                $"v1/zones/{zoneId}?recordName={Uri.EscapeDataString(recordName)}&recordType={Uri.EscapeDataString(recordType)}",
+                cancellationToken);
+
+            return result ?? new CustomerZone { Id = zoneId, Name = string.Empty };
+        }
+
+        public async Task CreateRecordsAsync(string zoneId, RecordParam[] records, CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.PostAsJsonAsync($"v1/zones/{zoneId}/records", records, cancellationToken);
+
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task DeleteRecordAsync(string zoneId, string recordId, CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.DeleteAsync($"v1/zones/{zoneId}/records/{recordId}", cancellationToken);
+
+            response.EnsureSuccessStatusCode();
+        }
+    }
+
+    internal class Zone
+    {
+        [JsonPropertyName("id")]
+        public required string Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public required string Name { get; set; }
+    }
+
+    internal class CustomerZone
+    {
+        [JsonPropertyName("id")]
+        public required string Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public required string Name { get; set; }
+
+        [JsonPropertyName("records")]
+        public RecordResponse[]? Records { get; set; }
+    }
+
+    internal class RecordParam
+    {
+        [JsonPropertyName("name")]
+        public required string Name { get; set; }
+
+        [JsonPropertyName("type")]
+        public required string Type { get; set; }
+
+        [JsonPropertyName("content")]
+        public required string Content { get; set; }
+
+        [JsonPropertyName("ttl")]
+        public int Ttl { get; set; }
+    }
+
+    internal class RecordResponse
+    {
+        [JsonPropertyName("id")]
+        public required string Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public required string Name { get; set; }
+
+        [JsonPropertyName("type")]
+        public required string Type { get; set; }
+
+        [JsonPropertyName("content")]
+        public required string Content { get; set; }
+    }
+}

--- a/src/Acmebot.App/Providers/UnitedDomainsProvider.cs
+++ b/src/Acmebot.App/Providers/UnitedDomainsProvider.cs
@@ -8,146 +8,147 @@ namespace Acmebot.App.Providers;
 
 public class UnitedDomainsProvider(UnitedDomainsOptions options) : IDnsProvider
 {
-    private readonly UnitedDomainsClient _client = new(options.ApiKey);
+  private readonly UnitedDomainsClient _client = new(options.ApiKey);
 
-    public string Name => "UnitedDomains";
+  public string Name => "UnitedDomains";
 
-    public TimeSpan PropagationDelay => TimeSpan.FromSeconds(60);
+  public TimeSpan PropagationDelay => TimeSpan.FromSeconds(60);
 
-    public async Task<IReadOnlyList<DnsZone>> ListZonesAsync(CancellationToken cancellationToken = default)
+  public async Task<IReadOnlyList<DnsZone>> ListZonesAsync(CancellationToken cancellationToken = default)
+  {
+    var zones = await _client.ListZonesAsync(cancellationToken);
+
+    return zones.Select(z => new DnsZone(this) { Id = z.Id, Name = z.Name }).ToList();
+  }
+
+  public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
+  {
+    var recordName = $"{relativeRecordName}.{zone.Name}";
+
+    var records = values.Select(v => new RecordParam
     {
-        var zones = await _client.ListZonesAsync(cancellationToken);
+      Name = recordName,
+      Type = "TXT",
+      Content = v,
+      Ttl = 60
+    }).ToArray();
 
-        return zones.Select(z => new DnsZone(this) { Id = z.Id, Name = z.Name }).ToList();
+    await _client.CreateRecordsAsync(zone.Id, records, cancellationToken);
+  }
+
+  public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
+  {
+    var recordName = $"{relativeRecordName}.{zone.Name}";
+
+    var zoneDetail = await _client.GetZoneAsync(zone.Id, recordName, "TXT", cancellationToken);
+
+    foreach (var record in zoneDetail.Records ?? [])
+    {
+      try
+      {
+        await _client.DeleteRecordAsync(zone.Id, record.Id, cancellationToken);
+      }
+      catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+      {
+        // ignored
+      }
+    }
+  }
+
+  private class UnitedDomainsClient
+  {
+    public UnitedDomainsClient(string apiKey)
+    {
+      _httpClient = new HttpClient
+      {
+        BaseAddress = new Uri("https://dnsapi.united-domains.de/dns/")
+      };
+
+      _httpClient.DefaultRequestHeaders.Add("X-API-Key", apiKey);
+      _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("acmebot");
     }
 
-    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
+    private readonly HttpClient _httpClient;
+
+    public async Task<IReadOnlyList<Zone>> ListZonesAsync(CancellationToken cancellationToken = default)
     {
-        var recordName = $"{relativeRecordName}.{zone.Name}";
+      var result = await _httpClient.GetFromJsonAsync<Zone[]>("v1/zones", cancellationToken);
 
-        var records = values.Select(v => new RecordParam
-        {
-            Name = recordName,
-            Type = "TXT",
-            Content = v,
-            Ttl = 60
-        }).ToArray();
-
-        await _client.CreateRecordsAsync(zone.Id, records, cancellationToken);
+      return result ?? [];
     }
 
-    public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
+    public async Task<CustomerZone> GetZoneAsync(string zoneId, string recordName, string recordType, CancellationToken cancellationToken = default)
     {
-        var recordName = $"{relativeRecordName}.{zone.Name}";
+      var result = await _httpClient.GetFromJsonAsync<CustomerZone>(
+          $"v1/zones/{zoneId}?recordName={Uri.EscapeDataString(recordName)}&recordType={Uri.EscapeDataString(recordType)}",
+          cancellationToken);
 
-        var zoneDetail = await _client.GetZoneAsync(zone.Id, recordName, "TXT", cancellationToken);
-
-        foreach (var record in zoneDetail.Records ?? [])
-        {
-            try
-            {
-                await _client.DeleteRecordAsync(zone.Id, record.Id, cancellationToken);
-            }
-            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-            {
-                // ignored
-            }
-        }
+      return result ?? new CustomerZone { Id = zoneId, Name = string.Empty };
     }
 
-    private class UnitedDomainsClient
+    public async Task CreateRecordsAsync(string zoneId, RecordParam[] records, CancellationToken cancellationToken = default)
     {
-        public UnitedDomainsClient(string apiKey)
-        {
-            _httpClient = new HttpClient
-            {
-                BaseAddress = new Uri("https://dnsapi.united-domains.de/dns/")
-            };
+      var response = await _httpClient.PostAsJsonAsync($"v1/zones/{zoneId}/records", records, cancellationToken);
 
-            _httpClient.DefaultRequestHeaders.Add("X-API-Key", apiKey);
-        }
-
-        private readonly HttpClient _httpClient;
-
-        public async Task<IReadOnlyList<Zone>> ListZonesAsync(CancellationToken cancellationToken = default)
-        {
-            var result = await _httpClient.GetFromJsonAsync<Zone[]>("v1/zones", cancellationToken);
-
-            return result ?? [];
-        }
-
-        public async Task<CustomerZone> GetZoneAsync(string zoneId, string recordName, string recordType, CancellationToken cancellationToken = default)
-        {
-            var result = await _httpClient.GetFromJsonAsync<CustomerZone>(
-                $"v1/zones/{zoneId}?recordName={Uri.EscapeDataString(recordName)}&recordType={Uri.EscapeDataString(recordType)}",
-                cancellationToken);
-
-            return result ?? new CustomerZone { Id = zoneId, Name = string.Empty };
-        }
-
-        public async Task CreateRecordsAsync(string zoneId, RecordParam[] records, CancellationToken cancellationToken = default)
-        {
-            var response = await _httpClient.PostAsJsonAsync($"v1/zones/{zoneId}/records", records, cancellationToken);
-
-            response.EnsureSuccessStatusCode();
-        }
-
-        public async Task DeleteRecordAsync(string zoneId, string recordId, CancellationToken cancellationToken = default)
-        {
-            var response = await _httpClient.DeleteAsync($"v1/zones/{zoneId}/records/{recordId}", cancellationToken);
-
-            response.EnsureSuccessStatusCode();
-        }
+      response.EnsureSuccessStatusCode();
     }
 
-    internal class Zone
+    public async Task DeleteRecordAsync(string zoneId, string recordId, CancellationToken cancellationToken = default)
     {
-        [JsonPropertyName("id")]
-        public required string Id { get; set; }
+      var response = await _httpClient.DeleteAsync($"v1/zones/{zoneId}/records/{recordId}", cancellationToken);
 
-        [JsonPropertyName("name")]
-        public required string Name { get; set; }
+      response.EnsureSuccessStatusCode();
     }
+  }
 
-    internal class CustomerZone
-    {
-        [JsonPropertyName("id")]
-        public required string Id { get; set; }
+  internal class Zone
+  {
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
 
-        [JsonPropertyName("name")]
-        public required string Name { get; set; }
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+  }
 
-        [JsonPropertyName("records")]
-        public RecordResponse[]? Records { get; set; }
-    }
+  internal class CustomerZone
+  {
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
 
-    internal class RecordParam
-    {
-        [JsonPropertyName("name")]
-        public required string Name { get; set; }
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
 
-        [JsonPropertyName("type")]
-        public required string Type { get; set; }
+    [JsonPropertyName("records")]
+    public RecordResponse[]? Records { get; set; }
+  }
 
-        [JsonPropertyName("content")]
-        public required string Content { get; set; }
+  internal class RecordParam
+  {
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
 
-        [JsonPropertyName("ttl")]
-        public int Ttl { get; set; }
-    }
+    [JsonPropertyName("type")]
+    public required string Type { get; set; }
 
-    internal class RecordResponse
-    {
-        [JsonPropertyName("id")]
-        public required string Id { get; set; }
+    [JsonPropertyName("content")]
+    public required string Content { get; set; }
 
-        [JsonPropertyName("name")]
-        public required string Name { get; set; }
+    [JsonPropertyName("ttl")]
+    public int Ttl { get; set; }
+  }
 
-        [JsonPropertyName("type")]
-        public required string Type { get; set; }
+  internal class RecordResponse
+  {
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
 
-        [JsonPropertyName("content")]
-        public required string Content { get; set; }
-    }
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonPropertyName("type")]
+    public required string Type { get; set; }
+
+    [JsonPropertyName("content")]
+    public required string Content { get; set; }
+  }
 }

--- a/src/Acmebot.App/Providers/UnitedDomainsProvider.cs
+++ b/src/Acmebot.App/Providers/UnitedDomainsProvider.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 
@@ -64,6 +65,7 @@ public class UnitedDomainsProvider(UnitedDomainsOptions options) : IDnsProvider
         BaseAddress = new Uri("https://dnsapi.united-domains.de/dns/")
       };
 
+      _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
       _httpClient.DefaultRequestHeaders.Add("X-API-Key", apiKey);
       _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("acmebot");
     }

--- a/src/Acmebot.App/Providers/UnitedDomainsProvider.cs
+++ b/src/Acmebot.App/Providers/UnitedDomainsProvider.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
@@ -9,148 +9,148 @@ namespace Acmebot.App.Providers;
 
 public class UnitedDomainsProvider(UnitedDomainsOptions options) : IDnsProvider
 {
-  private readonly UnitedDomainsClient _client = new(options.ApiKey);
+    private readonly UnitedDomainsClient _client = new(options.ApiKey);
 
-  public string Name => "UnitedDomains";
+    public string Name => "UnitedDomains";
 
-  public TimeSpan PropagationDelay => TimeSpan.FromSeconds(60);
+    public TimeSpan PropagationDelay => TimeSpan.FromSeconds(60);
 
-  public async Task<IReadOnlyList<DnsZone>> ListZonesAsync(CancellationToken cancellationToken = default)
-  {
-    var zones = await _client.ListZonesAsync(cancellationToken);
-
-    return zones.Select(z => new DnsZone(this) { Id = z.Id, Name = z.Name }).ToList();
-  }
-
-  public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
-  {
-    var recordName = $"{relativeRecordName}.{zone.Name}";
-
-    var records = values.Select(v => new RecordParam
+    public async Task<IReadOnlyList<DnsZone>> ListZonesAsync(CancellationToken cancellationToken = default)
     {
-      Name = recordName,
-      Type = "TXT",
-      Content = v,
-      Ttl = 60
-    }).ToArray();
+        var zones = await _client.ListZonesAsync(cancellationToken);
 
-    await _client.CreateRecordsAsync(zone.Id, records, cancellationToken);
-  }
-
-  public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
-  {
-    var recordName = $"{relativeRecordName}.{zone.Name}";
-
-    var zoneDetail = await _client.GetZoneAsync(zone.Id, recordName, "TXT", cancellationToken);
-
-    foreach (var record in zoneDetail.Records ?? [])
-    {
-      try
-      {
-        await _client.DeleteRecordAsync(zone.Id, record.Id, cancellationToken);
-      }
-      catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-      {
-        // ignored
-      }
-    }
-  }
-
-  private class UnitedDomainsClient
-  {
-    public UnitedDomainsClient(string apiKey)
-    {
-      _httpClient = new HttpClient
-      {
-        BaseAddress = new Uri("https://dnsapi.united-domains.de/dns/")
-      };
-
-      _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-      _httpClient.DefaultRequestHeaders.Add("X-API-Key", apiKey);
-      _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("acmebot");
+        return zones.Select(z => new DnsZone(this) { Id = z.Id, Name = z.Name }).ToList();
     }
 
-    private readonly HttpClient _httpClient;
-
-    public async Task<IReadOnlyList<Zone>> ListZonesAsync(CancellationToken cancellationToken = default)
+    public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
-      var result = await _httpClient.GetFromJsonAsync<Zone[]>("v1/zones", cancellationToken);
+        var recordName = $"{relativeRecordName}.{zone.Name}";
 
-      return result ?? [];
+        var records = values.Select(v => new RecordParam
+        {
+            Name = recordName,
+            Type = "TXT",
+            Content = v,
+            Ttl = 60
+        }).ToArray();
+
+        await _client.CreateRecordsAsync(zone.Id, records, cancellationToken);
     }
 
-    public async Task<CustomerZone> GetZoneAsync(string zoneId, string recordName, string recordType, CancellationToken cancellationToken = default)
+    public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
     {
-      var result = await _httpClient.GetFromJsonAsync<CustomerZone>(
-          $"v1/zones/{zoneId}?recordName={Uri.EscapeDataString(recordName)}&recordType={Uri.EscapeDataString(recordType)}",
-          cancellationToken);
+        var recordName = $"{relativeRecordName}.{zone.Name}";
 
-      return result ?? new CustomerZone { Id = zoneId, Name = string.Empty };
+        var zoneDetail = await _client.GetZoneAsync(zone.Id, recordName, "TXT", cancellationToken);
+
+        foreach (var record in zoneDetail.Records ?? [])
+        {
+            try
+            {
+                await _client.DeleteRecordAsync(zone.Id, record.Id, cancellationToken);
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                // ignored
+            }
+        }
     }
 
-    public async Task CreateRecordsAsync(string zoneId, RecordParam[] records, CancellationToken cancellationToken = default)
+    private class UnitedDomainsClient
     {
-      var response = await _httpClient.PostAsJsonAsync($"v1/zones/{zoneId}/records", records, cancellationToken);
+        public UnitedDomainsClient(string apiKey)
+        {
+            _httpClient = new HttpClient
+            {
+                BaseAddress = new Uri("https://dnsapi.united-domains.de/dns/")
+            };
 
-      response.EnsureSuccessStatusCode();
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _httpClient.DefaultRequestHeaders.Add("X-API-Key", apiKey);
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("acmebot");
+        }
+
+        private readonly HttpClient _httpClient;
+
+        public async Task<IReadOnlyList<Zone>> ListZonesAsync(CancellationToken cancellationToken = default)
+        {
+            var result = await _httpClient.GetFromJsonAsync<Zone[]>("v1/zones", cancellationToken);
+
+            return result ?? [];
+        }
+
+        public async Task<CustomerZone> GetZoneAsync(string zoneId, string recordName, string recordType, CancellationToken cancellationToken = default)
+        {
+            var result = await _httpClient.GetFromJsonAsync<CustomerZone>(
+                $"v1/zones/{zoneId}?recordName={Uri.EscapeDataString(recordName)}&recordType={Uri.EscapeDataString(recordType)}",
+                cancellationToken);
+
+            return result ?? new CustomerZone { Id = zoneId, Name = string.Empty };
+        }
+
+        public async Task CreateRecordsAsync(string zoneId, RecordParam[] records, CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.PostAsJsonAsync($"v1/zones/{zoneId}/records", records, cancellationToken);
+
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task DeleteRecordAsync(string zoneId, string recordId, CancellationToken cancellationToken = default)
+        {
+            var response = await _httpClient.DeleteAsync($"v1/zones/{zoneId}/records/{recordId}", cancellationToken);
+
+            response.EnsureSuccessStatusCode();
+        }
     }
 
-    public async Task DeleteRecordAsync(string zoneId, string recordId, CancellationToken cancellationToken = default)
+    internal class Zone
     {
-      var response = await _httpClient.DeleteAsync($"v1/zones/{zoneId}/records/{recordId}", cancellationToken);
+        [JsonPropertyName("id")]
+        public required string Id { get; set; }
 
-      response.EnsureSuccessStatusCode();
+        [JsonPropertyName("name")]
+        public required string Name { get; set; }
     }
-  }
 
-  internal class Zone
-  {
-    [JsonPropertyName("id")]
-    public required string Id { get; set; }
+    internal class CustomerZone
+    {
+        [JsonPropertyName("id")]
+        public required string Id { get; set; }
 
-    [JsonPropertyName("name")]
-    public required string Name { get; set; }
-  }
+        [JsonPropertyName("name")]
+        public required string Name { get; set; }
 
-  internal class CustomerZone
-  {
-    [JsonPropertyName("id")]
-    public required string Id { get; set; }
+        [JsonPropertyName("records")]
+        public RecordResponse[]? Records { get; set; }
+    }
 
-    [JsonPropertyName("name")]
-    public required string Name { get; set; }
+    internal class RecordParam
+    {
+        [JsonPropertyName("name")]
+        public required string Name { get; set; }
 
-    [JsonPropertyName("records")]
-    public RecordResponse[]? Records { get; set; }
-  }
+        [JsonPropertyName("type")]
+        public required string Type { get; set; }
 
-  internal class RecordParam
-  {
-    [JsonPropertyName("name")]
-    public required string Name { get; set; }
+        [JsonPropertyName("content")]
+        public required string Content { get; set; }
 
-    [JsonPropertyName("type")]
-    public required string Type { get; set; }
+        [JsonPropertyName("ttl")]
+        public int Ttl { get; set; }
+    }
 
-    [JsonPropertyName("content")]
-    public required string Content { get; set; }
+    internal class RecordResponse
+    {
+        [JsonPropertyName("id")]
+        public required string Id { get; set; }
 
-    [JsonPropertyName("ttl")]
-    public int Ttl { get; set; }
-  }
+        [JsonPropertyName("name")]
+        public required string Name { get; set; }
 
-  internal class RecordResponse
-  {
-    [JsonPropertyName("id")]
-    public required string Id { get; set; }
+        [JsonPropertyName("type")]
+        public required string Type { get; set; }
 
-    [JsonPropertyName("name")]
-    public required string Name { get; set; }
-
-    [JsonPropertyName("type")]
-    public required string Type { get; set; }
-
-    [JsonPropertyName("content")]
-    public required string Content { get; set; }
-  }
+        [JsonPropertyName("content")]
+        public required string Content { get; set; }
+    }
 }


### PR DESCRIPTION
This pull request adds support for United Domains as a DNS provider in the application. The main changes introduce a new provider implementation, configuration options, and integration into the provider selection logic.

**United Domains DNS provider integration:**

* Added a new `UnitedDomainsProvider` class that implements the `IDnsProvider` interface, allowing DNS operations (listing zones, creating and deleting TXT records) using the United Domains API. This includes an internal API client and data models for interacting with the United Domains DNS API.
* Updated the provider registration logic in `Program.cs` to include the new `UnitedDomainsProvider`, enabling it to be selected and used based on configuration.

**Configuration changes:**

* Added a new `UnitedDomainsOptions` class to hold the API key required for authenticating with the United Domains API.
* Extended the main `AcmebotOptions` configuration class to include an optional `UnitedDomains` property for configuring the new provider.## Summary

-

## Related Issue

- Closes #1024

## Validation

- [x] `dotnet build -c Release ./Acmebot.slnx`
- [x] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx`
- [ ] `az bicep build -f ./deploy/azuredeploy.bicep`
- [ ] Documentation updated if needed