### PR TITLE
Refactor output handling in HTTP functions to use typed output

### DIFF
--- a/src/Acmebot.App/Functions/Http/GetCertificates.cs
+++ b/src/Acmebot.App/Functions/Http/GetCertificates.cs
@@ -36,7 +36,9 @@ public partial class GetCertificates(IHttpContextAccessor httpContextAccessor, I
 
         var metadata = await starter.WaitForInstanceCompletionAsync(instanceId, getInputsAndOutputs: true);
 
-        return Ok(metadata.SerializedOutput);
+        var output = metadata.ReadOutputAs<IReadOnlyList<CertificateItem>>();
+
+        return Ok(output);
     }
 
     [LoggerMessage(LogLevel.Information, "Certificate list retrieval orchestration started. InstanceId: {InstanceId}")]

--- a/src/Acmebot.App/Functions/Http/GetDnsZones.cs
+++ b/src/Acmebot.App/Functions/Http/GetDnsZones.cs
@@ -36,7 +36,9 @@ public partial class GetDnsZones(IHttpContextAccessor httpContextAccessor, ILogg
 
         var metadata = await starter.WaitForInstanceCompletionAsync(instanceId, getInputsAndOutputs: true);
 
-        return Ok(metadata.SerializedOutput);
+        var output = metadata.ReadOutputAs<IReadOnlyList<DnsZoneGroup>>();
+
+        return Ok(output);
     }
 
     [LoggerMessage(LogLevel.Information, "DNS zone retrieval orchestration started. InstanceId: {InstanceId}")]

--- a/src/Acmebot.App/Functions/Http/GetInstanceState.cs
+++ b/src/Acmebot.App/Functions/Http/GetInstanceState.cs
@@ -21,18 +21,18 @@ public partial class GetInstanceState(IHttpContextAccessor httpContextAccessor, 
             return Unauthorized();
         }
 
-        var status = await starter.GetInstanceAsync(instanceId, getInputsAndOutputs: true);
+        var metadata = await starter.GetInstanceAsync(instanceId, getInputsAndOutputs: true);
 
-        if (status is null)
+        if (metadata is null)
         {
             LogInstanceStateNotFound(logger, instanceId);
 
             return BadRequest();
         }
 
-        return status.RuntimeStatus switch
+        return metadata.RuntimeStatus switch
         {
-            OrchestrationRuntimeStatus.Failed => Problem(status.SerializedOutput),
+            OrchestrationRuntimeStatus.Failed => Problem(metadata.FailureDetails?.ErrorMessage, type: metadata.FailureDetails?.ErrorType),
             OrchestrationRuntimeStatus.Running or OrchestrationRuntimeStatus.Pending => AcceptedAtFunction($"{nameof(GetInstanceState)}_{nameof(HttpStart)}", new { instanceId }, null),
             _ => Ok()
         };

--- a/src/Acmebot.App/Functions/Http/RevokeCertificate.cs
+++ b/src/Acmebot.App/Functions/Http/RevokeCertificate.cs
@@ -47,7 +47,12 @@ public partial class RevokeCertificate(IHttpContextAccessor httpContextAccessor,
 
         var metadata = await starter.WaitForInstanceCompletionAsync(instanceId, getInputsAndOutputs: true);
 
-        return Ok(metadata.SerializedOutput);
+        if (metadata.RuntimeStatus != OrchestrationRuntimeStatus.Completed)
+        {
+            return Problem();
+        }
+
+        return Ok();
     }
 
     [LoggerMessage(LogLevel.Information, "Certificate revocation orchestration started. CertificateName: {CertificateName}. InstanceId: {InstanceId}")]


### PR DESCRIPTION
This pull request refactors several HTTP-triggered Azure Function endpoints to improve how orchestration results are returned and error handling is performed. The main changes involve deserializing outputs to strongly-typed objects, enhancing error reporting, and standardizing response handling across endpoints.

**Improvements to output handling:**

* `GetCertificates.cs`, `GetDnsZones.cs`: Instead of returning `SerializedOutput` directly, the orchestration output is now deserialized into strongly-typed lists (`IReadOnlyList<CertificateItem>` and `IReadOnlyList<DnsZoneGroup>`) before being returned, providing clients with structured data. [[1]](diffhunk://#diff-ec6ef7208023ca2a49878f089fc7483d3045dbcc83243a8b5289b3a709ec5d6fL39-R41) [[2]](diffhunk://#diff-53b07662f72e5dc8bd20b187781ad1f9ad6a6b8b87f7caf0f8c19d1cdb6351afL39-R41)

**Enhanced error and status handling:**

* [`GetInstanceState.cs`](diffhunk://#diff-4e0950812191889144860705d00b5e64cf6801754d5468923f53c7376c2b9dbfL24-R35): The variable `status` is renamed to `metadata` for clarity, and error handling is improved by returning the orchestration's error message and type when the status is `Failed`.
* [`RevokeCertificate.cs`](diffhunk://#diff-5533c1a95934bacf76e33fe0f71e45acfaedb141e6e26887290d7449c0a37b24L50-R55): The function now checks the orchestration's runtime status and only returns `Ok()` if the status is `Completed`; otherwise, it returns a problem response, ensuring clients receive appropriate feedback on failures.