### PR TITLE
Change Dependabot directory from '/src' to '/'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/src"
+    directory: "/"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
This pull request makes a minor configuration change to the Dependabot settings. The update changes the directory that Dependabot scans for NuGet dependencies from `/src` to the root directory `/`.