### PR TITLE
Refactor HTTP client initialization in DnsMadeEasyProvider and TransIpProvider

### DIFF
--- a/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
+++ b/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
@@ -63,7 +63,7 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
     {
         public DnsMadeEasyClient(string apiKey, string secretKey)
         {
-            _httpClient = new HttpClient(new ApiKeyHandler(apiKey, secretKey, new HttpClientHandler()))
+            _httpClient = new HttpClient(new ApiKeyHandler(apiKey, secretKey))
             {
                 BaseAddress = new Uri("https://api.dnsmadeeasy.com/V2.0/dns/")
             };
@@ -101,7 +101,7 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
             response.EnsureSuccessStatusCode();
         }
 
-        private sealed class ApiKeyHandler(string apiKey, string secretKey, HttpMessageHandler innerHandler) : DelegatingHandler(innerHandler)
+        private sealed class ApiKeyHandler(string apiKey, string secretKey) : DelegatingHandler(new HttpClientHandler())
         {
             private string ApiKey { get; } = apiKey;
 

--- a/src/Acmebot.App/Providers/TransIpProvider.cs
+++ b/src/Acmebot.App/Providers/TransIpProvider.cs
@@ -125,7 +125,7 @@ public class TransIpProvider : IDnsProvider
         }
     }
 
-    private class TransIpSignHandler(string customerName, CryptographyClient cryptoClient) : DelegatingHandler
+    private class TransIpSignHandler(string customerName, CryptographyClient cryptoClient) : DelegatingHandler(new HttpClientHandler())
     {
         private readonly HttpClient _httpClient = new() { BaseAddress = new Uri("https://api.transip.nl/v6/") };
 


### PR DESCRIPTION
This pull request simplifies the construction of custom HTTP message handlers in both the `DnsMadeEasyProvider` and `TransIpProvider` classes. The main change is to ensure that custom `DelegatingHandler` implementations always use a default `HttpClientHandler` as their inner handler, rather than requiring it to be passed in from the outside.

**Refactoring of HTTP handler construction:**

* In `DnsMadeEasyProvider.cs`, the `ApiKeyHandler` class was changed to always use a new `HttpClientHandler` as its inner handler, simplifying its constructor and the way it is instantiated in `DnsMadeEasyClient`. [[1]](diffhunk://#diff-7a2da47667968afba3fb582ba81cc8e7d0b0a24f38686670bce51d4f84925988L66-R66) [[2]](diffhunk://#diff-7a2da47667968afba3fb582ba81cc8e7d0b0a24f38686670bce51d4f84925988L104-R104)
* In `TransIpProvider.cs`, the `TransIpSignHandler` class was updated to inherit from `DelegatingHandler(new HttpClientHandler())`, ensuring it always uses a default HTTP handler.

Ref https://github.com/polymind-inc/acmebot/discussions/1032