### PR TITLE
Add dashboard-vnext (Vite + Vue) and CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   DOTNET_VERSION: 10.0.x
+  NODE_VERSION: 24.x
   BICEP_VERSION: 0.42.1
 
 jobs:
@@ -23,6 +24,13 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        cache: npm
+        cache-dependency-path: src/Acmebot.App/ClientApp/package-lock.json
+
     - name: Use Bicep ${{ env.BICEP_VERSION }}
       run: |
         az config set bicep.use_binary_from_path=false
@@ -30,6 +38,12 @@ jobs:
 
     - name: Build project
       run: dotnet build -c Release ./Acmebot.slnx
+
+    - name: Build Dashboard
+      working-directory: ./src/Acmebot.App/ClientApp
+      run: |
+        npm ci
+        npm run build
 
     - name: Lint C# code
       run: dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   DOTNET_VERSION: 10.0.x
+  NODE_VERSION: 24.x
   BICEP_VERSION: 0.42.1
 
 jobs:
@@ -24,12 +25,28 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        cache: npm
+        cache-dependency-path: src/Acmebot.App/ClientApp/package-lock.json
+
     - name: Setup Version
       id: setup_version
       run: |
         FULL_VERSION=${GITHUB_REF/refs\/tags\/v/}
         echo "VERSION=${FULL_VERSION}" >> $GITHUB_OUTPUT
         echo "MAJOR_VERSION=${FULL_VERSION%%.*}" >> $GITHUB_OUTPUT
+
+    - name: Build Dashboard
+      working-directory: ./src/Acmebot.App/ClientApp
+      env:
+        ACMEBOT_DASHBOARD_VERSION: ${{ steps.setup_version.outputs.version }}
+        ACMEBOT_DASHBOARD_COMMIT: ${{ github.sha }}
+      run: |
+        npm ci
+        npm run build
 
     - name: Publish Function app
       run: dotnet publish -c Release --no-self-contained -o ./dist -p:Version=${{ steps.setup_version.outputs.version }} ./src/Acmebot.App

--- a/src/Acmebot.App/.gitignore
+++ b/src/Acmebot.App/.gitignore
@@ -267,3 +267,6 @@ __pycache__/
 Properties/serviceDependencies.json
 Properties/serviceDependencies.*.json
 Properties/ServiceDependencies/
+
+# Dashboard vnext
+wwwroot/dashboard-vnext/

--- a/src/Acmebot.App/ClientApp/README.md
+++ b/src/Acmebot.App/ClientApp/README.md
@@ -1,0 +1,28 @@
+# Acmebot Dashboard
+
+This folder contains the Vite + Vue 3 + TypeScript implementation of the Acmebot dashboard.
+
+## Commands
+
+```powershell
+npm install
+npm run dev
+npm run build
+```
+
+`npm run build` writes the static dashboard assets to `../wwwroot/dashboard-vnext` so they can be served by the existing Azure Functions static page endpoint while the current `/dashboard` UI remains available.
+
+Production builds always call the same-origin `/api/*` Azure Functions endpoints. The mock API switch is limited to the Vite development server, so files generated under `../wwwroot/dashboard-vnext` are safe to deploy with the Function app package.
+
+Source maps are disabled by default for deployable output. Set `ACMEBOT_BUILD_SOURCEMAP=true` before `npm run build` when you need browser debugging symbols.
+
+The dashboard footer displays build metadata embedded by Vite at build time. Set `ACMEBOT_DASHBOARD_VERSION` to the release version and `ACMEBOT_DASHBOARD_COMMIT` to the source commit hash before `npm run build`; when the commit variable is omitted, GitHub Actions `GITHUB_SHA` is used if available.
+
+For local API proxying during Vite development, set `ACMEBOT_API_ORIGIN` to an Azure Functions host, for example `http://localhost:7071`.
+
+To run the dashboard locally without an Azure Functions host, start Vite with mock data:
+
+```powershell
+$env:VITE_ACMEBOT_USE_MOCKS = 'true'
+npm run dev
+```

--- a/src/Acmebot.App/ClientApp/index.html
+++ b/src/Acmebot.App/ClientApp/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Acmebot Dashboard | Acmebot for Microsoft Azure</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/src/Acmebot.App/ClientApp/package-lock.json
+++ b/src/Acmebot.App/ClientApp/package-lock.json
@@ -1,0 +1,1516 @@
+{
+  "name": "acmebot-dashboard",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "acmebot-dashboard",
+      "version": "0.1.0",
+      "dependencies": {
+        "@tanstack/vue-table": "8.21.3",
+        "lucide-vue-next": "1.0.0",
+        "punycode": "2.3.1",
+        "reka-ui": "2.9.7",
+        "vue": "3.5.34"
+      },
+      "devDependencies": {
+        "@types/node": "25.6.2",
+        "@vitejs/plugin-vue": "6.0.6",
+        "typescript": "6.0.3",
+        "vite": "8.0.11",
+        "vue-tsc": "3.2.8"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/vue": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.11.tgz",
+      "integrity": "sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6",
+        "@floating-ui/utils": "^0.2.11",
+        "vue-demi": ">=0.13.0"
+      }
+    },
+    "node_modules/@floating-ui/vue/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
+      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.6.tgz",
+      "integrity": "sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-table/-/vue-table-8.21.3.tgz",
+      "integrity": "sha512-rusRyd77c5tDPloPskctMyPLFEQUeBzxdQ+2Eow4F7gDPlPOB1UnnhzfpdvqZ8ZyX2rRNGmqNnQWm87OI2OQPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": ">=3.2"
+      }
+    },
+    "node_modules/@tanstack/vue-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.24.tgz",
+      "integrity": "sha512-A0k2qF0zFSUStXSZkGXABouXr2Tw2Ztl/cVIYG9qy84uR8W7UNjAcX3DvzBS3YnDcwvLxab8v7dbmYBZ39itDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.0.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz",
+      "integrity": "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.13"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+      "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.34",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+      "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+      "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.34",
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.14",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+      "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.8.tgz",
+      "integrity": "sha512-9OiSPQFiAAWNVnXb0d2dcTmcKnFQamhuNES6ayyISrb/mwPWVgoGdAqSfCWqKhQpa3D5gDTcYD+w7ObiheZ81g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.1.2",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+      "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+      "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+      "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.34",
+        "@vue/runtime-core": "3.5.34",
+        "@vue/shared": "3.5.34",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+      "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34"
+      },
+      "peerDependencies": {
+        "vue": "3.5.34"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+      "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
+      "integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.3.0",
+        "@vueuse/shared": "14.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
+      "integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
+      "integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/alien-signals": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
+      "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lucide-vue-next": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
+      "integrity": "sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "license": "MIT"
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/reka-ui": {
+      "version": "2.9.7",
+      "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.9.7.tgz",
+      "integrity": "sha512-aX7foYYR20v4+majO58OJJdBNfLMm0eJb448l9N4JVy8JB7GXOr4H/S4a+J1pkcoxZH8Cb7YHpJ855+miAm7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.13",
+        "@floating-ui/vue": "^1.1.6",
+        "@internationalized/date": "^3.5.0",
+        "@internationalized/number": "^3.5.0",
+        "@tanstack/vue-virtual": "^3.12.0",
+        "@vueuse/core": "^14.1.0",
+        "@vueuse/shared": "^14.1.0",
+        "aria-hidden": "^1.2.4",
+        "defu": "^6.1.5",
+        "ohash": "^2.0.11"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/zernonia"
+      },
+      "peerDependencies": {
+        "vue": ">= 3.4.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.128.0",
+        "@rolldown/pluginutils": "1.0.0-rc.18"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0-rc.18",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+      "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-sfc": "3.5.34",
+        "@vue/runtime-dom": "3.5.34",
+        "@vue/server-renderer": "3.5.34",
+        "@vue/shared": "3.5.34"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.8.tgz",
+      "integrity": "sha512-27vTLJ6Q2370obOd0PFYoYoKnmXJ521uUIedrs3Zhhhg/8YG10VOCMmwt+JQslatpAMTDbnWiitLnoD5VlIvog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.2.8"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      }
+    }
+  }
+}

--- a/src/Acmebot.App/ClientApp/package.json
+++ b/src/Acmebot.App/ClientApp/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "acmebot-dashboard",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1",
+    "build": "vue-tsc --noEmit && vite build",
+    "preview": "vite preview --host 127.0.0.1"
+  },
+  "dependencies": {
+    "@tanstack/vue-table": "8.21.3",
+    "lucide-vue-next": "1.0.0",
+    "punycode": "2.3.1",
+    "reka-ui": "2.9.7",
+    "vue": "3.5.34"
+  },
+  "devDependencies": {
+    "@types/node": "25.6.2",
+    "@vitejs/plugin-vue": "6.0.6",
+    "typescript": "6.0.3",
+    "vite": "8.0.11",
+    "vue-tsc": "3.2.8"
+  }
+}

--- a/src/Acmebot.App/ClientApp/src/App.vue
+++ b/src/Acmebot.App/ClientApp/src/App.vue
@@ -1,0 +1,283 @@
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue';
+import { Activity, AlertTriangle, BadgeCheck, CircleSlash, LayoutDashboard, Shield, ShieldAlert, ShieldCheck } from 'lucide-vue-next';
+
+import { formatApiError, getCertificates, getDnsZones, issueCertificate, renewCertificate, revokeCertificate } from '@/api/acmebotApi';
+import type { CertificateItem, CertificatePolicyItem, DnsZoneGroup } from '@/api/types';
+import AddCertificateDialog from '@/components/AddCertificateDialog.vue';
+import CertificateTable from '@/components/CertificateTable.vue';
+import ConfirmRevokeDialog from '@/components/ConfirmRevokeDialog.vue';
+import DetailsDrawer from '@/components/DetailsDrawer.vue';
+import OperationOverlay from '@/components/OperationOverlay.vue';
+import ToastStack, { type ToastMessage } from '@/components/ToastStack.vue';
+import { getCertificateCategory, getCertificateStatus } from '@/utils/certificates';
+
+const certificates = ref<CertificateItem[]>([]);
+const dnsZoneGroups = ref<DnsZoneGroup[]>([]);
+const selectedCertificate = ref<CertificateItem | null>(null);
+const pendingRevokeCertificate = ref<CertificateItem | null>(null);
+const addDialogOpen = ref(false);
+const detailsBusy = ref(false);
+const toasts = ref<ToastMessage[]>([]);
+let toastId = 0;
+const dashboardVersion = __ACMEBOT_DASHBOARD_VERSION__;
+const dashboardCommitHash = __ACMEBOT_DASHBOARD_COMMIT_HASH__;
+
+const certificateState = reactive({
+  loading: false,
+  error: ''
+});
+
+const dnsZoneState = reactive({
+  loading: false,
+  loaded: false
+});
+
+const operation = reactive({
+  active: false,
+  title: '',
+  message: ''
+});
+
+const summary = computed(() => {
+  const statusCounts = certificates.value.reduce(
+    (counts, certificate) => {
+      const status = getCertificateStatus(certificate);
+      counts[status.kind] += 1;
+      return counts;
+    },
+    { valid: 0, warning: 0, expired: 0 }
+  );
+
+  return {
+    total: certificates.value.length,
+    managed: certificates.value.filter((certificate) => getCertificateCategory(certificate) === 'managed').length,
+    otherCa: certificates.value.filter((certificate) => getCertificateCategory(certificate) === 'other-ca').length,
+    unmanaged: certificates.value.filter((certificate) => getCertificateCategory(certificate) === 'unmanaged').length,
+    ...statusCounts
+  };
+});
+
+const summaryItems = computed(() => [
+  { label: 'Managed', value: summary.value.managed, tone: 'good', icon: ShieldCheck },
+  { label: 'Expiring soon', value: summary.value.warning, tone: 'warning', icon: ShieldAlert },
+  { label: 'Expired', value: summary.value.expired, tone: 'danger', icon: AlertTriangle },
+  { label: 'Other CA', value: summary.value.otherCa, tone: 'neutral', icon: BadgeCheck },
+  { label: 'Unmanaged', value: summary.value.unmanaged, tone: 'neutral', icon: CircleSlash }
+]);
+
+const dashboardCommitLabel = computed(() => (dashboardCommitHash.length > 7 ? dashboardCommitHash.slice(0, 7) : dashboardCommitHash));
+
+onMounted(async () => {
+  await loadCertificates();
+});
+
+function pushToast(type: ToastMessage['type'], title: string, message: string): void {
+  const id = ++toastId;
+  toasts.value = [...toasts.value, { id, type, title, message }];
+  window.setTimeout(() => dismissToast(id), 6000);
+}
+
+function dismissToast(id: number): void {
+  toasts.value = toasts.value.filter((message) => message.id !== id);
+}
+
+async function loadCertificates(): Promise<void> {
+  certificateState.loading = true;
+  certificateState.error = '';
+
+  try {
+    certificates.value = await getCertificates();
+  } catch (error) {
+    certificateState.error = formatApiError(error);
+    pushToast('error', 'Failed to load certificates', certificateState.error);
+  } finally {
+    certificateState.loading = false;
+  }
+}
+
+async function loadDnsZones(): Promise<void> {
+  if (dnsZoneState.loaded || dnsZoneState.loading) {
+    return;
+  }
+
+  dnsZoneState.loading = true;
+
+  try {
+    dnsZoneGroups.value = await getDnsZones();
+    dnsZoneState.loaded = true;
+  } catch (error) {
+    pushToast('error', 'Failed to load DNS zones', formatApiError(error));
+  } finally {
+    dnsZoneState.loading = false;
+  }
+}
+
+async function runCertificateOperation(title: string, message: string, action: () => Promise<void>): Promise<void> {
+  operation.active = true;
+  operation.title = title;
+  operation.message = message;
+
+  try {
+    await action();
+    pushToast('success', 'Operation completed', message.replace('...', ' completed.'));
+    addDialogOpen.value = false;
+    selectedCertificate.value = null;
+    await loadCertificates();
+  } catch (error) {
+    pushToast('error', 'Operation failed', formatApiError(error));
+  } finally {
+    operation.active = false;
+  }
+}
+
+async function handleIssueCertificate(policy: CertificatePolicyItem): Promise<void> {
+  await runCertificateOperation('Issuing certificate', 'Issuing certificate...', () => issueCertificate(policy));
+}
+
+async function handleRenewCertificate(certificate: CertificateItem): Promise<void> {
+  detailsBusy.value = true;
+
+  try {
+    await runCertificateOperation('Renewing certificate', `Renewing ${certificate.name}...`, () => renewCertificate(certificate.name));
+  } finally {
+    detailsBusy.value = false;
+  }
+}
+
+async function handleRevokeCertificate(certificate: CertificateItem): Promise<void> {
+  pendingRevokeCertificate.value = certificate;
+}
+
+async function handleCopy(label: string, value: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(value);
+    pushToast('success', `${label} copied`, 'Copied to clipboard.');
+  } catch {
+    pushToast('error', 'Copy failed', `Could not copy ${label.toLowerCase()}.`);
+  }
+}
+
+async function confirmRevokeCertificate(): Promise<void> {
+  if (!pendingRevokeCertificate.value) {
+    return;
+  }
+
+  const certificate = pendingRevokeCertificate.value;
+
+  detailsBusy.value = true;
+
+  try {
+    await runCertificateOperation('Revoking certificate', `Revoking ${certificate.name}...`, () => revokeCertificate(certificate.name));
+  } finally {
+    detailsBusy.value = false;
+    pendingRevokeCertificate.value = null;
+  }
+}
+</script>
+
+<template>
+  <div class="app-shell">
+    <header class="app-header">
+      <div class="app-header__inner">
+        <div class="brand-lockup">
+          <div class="brand-mark" aria-hidden="true">
+            <Shield :size="21" />
+          </div>
+          <div>
+            <div class="brand-title">Acmebot</div>
+            <div class="brand-subtitle">Certificate automation</div>
+          </div>
+        </div>
+        <div class="header-status">
+          <Activity :size="16" aria-hidden="true" />
+          <span>{{ summary.total }} certificates</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="app-main">
+      <section class="page-title-row" aria-labelledby="page-heading">
+        <div>
+          <div class="eyebrow">Azure Key Vault certificate automation</div>
+          <h1 id="page-heading">Certificate Operations</h1>
+        </div>
+        <div class="dashboard-pill">
+          <LayoutDashboard :size="15" aria-hidden="true" />
+          Operations dashboard
+        </div>
+      </section>
+
+      <section class="summary-grid" aria-label="Certificate summary">
+        <div v-for="item in summaryItems" :key="item.label" class="summary-item" :class="`summary-item--${item.tone}`">
+          <component :is="item.icon" :size="18" aria-hidden="true" />
+          <div>
+            <div class="summary-item__value">{{ item.value }}</div>
+            <div class="summary-item__label">{{ item.label }}</div>
+          </div>
+        </div>
+      </section>
+
+      <div v-if="certificateState.error" class="banner banner--error" role="alert">
+        <AlertTriangle :size="17" aria-hidden="true" />
+        <span>{{ certificateState.error }}</span>
+      </div>
+
+      <CertificateTable
+        :certificates="certificates"
+        :loading="certificateState.loading"
+        :selected-certificate="selectedCertificate"
+        @select="selectedCertificate = $event"
+        @refresh="loadCertificates"
+        @add="addDialogOpen = true"
+      />
+    </main>
+
+    <footer class="app-footer" aria-label="Dashboard build metadata">
+      <div class="app-footer__inner">
+        <span>Acmebot Dashboard</span>
+        <dl class="build-metadata">
+          <div class="build-metadata__item">
+            <dt>Version</dt>
+            <dd>{{ dashboardVersion }}</dd>
+          </div>
+          <div class="build-metadata__item">
+            <dt>Commit</dt>
+            <dd :title="dashboardCommitHash">{{ dashboardCommitLabel }}</dd>
+          </div>
+        </dl>
+      </div>
+    </footer>
+
+    <AddCertificateDialog
+      :open="addDialogOpen"
+      :zones="dnsZoneGroups"
+      :loading-zones="dnsZoneState.loading"
+      :sending="operation.active"
+      @close="addDialogOpen = false"
+      @load-zones="loadDnsZones"
+      @submit="handleIssueCertificate"
+    />
+
+    <DetailsDrawer
+      :open="selectedCertificate !== null"
+      :certificate="selectedCertificate"
+      :busy="detailsBusy || operation.active"
+      @close="selectedCertificate = null"
+      @renew="handleRenewCertificate"
+      @revoke="handleRevokeCertificate"
+      @copy="handleCopy"
+    />
+
+    <ConfirmRevokeDialog
+      :open="pendingRevokeCertificate !== null"
+      :certificate-name="pendingRevokeCertificate?.name ?? ''"
+      :busy="detailsBusy || operation.active"
+      @cancel="pendingRevokeCertificate = null"
+      @confirm="confirmRevokeCertificate"
+    />
+
+    <OperationOverlay :active="operation.active" :title="operation.title" :message="operation.message" />
+    <ToastStack :messages="toasts" @dismiss="dismissToast" />
+  </div>
+</template>

--- a/src/Acmebot.App/ClientApp/src/App.vue
+++ b/src/Acmebot.App/ClientApp/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue';
-import { Activity, AlertTriangle, BadgeCheck, CircleSlash, LayoutDashboard, Shield, ShieldAlert, ShieldCheck } from 'lucide-vue-next';
+import { Activity, AlertTriangle, BadgeCheck, CircleSlash, Shield, ShieldAlert, ShieldCheck } from 'lucide-vue-next';
 
 import { formatApiError, getCertificates, getDnsZones, issueCertificate, renewCertificate, revokeCertificate } from '@/api/acmebotApi';
 import type { CertificateItem, CertificatePolicyItem, DnsZoneGroup } from '@/api/types';
@@ -70,6 +70,7 @@ const dashboardCommitLabel = computed(() => (dashboardCommitHash.length > 7 ? da
 
 onMounted(async () => {
   await loadCertificates();
+  await loadDnsZones(false);
 });
 
 function pushToast(type: ToastMessage['type'], title: string, message: string): void {
@@ -96,7 +97,7 @@ async function loadCertificates(): Promise<void> {
   }
 }
 
-async function loadDnsZones(): Promise<void> {
+async function loadDnsZones(showErrorToast = true): Promise<void> {
   if (dnsZoneState.loaded || dnsZoneState.loading) {
     return;
   }
@@ -107,7 +108,9 @@ async function loadDnsZones(): Promise<void> {
     dnsZoneGroups.value = await getDnsZones();
     dnsZoneState.loaded = true;
   } catch (error) {
-    pushToast('error', 'Failed to load DNS zones', formatApiError(error));
+    if (showErrorToast) {
+      pushToast('error', 'Failed to load DNS zones', formatApiError(error));
+    }
   } finally {
     dnsZoneState.loading = false;
   }
@@ -197,16 +200,7 @@ async function confirmRevokeCertificate(): Promise<void> {
     </header>
 
     <main class="app-main">
-      <section class="page-title-row" aria-labelledby="page-heading">
-        <div>
-          <div class="eyebrow">Azure Key Vault certificate automation</div>
-          <h1 id="page-heading">Certificate Operations</h1>
-        </div>
-        <div class="dashboard-pill">
-          <LayoutDashboard :size="15" aria-hidden="true" />
-          Operations dashboard
-        </div>
-      </section>
+      <h1 id="page-heading" class="visually-hidden">Certificate Operations</h1>
 
       <section class="summary-grid" aria-label="Certificate summary">
         <div v-for="item in summaryItems" :key="item.label" class="summary-item" :class="`summary-item--${item.tone}`">
@@ -225,6 +219,7 @@ async function confirmRevokeCertificate(): Promise<void> {
 
       <CertificateTable
         :certificates="certificates"
+        :dns-zone-groups="dnsZoneGroups"
         :loading="certificateState.loading"
         :selected-certificate="selectedCertificate"
         @select="selectedCertificate = $event"

--- a/src/Acmebot.App/ClientApp/src/api/acmebotApi.ts
+++ b/src/Acmebot.App/ClientApp/src/api/acmebotApi.ts
@@ -1,0 +1,173 @@
+import type { CertificateItem, CertificatePolicyItem, DnsZoneGroup, ProblemDetails } from './types';
+
+const useMockApi = import.meta.env.DEV && import.meta.env.VITE_ACMEBOT_USE_MOCKS === 'true';
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly problem?: ProblemDetails
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+async function parseResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+
+  if (!text) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function getProblemMessage(status: number, body: unknown): string {
+  if (typeof body === 'string') {
+    return body;
+  }
+
+  const problem = body as ProblemDetails | undefined;
+
+  if (problem?.errors) {
+    return Object.values(problem.errors).flat().join('\n');
+  }
+
+  return problem?.detail ?? problem?.output ?? problem?.title ?? `HTTP Response ${status} Error`;
+}
+
+async function requestJson<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    headers: {
+      Accept: 'application/json',
+      ...init?.headers
+    },
+    ...init
+  });
+  const body = await parseResponseBody(response);
+
+  if (!response.ok) {
+    throw new ApiError(getProblemMessage(response.status, body), response.status, body as ProblemDetails);
+  }
+
+  return body as T;
+}
+
+async function startOperation(input: RequestInfo | URL, init?: RequestInit): Promise<string> {
+  const response = await fetch(input, {
+    headers: {
+      Accept: 'application/json',
+      ...init?.headers
+    },
+    ...init
+  });
+  const body = await parseResponseBody(response);
+
+  if (!response.ok) {
+    throw new ApiError(getProblemMessage(response.status, body), response.status, body as ProblemDetails);
+  }
+
+  const location = response.headers.get('location');
+
+  if (!location) {
+    throw new ApiError('The operation response did not include a status URL.', response.status);
+  }
+
+  return location;
+}
+
+async function pollOperation(location: string): Promise<void> {
+  while (true) {
+    await new Promise((resolve) => window.setTimeout(resolve, 3000));
+
+    const response = await fetch(location, { headers: { Accept: 'application/json' } });
+    const body = await parseResponseBody(response);
+
+    if (response.status === 200) {
+      return;
+    }
+
+    if (response.status !== 202) {
+      throw new ApiError(getProblemMessage(response.status, body), response.status, body as ProblemDetails);
+    }
+  }
+}
+
+export async function getCertificates(): Promise<CertificateItem[]> {
+  if (useMockApi) {
+    const { getMockCertificates } = await import('./mockData');
+    return getMockCertificates();
+  }
+
+  const certificates = await requestJson<CertificateItem[]>('/api/certificates');
+
+  return certificates.toSorted((left, right) => left.expiresOn.localeCompare(right.expiresOn));
+}
+
+export async function getDnsZones(): Promise<DnsZoneGroup[]> {
+  if (useMockApi) {
+    const { getMockDnsZones } = await import('./mockData');
+    return getMockDnsZones();
+  }
+
+  return requestJson<DnsZoneGroup[]>('/api/dns-zones');
+}
+
+export async function issueCertificate(policy: CertificatePolicyItem): Promise<void> {
+  if (useMockApi) {
+    const { mockIssueCertificate } = await import('./mockData');
+    await mockIssueCertificate(policy);
+    return;
+  }
+
+  const location = await startOperation('/api/certificate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(policy)
+  });
+
+  await pollOperation(location);
+}
+
+export async function renewCertificate(certificateName: string): Promise<void> {
+  if (useMockApi) {
+    const { mockRenewCertificate } = await import('./mockData');
+    await mockRenewCertificate(certificateName);
+    return;
+  }
+
+  const location = await startOperation(`/api/certificate/${encodeURIComponent(certificateName)}/renew`, {
+    method: 'POST'
+  });
+
+  await pollOperation(location);
+}
+
+export async function revokeCertificate(certificateName: string): Promise<void> {
+  if (useMockApi) {
+    const { mockRevokeCertificate } = await import('./mockData');
+    await mockRevokeCertificate(certificateName);
+    return;
+  }
+
+  await requestJson<void>(`/api/certificate/${encodeURIComponent(certificateName)}/revoke`, {
+    method: 'POST'
+  });
+}
+
+export function formatApiError(error: unknown): string {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'An unexpected error occurred.';
+}

--- a/src/Acmebot.App/ClientApp/src/api/mockData.ts
+++ b/src/Acmebot.App/ClientApp/src/api/mockData.ts
@@ -29,6 +29,40 @@ let mockCertificates: CertificateItem[] = [
     dnsAlias: null
   },
   {
+    id: 'https://mock.vault/certificates/apex-example-co-jp',
+    name: 'apex-example-co-jp',
+    dnsNames: ['example.co.jp'],
+    dnsProviderName: 'Azure DNS',
+    createdOn: dateBefore(20),
+    expiresOn: dateFromNow(68),
+    x509Thumbprint: '62B4E2103E9B4E46B9E09172B0A321AD108D2D54',
+    keyType: 'RSA',
+    keySize: 2048,
+    reuseKey: false,
+    isExpired: false,
+    isIssuedByAcmebot: true,
+    isSameEndpoint: true,
+    acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
+    dnsAlias: null
+  },
+  {
+    id: 'https://mock.vault/certificates/app-www-example-co-jp',
+    name: 'app-www-example-co-jp',
+    dnsNames: ['app.www.example.co.jp'],
+    dnsProviderName: 'Azure DNS',
+    createdOn: dateBefore(19),
+    expiresOn: dateFromNow(69),
+    x509Thumbprint: '78E62B4E2103E9B4E46B9E09172B0A321AD108D',
+    keyType: 'RSA',
+    keySize: 2048,
+    reuseKey: false,
+    isExpired: false,
+    isIssuedByAcmebot: true,
+    isSameEndpoint: true,
+    acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
+    dnsAlias: null
+  },
+  {
     id: 'https://mock.vault/certificates/api-contoso-com',
     name: 'api-contoso-com',
     dnsNames: ['api.contoso.com'],
@@ -118,7 +152,7 @@ let mockCertificates: CertificateItem[] = [
 const mockDnsZoneGroups: DnsZoneGroup[] = [
   {
     dnsProviderName: 'Azure DNS',
-    dnsZones: [{ name: 'example.com' }, { name: 'example.org' }, { name: 'fabrikam.net' }]
+    dnsZones: [{ name: 'example.com' }, { name: 'example.co.jp' }, { name: 'www.example.co.jp' }, { name: 'example.org' }, { name: 'fabrikam.net' }]
   },
   {
     dnsProviderName: 'Cloudflare',

--- a/src/Acmebot.App/ClientApp/src/api/mockData.ts
+++ b/src/Acmebot.App/ClientApp/src/api/mockData.ts
@@ -1,0 +1,191 @@
+import type { CertificateItem, CertificatePolicyItem, DnsZoneGroup } from './types';
+
+const day = 86_400_000;
+
+function dateFromNow(days: number): string {
+  return new Date(Date.now() + days * day).toISOString();
+}
+
+function dateBefore(days: number): string {
+  return new Date(Date.now() - days * day).toISOString();
+}
+
+let mockCertificates: CertificateItem[] = [
+  {
+    id: 'https://mock.vault/certificates/www-example-com',
+    name: 'www-example-com',
+    dnsNames: ['www.example.com', 'example.com'],
+    dnsProviderName: 'Azure DNS',
+    createdOn: dateBefore(38),
+    expiresOn: dateFromNow(52),
+    x509Thumbprint: 'A4B2C2D9F1E0ACB81E7A1022E8C5F4A55F90D4B1',
+    keyType: 'RSA',
+    keySize: 2048,
+    reuseKey: false,
+    isExpired: false,
+    isIssuedByAcmebot: true,
+    isSameEndpoint: true,
+    acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
+    dnsAlias: null
+  },
+  {
+    id: 'https://mock.vault/certificates/api-contoso-com',
+    name: 'api-contoso-com',
+    dnsNames: ['api.contoso.com'],
+    dnsProviderName: 'Cloudflare',
+    createdOn: dateBefore(82),
+    expiresOn: dateFromNow(12),
+    x509Thumbprint: '9C98E7D650C181B04A15AE0C096027862B73E33A',
+    keyType: 'EC',
+    keyCurveName: 'P-256',
+    reuseKey: true,
+    isExpired: false,
+    isIssuedByAcmebot: true,
+    isSameEndpoint: true,
+    acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
+    dnsAlias: null
+  },
+  {
+    id: 'https://mock.vault/certificates/edge-adatum-io',
+    name: 'edge-adatum-io',
+    dnsNames: ['edge.adatum.io'],
+    dnsProviderName: 'Cloudflare',
+    createdOn: dateBefore(6),
+    expiresOn: dateFromNow(1.5),
+    x509Thumbprint: '35B9E8D3A20F42629D01C8D8CDAE0E31E2A0B90B',
+    keyType: 'EC',
+    keyCurveName: 'P-256',
+    reuseKey: false,
+    isExpired: false,
+    isIssuedByAcmebot: true,
+    isSameEndpoint: true,
+    acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
+    dnsAlias: null
+  },
+  {
+    id: 'https://mock.vault/certificates/wildcard-fabrikam-net',
+    name: 'wildcard-fabrikam-net',
+    dnsNames: ['*.fabrikam.net', 'fabrikam.net'],
+    dnsProviderName: 'Azure DNS',
+    createdOn: dateBefore(94),
+    expiresOn: dateFromNow(-3),
+    x509Thumbprint: '10F0403D238C285E9B4E46B9E09172B0A321AD10',
+    keyType: 'RSA',
+    keySize: 3072,
+    reuseKey: false,
+    isExpired: true,
+    isIssuedByAcmebot: true,
+    isSameEndpoint: true,
+    acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
+    dnsAlias: 'dns-alias.fabrikam.net'
+  },
+  {
+    id: 'https://mock.vault/certificates/portal-example-org',
+    name: 'portal-example-org',
+    dnsNames: ['portal.example.org'],
+    dnsProviderName: 'Azure DNS',
+    createdOn: dateBefore(31),
+    expiresOn: dateFromNow(58),
+    x509Thumbprint: '66342F778F40DA3CCECFB2D908390F0B4119084A',
+    keyType: 'RSA',
+    keySize: 2048,
+    reuseKey: false,
+    isExpired: false,
+    isIssuedByAcmebot: true,
+    isSameEndpoint: false,
+    acmeEndpoint: 'https://acme.zerossl.com/v2/DV90',
+    dnsAlias: null
+  },
+  {
+    id: 'https://mock.vault/certificates/imported-legacy-net',
+    name: 'imported-legacy-net',
+    dnsNames: ['legacy.net'],
+    dnsProviderName: null,
+    createdOn: dateBefore(120),
+    expiresOn: dateFromNow(144),
+    x509Thumbprint: 'E42F40A663778F40DA3CCECFB2D908390F0B4119',
+    keyType: 'RSA',
+    keySize: 4096,
+    reuseKey: null,
+    isExpired: false,
+    isIssuedByAcmebot: false,
+    isSameEndpoint: false,
+    acmeEndpoint: null,
+    dnsAlias: null
+  }
+];
+
+const mockDnsZoneGroups: DnsZoneGroup[] = [
+  {
+    dnsProviderName: 'Azure DNS',
+    dnsZones: [{ name: 'example.com' }, { name: 'example.org' }, { name: 'fabrikam.net' }]
+  },
+  {
+    dnsProviderName: 'Cloudflare',
+    dnsZones: [{ name: 'contoso.com' }, { name: 'adatum.io' }]
+  },
+  {
+    dnsProviderName: 'Route 53',
+    dnsZones: [{ name: 'wingtiptoys.com' }]
+  }
+];
+
+export async function getMockCertificates(): Promise<CertificateItem[]> {
+  await delay(250);
+  return structuredClone(mockCertificates).toSorted((left, right) => left.expiresOn.localeCompare(right.expiresOn));
+}
+
+export async function getMockDnsZones(): Promise<DnsZoneGroup[]> {
+  await delay(250);
+  return structuredClone(mockDnsZoneGroups);
+}
+
+export async function mockIssueCertificate(policy: CertificatePolicyItem): Promise<void> {
+  await delay(700);
+  const certificateName = policy.certificateName || policy.dnsNames[0].replaceAll('*', 'wildcard').replaceAll('.', '-');
+
+  mockCertificates = [
+    ...mockCertificates,
+    {
+      id: `https://mock.vault/certificates/${certificateName}`,
+      name: certificateName,
+      dnsNames: [...policy.dnsNames],
+      dnsProviderName: policy.dnsProviderName,
+      createdOn: new Date().toISOString(),
+      expiresOn: dateFromNow(90),
+      x509Thumbprint: 'MOCKEDCERTIFICATEOPERATION0000000000000000',
+      keyType: policy.keyType,
+      keySize: policy.keySize,
+      keyCurveName: policy.keyCurveName,
+      reuseKey: policy.reuseKey,
+      isExpired: false,
+      isIssuedByAcmebot: true,
+      isSameEndpoint: true,
+      acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
+      dnsAlias: policy.dnsAlias
+    }
+  ];
+}
+
+export async function mockRenewCertificate(certificateName: string): Promise<void> {
+  await delay(650);
+  mockCertificates = mockCertificates.map((certificate) =>
+    certificate.name === certificateName
+      ? {
+          ...certificate,
+          createdOn: new Date().toISOString(),
+          expiresOn: dateFromNow(90),
+          isExpired: false
+        }
+      : certificate
+  );
+}
+
+export async function mockRevokeCertificate(certificateName: string): Promise<void> {
+  await delay(650);
+  mockCertificates = mockCertificates.filter((certificate) => certificate.name !== certificateName);
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+}

--- a/src/Acmebot.App/ClientApp/src/api/types.ts
+++ b/src/Acmebot.App/ClientApp/src/api/types.ts
@@ -1,0 +1,54 @@
+export type KeyType = 'RSA' | 'EC';
+export type KeyCurveName = 'P-256' | 'P-384' | 'P-521' | 'P-256K';
+export type CertificateCategory = 'managed' | 'other-ca' | 'unmanaged';
+export type CertificateStatusKind = 'valid' | 'warning' | 'expired';
+
+export interface CertificateItem {
+  id: string;
+  name: string;
+  dnsNames: string[];
+  dnsProviderName?: string | null;
+  createdOn: string;
+  expiresOn: string;
+  x509Thumbprint?: string | null;
+  keyType?: KeyType | string | null;
+  keySize?: number | null;
+  keyCurveName?: KeyCurveName | string | null;
+  reuseKey?: boolean | null;
+  isExpired: boolean;
+  isIssuedByAcmebot: boolean;
+  isSameEndpoint: boolean;
+  acmeEndpoint?: string | null;
+  dnsAlias?: string | null;
+}
+
+export interface DnsZoneItem {
+  name: string;
+}
+
+export interface DnsZoneGroup {
+  dnsProviderName: string;
+  dnsZones: DnsZoneItem[] | null;
+}
+
+export interface SelectableDnsZone extends DnsZoneItem {
+  dnsProviderName: string;
+}
+
+export interface CertificatePolicyItem {
+  certificateName?: string;
+  dnsNames: string[];
+  dnsProviderName?: string;
+  keyType: KeyType;
+  keySize?: number;
+  keyCurveName?: KeyCurveName;
+  reuseKey?: boolean;
+  dnsAlias?: string;
+}
+
+export interface ProblemDetails {
+  title?: string;
+  detail?: string;
+  output?: string;
+  errors?: Record<string, string[]>;
+}

--- a/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
@@ -1,0 +1,332 @@
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue';
+import { CirclePlus, KeyRound, Plus, ShieldPlus, Trash2, X } from 'lucide-vue-next';
+import { toASCII } from 'punycode/';
+
+import type { CertificatePolicyItem, DnsZoneGroup, KeyCurveName, KeyType, SelectableDnsZone } from '@/api/types';
+import { displayDnsName } from '@/utils/certificates';
+
+import SearchableZoneSelect from './SearchableZoneSelect.vue';
+
+const props = defineProps<{
+  open: boolean;
+  zones: DnsZoneGroup[];
+  loadingZones: boolean;
+  sending: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  submit: [policy: CertificatePolicyItem];
+  'load-zones': [];
+}>();
+
+const selectedZone = ref<SelectableDnsZone | null>(null);
+const formMessage = ref('');
+
+const form = reactive({
+  recordName: '',
+  dnsNames: [] as string[],
+  dnsProviderName: '',
+  useAdvancedOptions: false,
+  certificateName: '',
+  keyType: 'RSA' as KeyType,
+  keySize: 2048,
+  keyCurveName: 'P-256' as KeyCurveName,
+  reuseKey: false,
+  dnsAlias: ''
+});
+
+const canSubmit = computed(() => form.dnsNames.length > 0 && !props.sending);
+const fullDnsName = computed(() => buildDnsName());
+const keySummary = computed(() => (form.keyType === 'RSA' ? `${form.keySize} bit RSA` : `${form.keyCurveName} EC`));
+const issueStatusLabel = computed(() => {
+  if (form.dnsNames.length > 0) {
+    return 'Ready';
+  }
+
+  if (selectedZone.value) {
+    return 'Add DNS name';
+  }
+
+  return 'Select zone';
+});
+const dnsNamesSummary = computed(() => {
+  if (form.dnsNames.length === 0) {
+    return 'None added';
+  }
+
+  const firstDnsName = displayDnsName(form.dnsNames[0]);
+
+  if (form.dnsNames.length === 1) {
+    return firstDnsName;
+  }
+
+  return `${firstDnsName} +${form.dnsNames.length - 1}`;
+});
+const dnsNameCountLabel = computed(() => `${form.dnsNames.length} ${form.dnsNames.length === 1 ? 'DNS name' : 'DNS names'}`);
+
+watch(
+  () => props.open,
+  (open) => {
+    if (open) {
+      resetForm();
+      emit('load-zones');
+    }
+  }
+);
+
+function resetForm(): void {
+  selectedZone.value = null;
+  formMessage.value = '';
+  form.recordName = '';
+  form.dnsNames = [];
+  form.dnsProviderName = '';
+  form.useAdvancedOptions = false;
+  form.certificateName = '';
+  form.keyType = 'RSA';
+  form.keySize = 2048;
+  form.keyCurveName = 'P-256';
+  form.reuseKey = false;
+  form.dnsAlias = '';
+}
+
+function normalizeRecordName(recordName: string): string {
+  return recordName.trim().replace(/\.$/, '');
+}
+
+function buildDnsName(): string | null {
+  if (!selectedZone.value) {
+    return null;
+  }
+
+  const normalizedRecordName = normalizeRecordName(form.recordName);
+
+  if (!normalizedRecordName || normalizedRecordName === '@') {
+    return selectedZone.value.name;
+  }
+
+  if (normalizedRecordName.endsWith(`.${selectedZone.value.name}`)) {
+    return toASCII(normalizedRecordName);
+  }
+
+  return `${toASCII(normalizedRecordName)}.${selectedZone.value.name}`;
+}
+
+function addDnsName(): void {
+  formMessage.value = '';
+
+  if (!selectedZone.value) {
+    return;
+  }
+
+  if (form.dnsProviderName && form.dnsProviderName !== selectedZone.value.dnsProviderName) {
+    formMessage.value = 'DNS names in one certificate must use the same DNS provider.';
+    return;
+  }
+
+  const dnsName = buildDnsName();
+
+  if (!dnsName) {
+    return;
+  }
+
+  if (!form.dnsNames.includes(dnsName)) {
+    form.dnsNames.push(dnsName);
+  } else {
+    formMessage.value = 'This DNS name is already in the certificate.';
+    return;
+  }
+
+  form.dnsProviderName = selectedZone.value.dnsProviderName;
+  form.recordName = '';
+}
+
+function removeDnsName(dnsName: string): void {
+  form.dnsNames = form.dnsNames.filter((candidate) => candidate !== dnsName);
+
+  if (form.dnsNames.length === 0) {
+    form.dnsProviderName = '';
+    formMessage.value = '';
+  }
+}
+
+function submit(): void {
+  if (!canSubmit.value) {
+    return;
+  }
+
+  const policy: CertificatePolicyItem = {
+    dnsNames: form.dnsNames,
+    dnsProviderName: form.dnsProviderName || undefined,
+    certificateName: form.certificateName.trim() || undefined,
+    keyType: form.keyType,
+    reuseKey: form.reuseKey,
+    dnsAlias: form.dnsAlias.trim() || undefined
+  };
+
+  if (form.keyType === 'RSA') {
+    policy.keySize = form.keySize;
+  } else {
+    policy.keyCurveName = form.keyCurveName;
+  }
+
+  emit('submit', policy);
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="open" class="modal-shell" role="dialog" aria-modal="true" aria-labelledby="add-certificate-heading">
+      <button class="modal-scrim" type="button" title="Close issue certificate" :disabled="sending" @click="emit('close')"></button>
+      <section class="modal-panel modal-panel--wide">
+        <header class="modal-panel__header">
+          <div>
+            <div class="eyebrow">Certificate issuance</div>
+            <h2 id="add-certificate-heading">Issue Certificate</h2>
+          </div>
+          <button class="icon-only-button" type="button" title="Close issue certificate" :disabled="sending" @click="emit('close')">
+            <X :size="18" aria-hidden="true" />
+          </button>
+        </header>
+
+        <div class="wizard-layout">
+          <aside class="setup-rail" aria-label="Certificate issue setup">
+            <div class="setup-rail__header">
+              <span>Issue setup</span>
+              <strong>{{ issueStatusLabel }}</strong>
+            </div>
+            <div class="setup-step" :class="{ 'is-complete': selectedZone }">
+              <ShieldPlus :size="17" aria-hidden="true" />
+              <div class="setup-step__body">
+                <span>Zone</span>
+                <strong>{{ selectedZone ? displayDnsName(selectedZone.name) : 'Not selected' }}</strong>
+                <small v-if="selectedZone">{{ selectedZone.dnsProviderName }}</small>
+              </div>
+            </div>
+            <div class="setup-step" :class="{ 'is-complete': form.dnsNames.length > 0 }">
+              <CirclePlus :size="17" aria-hidden="true" />
+              <div class="setup-step__body">
+                <span>Names</span>
+                <strong>{{ dnsNamesSummary }}</strong>
+                <small>{{ dnsNameCountLabel }}</small>
+              </div>
+            </div>
+            <div class="setup-step" :class="{ 'is-complete': form.useAdvancedOptions }">
+              <KeyRound :size="17" aria-hidden="true" />
+              <div class="setup-step__body">
+                <span>Key</span>
+                <strong>{{ keySummary }}</strong>
+                <small>{{ form.useAdvancedOptions ? 'Custom settings' : 'Default settings' }}</small>
+              </div>
+            </div>
+          </aside>
+
+          <div class="wizard-body">
+            <div class="form-section">
+              <label class="form-label">DNS Zone</label>
+              <SearchableZoneSelect v-model:selected="selectedZone" :groups="zones" :loading="loadingZones" />
+            </div>
+
+            <div class="form-section">
+              <label class="form-label" for="record-name">DNS Name</label>
+              <div class="compound-input">
+                <input
+                  id="record-name"
+                  v-model="form.recordName"
+                  type="text"
+                  placeholder="@, www, api, *"
+                  :disabled="!selectedZone"
+                  @keydown.enter.prevent="addDnsName"
+                />
+                <span class="compound-input__suffix">.{{ selectedZone ? displayDnsName(selectedZone.name) : 'zone' }}</span>
+                <button class="icon-button" type="button" :disabled="!selectedZone" @click="addDnsName">
+                  <Plus :size="16" aria-hidden="true" />
+                  <span>Add</span>
+                </button>
+              </div>
+              <div v-if="fullDnsName" class="form-result">
+                <span>Full DNS name</span>
+                <strong>{{ displayDnsName(fullDnsName) }}</strong>
+              </div>
+              <p v-if="formMessage" class="form-error">{{ formMessage }}</p>
+              <div class="dns-list dns-list--editable">
+                <span v-for="dnsName in form.dnsNames" :key="dnsName" class="dns-chip dns-chip--removable">
+                  {{ displayDnsName(dnsName) }}
+                  <button type="button" title="Remove DNS name" @click="removeDnsName(dnsName)">
+                    <Trash2 :size="13" aria-hidden="true" />
+                  </button>
+                </span>
+              </div>
+            </div>
+
+            <div class="form-section form-section--inline">
+              <label class="toggle-row">
+                <input v-model="form.useAdvancedOptions" type="checkbox" />
+                <span>Advanced options</span>
+              </label>
+            </div>
+
+            <div v-if="form.useAdvancedOptions" class="advanced-grid">
+              <label class="form-field">
+                <span class="form-label">Certificate Name</span>
+                <input v-model="form.certificateName" type="text" placeholder="Optional certificate name" />
+              </label>
+
+              <label class="form-field">
+                <span class="form-label">Key Type</span>
+                <select v-model="form.keyType">
+                  <option value="RSA">RSA</option>
+                  <option value="EC">EC</option>
+                </select>
+              </label>
+
+              <label v-if="form.keyType === 'RSA'" class="form-field">
+                <span class="form-label">Key Size</span>
+                <select v-model.number="form.keySize">
+                  <option :value="2048">2048</option>
+                  <option :value="3072">3072</option>
+                  <option :value="4096">4096</option>
+                </select>
+              </label>
+
+              <label v-else class="form-field">
+                <span class="form-label">Curve</span>
+                <select v-model="form.keyCurveName">
+                  <option value="P-256">P-256</option>
+                  <option value="P-384">P-384</option>
+                  <option value="P-521">P-521</option>
+                  <option value="P-256K">P-256K</option>
+                </select>
+              </label>
+
+              <label class="form-field">
+                <span class="form-label">DNS Alias</span>
+                <input v-model="form.dnsAlias" type="text" placeholder="alias.example.com" />
+              </label>
+
+              <label class="toggle-row advanced-grid__toggle">
+                <input v-model="form.reuseKey" type="checkbox" />
+                <span>Reuse key on renewal</span>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <footer class="modal-panel__footer">
+          <div class="modal-panel__footer-meta">
+            <span>{{ dnsNameCountLabel }}</span>
+            <span>{{ keySummary }}</span>
+          </div>
+          <div class="modal-panel__footer-actions">
+            <button class="secondary-button" type="button" :disabled="sending" @click="emit('close')">Cancel</button>
+            <button class="primary-button" type="button" :disabled="!canSubmit" @click="submit">
+              <ShieldPlus :size="17" aria-hidden="true" />
+              <span>Issue Certificate</span>
+            </button>
+          </div>
+        </footer>
+      </section>
+    </div>
+  </Teleport>
+</template>

--- a/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
@@ -21,8 +21,18 @@ const emit = defineEmits<{
   'load-zones': [];
 }>();
 
+interface ValidationOutcome {
+  value: string;
+  message: string;
+}
+
 const selectedZone = ref<SelectableDnsZone | null>(null);
-const formMessage = ref('');
+const validationErrors = reactive({
+  dnsName: ''
+});
+
+const validKeySizes = [2048, 3072, 4096];
+const validKeyCurves: KeyCurveName[] = ['P-256', 'P-384', 'P-521', 'P-256K'];
 
 const form = reactive({
   recordName: '',
@@ -37,8 +47,19 @@ const form = reactive({
   dnsAlias: ''
 });
 
-const canSubmit = computed(() => form.dnsNames.length > 0 && !props.sending);
-const fullDnsName = computed(() => buildDnsName());
+const certificateNameError = computed(() => (form.useAdvancedOptions ? validateCertificateName(form.certificateName) : ''));
+const dnsAliasValidation = computed(() => (form.useAdvancedOptions ? validateOptionalDnsAlias(form.dnsAlias) : { value: '', message: '' }));
+const dnsAliasError = computed(() => dnsAliasValidation.value.message);
+const keyOptionError = computed(() => validateKeyOptions());
+const submitValidationMessage = computed(() => {
+  if (form.dnsNames.length === 0) {
+    return 'Add at least one DNS name.';
+  }
+
+  return certificateNameError.value || dnsAliasError.value || keyOptionError.value;
+});
+const canSubmit = computed(() => !props.sending && submitValidationMessage.value === '');
+const fullDnsName = computed(() => (selectedZone.value ? validateRecordDnsName(form.recordName, selectedZone.value).value || null : null));
 const keySummary = computed(() => (form.keyType === 'RSA' ? `${form.keySize} bit RSA` : `${form.keyCurveName} EC`));
 const issueStatusLabel = computed(() => {
   if (form.dnsNames.length > 0) {
@@ -76,9 +97,23 @@ watch(
   }
 );
 
+watch(
+  () => form.useAdvancedOptions,
+  (useAdvancedOptions) => {
+    if (!useAdvancedOptions) {
+      form.certificateName = '';
+      form.keyType = 'RSA';
+      form.keySize = 2048;
+      form.keyCurveName = 'P-256';
+      form.reuseKey = false;
+      form.dnsAlias = '';
+    }
+  }
+);
+
 function resetForm(): void {
   selectedZone.value = null;
-  formMessage.value = '';
+  validationErrors.dnsName = '';
   form.recordName = '';
   form.dnsNames = [];
   form.dnsProviderName = '';
@@ -92,52 +127,168 @@ function resetForm(): void {
 }
 
 function normalizeRecordName(recordName: string): string {
-  return recordName.trim().replace(/\.$/, '');
+  return recordName.trim().replace(/\.+$/, '');
 }
 
-function buildDnsName(): string | null {
-  if (!selectedZone.value) {
+function toAsciiDnsName(value: string): string | null {
+  try {
+    return toASCII(value).toLowerCase();
+  } catch {
     return null;
   }
+}
 
-  const normalizedRecordName = normalizeRecordName(form.recordName);
+function validateCertificateName(certificateName: string): string {
+  const normalizedCertificateName = certificateName.trim();
+
+  if (!normalizedCertificateName) {
+    return '';
+  }
+
+  if (normalizedCertificateName.length > 127) {
+    return 'Certificate Name must be 127 characters or fewer.';
+  }
+
+  if (!/^[0-9a-zA-Z-]+$/.test(normalizedCertificateName)) {
+    return 'Certificate Name can contain only letters, numbers, and hyphens.';
+  }
+
+  return '';
+}
+
+function validateDnsName(value: string, fieldLabel: string, allowWildcard: boolean): ValidationOutcome {
+  const normalizedInput = normalizeRecordName(value);
+
+  if (!normalizedInput) {
+    return { value: '', message: `${fieldLabel} is required.` };
+  }
+
+  const asciiName = toAsciiDnsName(normalizedInput);
+
+  if (!asciiName) {
+    return { value: '', message: `${fieldLabel} contains characters that cannot be converted to a DNS name.` };
+  }
+
+  if (asciiName.length > 253) {
+    return { value: '', message: `${fieldLabel} must be 253 characters or fewer.` };
+  }
+
+  const labels = asciiName.split('.');
+
+  if (labels.length < 2) {
+    return { value: '', message: `${fieldLabel} must include a domain suffix.` };
+  }
+
+  for (const [labelIndex, label] of labels.entries()) {
+    if (!label) {
+      return { value: '', message: `${fieldLabel} cannot contain empty DNS labels.` };
+    }
+
+    if (label.length > 63) {
+      return { value: '', message: 'Each DNS label must be 63 characters or fewer.' };
+    }
+
+    if (label === '*') {
+      if (!allowWildcard) {
+        return { value: '', message: `${fieldLabel} cannot be a wildcard.` };
+      }
+
+      if (labelIndex !== 0) {
+        return { value: '', message: 'A wildcard can only be the leftmost DNS label.' };
+      }
+
+      continue;
+    }
+
+    if (label.includes('*') || !/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label)) {
+      return { value: '', message: `${fieldLabel} can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.` };
+    }
+  }
+
+  return { value: asciiName, message: '' };
+}
+
+function validateOptionalDnsAlias(dnsAlias: string): ValidationOutcome {
+  if (!dnsAlias.trim()) {
+    return { value: '', message: '' };
+  }
+
+  return validateDnsName(dnsAlias, 'DNS Alias', false);
+}
+
+function validateRecordDnsName(recordName: string, zone: SelectableDnsZone): ValidationOutcome {
+  const zoneValidation = validateDnsName(zone.name, 'DNS zone', false);
+
+  if (zoneValidation.message) {
+    return zoneValidation;
+  }
+
+  const normalizedRecordName = normalizeRecordName(recordName);
+  let candidateDnsName: string;
 
   if (!normalizedRecordName || normalizedRecordName === '@') {
-    return selectedZone.value.name;
+    candidateDnsName = zoneValidation.value;
+  } else {
+    const asciiRecordName = toAsciiDnsName(normalizedRecordName);
+
+    if (!asciiRecordName) {
+      return { value: '', message: 'DNS Name contains characters that cannot be converted to a DNS name.' };
+    }
+
+    if (asciiRecordName === zoneValidation.value) {
+      candidateDnsName = zoneValidation.value;
+    } else if (asciiRecordName.endsWith(`.${zoneValidation.value}`)) {
+      candidateDnsName = asciiRecordName;
+    } else {
+      candidateDnsName = `${asciiRecordName}.${zoneValidation.value}`;
+    }
   }
 
-  if (normalizedRecordName.endsWith(`.${selectedZone.value.name}`)) {
-    return toASCII(normalizedRecordName);
+  return validateDnsName(candidateDnsName, 'DNS Name', true);
+}
+
+function validateKeyOptions(): string {
+  if (form.keyType === 'RSA' && !validKeySizes.includes(form.keySize)) {
+    return 'Key Size must be 2048, 3072, or 4096 when Key Type is RSA.';
   }
 
-  return `${toASCII(normalizedRecordName)}.${selectedZone.value.name}`;
+  if (form.keyType === 'EC' && !validKeyCurves.includes(form.keyCurveName)) {
+    return 'Curve must be P-256, P-384, P-521, or P-256K when Key Type is EC.';
+  }
+
+  return '';
+}
+
+function clearDnsNameError(): void {
+  validationErrors.dnsName = '';
 }
 
 function addDnsName(): void {
-  formMessage.value = '';
+  validationErrors.dnsName = '';
 
   if (!selectedZone.value) {
+    validationErrors.dnsName = 'Select a DNS zone before adding a DNS name.';
     return;
   }
 
   if (form.dnsProviderName && form.dnsProviderName !== selectedZone.value.dnsProviderName) {
-    formMessage.value = 'DNS names in one certificate must use the same DNS provider.';
+    validationErrors.dnsName = 'DNS names in one certificate must use the same DNS provider.';
     return;
   }
 
-  const dnsName = buildDnsName();
+  const dnsNameValidation = validateRecordDnsName(form.recordName, selectedZone.value);
 
-  if (!dnsName) {
+  if (dnsNameValidation.message) {
+    validationErrors.dnsName = dnsNameValidation.message;
     return;
   }
 
-  if (!form.dnsNames.includes(dnsName)) {
-    form.dnsNames.push(dnsName);
-  } else {
-    formMessage.value = 'This DNS name is already in the certificate.';
+  if (form.dnsNames.some((dnsName) => dnsName.toLowerCase() === dnsNameValidation.value)) {
+    validationErrors.dnsName = 'This DNS name is already in the certificate.';
     return;
   }
 
+  form.dnsNames.push(dnsNameValidation.value);
   form.dnsProviderName = selectedZone.value.dnsProviderName;
   form.recordName = '';
 }
@@ -147,22 +298,30 @@ function removeDnsName(dnsName: string): void {
 
   if (form.dnsNames.length === 0) {
     form.dnsProviderName = '';
-    formMessage.value = '';
+    validationErrors.dnsName = '';
   }
 }
 
 function submit(): void {
+  if (form.dnsNames.length === 0) {
+    validationErrors.dnsName = 'Add at least one DNS name before issuing the certificate.';
+    return;
+  }
+
   if (!canSubmit.value) {
     return;
   }
 
+  const normalizedCertificateName = form.useAdvancedOptions ? form.certificateName.trim() : '';
+  const normalizedDnsAlias = form.useAdvancedOptions ? dnsAliasValidation.value.value : '';
+
   const policy: CertificatePolicyItem = {
     dnsNames: form.dnsNames,
     dnsProviderName: form.dnsProviderName || undefined,
-    certificateName: form.certificateName.trim() || undefined,
+    certificateName: normalizedCertificateName || undefined,
     keyType: form.keyType,
-    reuseKey: form.reuseKey,
-    dnsAlias: form.dnsAlias.trim() || undefined
+    reuseKey: form.useAdvancedOptions ? form.reuseKey : false,
+    dnsAlias: normalizedDnsAlias || undefined
   };
 
   if (form.keyType === 'RSA') {
@@ -237,7 +396,9 @@ function submit(): void {
                   type="text"
                   placeholder="@, www, api, *"
                   :disabled="!selectedZone"
+                  :aria-invalid="validationErrors.dnsName ? 'true' : 'false'"
                   @keydown.enter.prevent="addDnsName"
+                  @input="clearDnsNameError"
                 />
                 <span class="compound-input__suffix">.{{ selectedZone ? displayDnsName(selectedZone.name) : 'zone' }}</span>
                 <button class="icon-button" type="button" :disabled="!selectedZone" @click="addDnsName">
@@ -249,7 +410,7 @@ function submit(): void {
                 <span>Full DNS name</span>
                 <strong>{{ displayDnsName(fullDnsName) }}</strong>
               </div>
-              <p v-if="formMessage" class="form-error">{{ formMessage }}</p>
+              <p v-if="validationErrors.dnsName" class="form-error">{{ validationErrors.dnsName }}</p>
               <div class="dns-list dns-list--editable">
                 <span v-for="dnsName in form.dnsNames" :key="dnsName" class="dns-chip dns-chip--removable">
                   {{ displayDnsName(dnsName) }}
@@ -268,17 +429,19 @@ function submit(): void {
             </div>
 
             <div v-if="form.useAdvancedOptions" class="advanced-grid">
-              <label class="form-field">
+              <label class="form-field" :class="{ 'is-invalid': certificateNameError }">
                 <span class="form-label">Certificate Name</span>
-                <input v-model="form.certificateName" type="text" placeholder="Optional certificate name" />
+                <input v-model="form.certificateName" type="text" placeholder="Optional certificate name" :aria-invalid="certificateNameError ? 'true' : 'false'" />
+                <span v-if="certificateNameError" class="form-error">{{ certificateNameError }}</span>
               </label>
 
-              <label class="form-field">
+              <label class="form-field" :class="{ 'is-invalid': keyOptionError }">
                 <span class="form-label">Key Type</span>
                 <select v-model="form.keyType">
                   <option value="RSA">RSA</option>
                   <option value="EC">EC</option>
                 </select>
+                <span v-if="keyOptionError" class="form-error">{{ keyOptionError }}</span>
               </label>
 
               <label v-if="form.keyType === 'RSA'" class="form-field">
@@ -300,9 +463,10 @@ function submit(): void {
                 </select>
               </label>
 
-              <label class="form-field">
+              <label class="form-field" :class="{ 'is-invalid': dnsAliasError }">
                 <span class="form-label">DNS Alias</span>
-                <input v-model="form.dnsAlias" type="text" placeholder="alias.example.com" />
+                <input v-model="form.dnsAlias" type="text" placeholder="alias.example.com" :aria-invalid="dnsAliasError ? 'true' : 'false'" />
+                <span v-if="dnsAliasError" class="form-error">{{ dnsAliasError }}</span>
               </label>
 
               <label class="toggle-row advanced-grid__toggle">

--- a/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
+++ b/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
@@ -1,0 +1,322 @@
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue';
+import { createColumnHelper, FlexRender, getCoreRowModel, getSortedRowModel, useVueTable, type Row, type SortingState } from '@tanstack/vue-table';
+import { ArrowDown, ArrowUp, ArrowUpDown, CirclePlus, Filter, LoaderCircle, RefreshCw, Search, SearchX, ServerCog, SlidersHorizontal, X } from 'lucide-vue-next';
+
+import type { CertificateCategory, CertificateItem, CertificateStatusKind } from '@/api/types';
+import {
+  displayDnsName,
+  formatDate,
+  getCategoryLabel,
+  getCertificateCategory,
+  getCertificateStatus,
+  getPrimaryZone,
+  isShortLived
+} from '@/utils/certificates';
+
+import StatusBadge from './StatusBadge.vue';
+
+const props = defineProps<{
+  certificates: CertificateItem[];
+  loading: boolean;
+  selectedCertificate?: CertificateItem | null;
+}>();
+
+const emit = defineEmits<{
+  select: [certificate: CertificateItem];
+  refresh: [];
+  add: [];
+}>();
+
+type CategoryFilter = 'all' | CertificateCategory;
+type StatusFilter = 'all' | CertificateStatusKind;
+type CertificateRow = Row<CertificateItem>;
+const noProviderValue = '__none';
+
+const filters = reactive({
+  query: '',
+  category: 'managed' as CategoryFilter,
+  status: 'all' as StatusFilter,
+  provider: 'all'
+});
+const sorting = ref<SortingState>([{ id: 'expiresOn', desc: false }]);
+
+const columnHelper = createColumnHelper<CertificateItem>();
+const columns = [
+  columnHelper.accessor('name', { header: 'Name' }),
+  columnHelper.display({ id: 'dnsNames', header: 'DNS Names', enableSorting: false }),
+  columnHelper.accessor((certificate) => getCategoryLabel(getCertificateCategory(certificate)), { id: 'category', header: 'Category' }),
+  columnHelper.accessor('expiresOn', { header: 'Expires' }),
+  columnHelper.accessor((certificate) => `${certificate.keyType ?? ''} ${certificate.keySize ?? certificate.keyCurveName ?? ''}`, { id: 'key', header: 'Key' }),
+  columnHelper.display({ id: 'actions', header: '', enableSorting: false })
+];
+
+const categoryOptions: { label: string; value: CategoryFilter }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Managed', value: 'managed' },
+  { label: 'Other CA', value: 'other-ca' },
+  { label: 'Unmanaged', value: 'unmanaged' }
+];
+
+const providerOptions = computed(() => {
+  const providerNames = new Set<string>();
+  let hasNoProvider = false;
+
+  for (const certificate of props.certificates) {
+    if (certificate.dnsProviderName) {
+      providerNames.add(certificate.dnsProviderName);
+    } else {
+      hasNoProvider = true;
+    }
+  }
+
+  const options = Array.from(providerNames)
+    .toSorted((left, right) => left.localeCompare(right))
+    .map((providerName) => ({ label: providerName, value: providerName }));
+
+  if (hasNoProvider) {
+    options.push({ label: 'No provider', value: noProviderValue });
+  }
+
+  return options;
+});
+
+const hasActiveFilters = computed(
+  () => filters.query.trim() !== '' || filters.category !== 'managed' || filters.status !== 'all' || filters.provider !== 'all'
+);
+
+const filteredCertificates = computed(() => {
+  const normalizedQuery = filters.query.trim().toLowerCase();
+
+  return props.certificates.filter((certificate) => {
+    const category = getCertificateCategory(certificate);
+    const status = getCertificateStatus(certificate);
+    const provider = certificate.dnsProviderName ?? noProviderValue;
+    const matchesCategory = filters.category === 'all' || filters.category === category;
+    const matchesStatus = filters.status === 'all' || filters.status === status.kind;
+    const matchesProvider = filters.provider === 'all' || filters.provider === provider;
+    const matchesQuery =
+      !normalizedQuery ||
+      certificate.name.toLowerCase().includes(normalizedQuery) ||
+      certificate.dnsNames.some((dnsName) => displayDnsName(dnsName).toLowerCase().includes(normalizedQuery) || dnsName.toLowerCase().includes(normalizedQuery));
+
+    return matchesCategory && matchesStatus && matchesProvider && matchesQuery;
+  });
+});
+
+const tableTitle = computed(() => {
+  if (filters.category === 'all') {
+    return 'Certificates';
+  }
+
+  return `${getCategoryLabel(filters.category)} Certificates`;
+});
+
+const table = useVueTable({
+  get data() {
+    return filteredCertificates.value;
+  },
+  columns,
+  state: {
+    get sorting() {
+      return sorting.value;
+    }
+  },
+  onSortingChange: (updaterOrValue) => {
+    sorting.value = typeof updaterOrValue === 'function' ? updaterOrValue(sorting.value) : updaterOrValue;
+  },
+  getCoreRowModel: getCoreRowModel(),
+  getSortedRowModel: getSortedRowModel()
+});
+
+const zoneGroups = computed(() => {
+  const groups: { zoneName: string; rows: CertificateRow[] }[] = [];
+  const groupIndexByZone = new Map<string, number>();
+
+  for (const row of table.getRowModel().rows) {
+    const zoneName = getPrimaryZone(row.original);
+    const groupIndex = groupIndexByZone.get(zoneName);
+
+    if (groupIndex === undefined) {
+      groupIndexByZone.set(zoneName, groups.length);
+      groups.push({ zoneName, rows: [row] });
+    } else {
+      groups[groupIndex].rows.push(row);
+    }
+  }
+
+  return groups;
+});
+
+function clearFilters(): void {
+  filters.query = '';
+  filters.category = 'managed';
+  filters.status = 'all';
+  filters.provider = 'all';
+}
+
+function getSortIcon(sortDirection: false | 'asc' | 'desc') {
+  if (sortDirection === 'asc') {
+    return ArrowUp;
+  }
+
+  if (sortDirection === 'desc') {
+    return ArrowDown;
+  }
+
+  return ArrowUpDown;
+}
+
+function formatCertificateCount(count: number): string {
+  return `${count} ${count === 1 ? 'certificate' : 'certificates'}`;
+}
+</script>
+
+<template>
+  <section class="table-surface" aria-labelledby="certificate-table-heading">
+    <div class="table-toolbar">
+      <div>
+        <h2 id="certificate-table-heading" class="section-heading">{{ tableTitle }}</h2>
+        <div class="section-meta">{{ filteredCertificates.length }} of {{ certificates.length }}</div>
+      </div>
+      <div class="table-toolbar__actions">
+        <button class="icon-button" type="button" title="Refresh certificates" :disabled="loading" @click="emit('refresh')">
+          <RefreshCw :class="{ 'spin': loading }" :size="17" aria-hidden="true" />
+          <span>Refresh</span>
+        </button>
+        <button class="primary-button" type="button" @click="emit('add')">
+          <CirclePlus :size="17" aria-hidden="true" />
+          <span>Issue Certificate</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="table-controls">
+      <label class="search-field">
+        <Search :size="16" aria-hidden="true" />
+        <input v-model="filters.query" type="search" placeholder="Search certificates or domains" />
+      </label>
+      <div class="segmented-control" aria-label="Certificate category">
+        <button
+          v-for="option in categoryOptions"
+          :key="option.value"
+          type="button"
+          :class="{ 'is-selected': filters.category === option.value }"
+          @click="filters.category = option.value"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+      <label class="select-field">
+        <Filter :size="15" aria-hidden="true" />
+        <select v-model="filters.status">
+          <option value="all">Any status</option>
+          <option value="valid">Valid</option>
+          <option value="warning">Expiring soon</option>
+          <option value="expired">Expired</option>
+        </select>
+      </label>
+      <label class="select-field">
+        <ServerCog :size="15" aria-hidden="true" />
+        <select v-model="filters.provider" :disabled="providerOptions.length === 0">
+          <option value="all">Any provider</option>
+          <option v-for="option in providerOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
+        </select>
+      </label>
+      <button v-if="hasActiveFilters" class="icon-button" type="button" @click="clearFilters">
+        <X :size="16" aria-hidden="true" />
+        <span>Clear</span>
+      </button>
+    </div>
+
+    <div class="table-wrap">
+      <table class="certificate-table">
+        <thead>
+          <tr v-for="headerGroup in table.getHeaderGroups()" :key="headerGroup.id">
+            <th v-for="header in headerGroup.headers" :key="header.id">
+              <button
+                v-if="!header.isPlaceholder && header.column.getCanSort()"
+                class="table-sort-button"
+                type="button"
+                @click="header.column.getToggleSortingHandler()?.($event)"
+              >
+                <FlexRender :render="header.column.columnDef.header" :props="header.getContext()" />
+                <component :is="getSortIcon(header.column.getIsSorted())" :size="14" aria-hidden="true" />
+              </button>
+              <FlexRender v-else-if="!header.isPlaceholder" :render="header.column.columnDef.header" :props="header.getContext()" />
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="loading">
+            <td colspan="6">
+              <div class="table-empty table-empty--compact">
+                <LoaderCircle class="spin" :size="24" aria-hidden="true" />
+                <strong>Loading certificates</strong>
+              </div>
+            </td>
+          </tr>
+          <tr v-else-if="filteredCertificates.length === 0">
+            <td colspan="6">
+              <div class="table-empty">
+                <SearchX :size="28" aria-hidden="true" />
+                <strong>No certificates found</strong>
+                <span>{{ hasActiveFilters ? 'No rows match the current filters.' : 'No certificates are available yet.' }}</span>
+                <button v-if="hasActiveFilters" class="secondary-button" type="button" @click="clearFilters">Clear filters</button>
+                <button v-else class="primary-button" type="button" @click="emit('add')">
+                  <CirclePlus :size="17" aria-hidden="true" />
+                  <span>Issue Certificate</span>
+                </button>
+              </div>
+            </td>
+          </tr>
+          <template v-else>
+            <template v-for="group in zoneGroups" :key="group.zoneName">
+              <tr class="zone-group-row">
+                <td colspan="6">
+                  <div class="zone-group">
+                    <span class="zone-group__name">{{ group.zoneName }}</span>
+                    <span class="zone-group__meta">{{ formatCertificateCount(group.rows.length) }}</span>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                v-for="row in group.rows"
+                :key="row.original.id"
+                class="certificate-row"
+                :class="{ 'is-selected': selectedCertificate?.id === row.original.id }"
+                @click="emit('select', row.original)"
+              >
+                <td>
+                  <div class="certificate-name">{{ row.original.name }}</div>
+                  <div v-if="isShortLived(row.original)" class="inline-note">Short-lived</div>
+                </td>
+                <td>
+                  <div class="dns-list">
+                    <span v-for="dnsName in row.original.dnsNames.slice(0, 3)" :key="dnsName" class="dns-chip">{{ displayDnsName(dnsName) }}</span>
+                    <span v-if="row.original.dnsNames.length > 3" class="dns-chip dns-chip--muted">+{{ row.original.dnsNames.length - 3 }}</span>
+                  </div>
+                </td>
+                <td>{{ getCategoryLabel(getCertificateCategory(row.original)) }}</td>
+                <td>
+                  <StatusBadge :certificate="row.original" />
+                  <div class="cell-subtext">{{ formatDate(row.original.expiresOn) }}</div>
+                </td>
+                <td>
+                  <span>{{ row.original.keyType ?? '-' }}</span>
+                  <span v-if="row.original.keySize" class="cell-subtext">{{ row.original.keySize }} bit</span>
+                  <span v-else-if="row.original.keyCurveName" class="cell-subtext">{{ row.original.keyCurveName }}</span>
+                </td>
+                <td>
+                  <button class="row-action" type="button" title="Open certificate details" @click.stop="emit('select', row.original)">
+                    <SlidersHorizontal :size="16" aria-hidden="true" />
+                  </button>
+                </td>
+              </tr>
+            </template>
+          </template>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</template>

--- a/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
+++ b/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
@@ -1,9 +1,26 @@
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue';
 import { createColumnHelper, FlexRender, getCoreRowModel, getSortedRowModel, useVueTable, type Row, type SortingState } from '@tanstack/vue-table';
-import { ArrowDown, ArrowUp, ArrowUpDown, CirclePlus, Filter, LoaderCircle, RefreshCw, Search, SearchX, ServerCog, SlidersHorizontal, X } from 'lucide-vue-next';
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  ChevronDown,
+  ChevronRight,
+  ChevronsDownUp,
+  ChevronsUpDown,
+  CirclePlus,
+  Filter,
+  LoaderCircle,
+  RefreshCw,
+  Search,
+  SearchX,
+  ServerCog,
+  SlidersHorizontal,
+  X
+} from 'lucide-vue-next';
 
-import type { CertificateCategory, CertificateItem, CertificateStatusKind } from '@/api/types';
+import type { CertificateCategory, CertificateItem, CertificateStatusKind, DnsZoneGroup } from '@/api/types';
 import {
   displayDnsName,
   formatDate,
@@ -18,6 +35,7 @@ import StatusBadge from './StatusBadge.vue';
 
 const props = defineProps<{
   certificates: CertificateItem[];
+  dnsZoneGroups?: DnsZoneGroup[];
   loading: boolean;
   selectedCertificate?: CertificateItem | null;
 }>();
@@ -31,6 +49,12 @@ const emit = defineEmits<{
 type CategoryFilter = 'all' | CertificateCategory;
 type StatusFilter = 'all' | CertificateStatusKind;
 type CertificateRow = Row<CertificateItem>;
+interface ZoneGroup {
+  zoneName: string;
+  rows: CertificateRow[];
+  statusCounts: Record<CertificateStatusKind, number>;
+}
+
 const noProviderValue = '__none';
 
 const filters = reactive({
@@ -40,6 +64,7 @@ const filters = reactive({
   provider: 'all'
 });
 const sorting = ref<SortingState>([{ id: 'expiresOn', desc: false }]);
+const collapsedZones = ref<Set<string>>(new Set());
 
 const columnHelper = createColumnHelper<CertificateItem>();
 const columns = [
@@ -129,24 +154,37 @@ const table = useVueTable({
   getSortedRowModel: getSortedRowModel()
 });
 
-const zoneGroups = computed(() => {
-  const groups: { zoneName: string; rows: CertificateRow[] }[] = [];
+const zoneGroups = computed<ZoneGroup[]>(() => {
+  const groups: ZoneGroup[] = [];
   const groupIndexByZone = new Map<string, number>();
 
   for (const row of table.getRowModel().rows) {
-    const zoneName = getPrimaryZone(row.original);
+    const zoneName = getPrimaryZone(row.original, props.dnsZoneGroups ?? []);
     const groupIndex = groupIndexByZone.get(zoneName);
+    const statusKind = getCertificateStatus(row.original).kind;
 
     if (groupIndex === undefined) {
       groupIndexByZone.set(zoneName, groups.length);
-      groups.push({ zoneName, rows: [row] });
+      groups.push({
+        zoneName,
+        rows: [row],
+        statusCounts: {
+          valid: statusKind === 'valid' ? 1 : 0,
+          warning: statusKind === 'warning' ? 1 : 0,
+          expired: statusKind === 'expired' ? 1 : 0
+        }
+      });
     } else {
-      groups[groupIndex].rows.push(row);
+      const group = groups[groupIndex];
+      group.rows.push(row);
+      group.statusCounts[statusKind] += 1;
     }
   }
 
   return groups;
 });
+
+const allZoneGroupsCollapsed = computed(() => zoneGroups.value.length > 0 && zoneGroups.value.every((group) => collapsedZones.value.has(group.zoneName)));
 
 function clearFilters(): void {
   filters.query = '';
@@ -169,6 +207,26 @@ function getSortIcon(sortDirection: false | 'asc' | 'desc') {
 
 function formatCertificateCount(count: number): string {
   return `${count} ${count === 1 ? 'certificate' : 'certificates'}`;
+}
+
+function isZoneCollapsed(zoneName: string): boolean {
+  return collapsedZones.value.has(zoneName);
+}
+
+function toggleZoneGroup(zoneName: string): void {
+  const nextCollapsedZones = new Set(collapsedZones.value);
+
+  if (nextCollapsedZones.has(zoneName)) {
+    nextCollapsedZones.delete(zoneName);
+  } else {
+    nextCollapsedZones.add(zoneName);
+  }
+
+  collapsedZones.value = nextCollapsedZones;
+}
+
+function toggleAllZoneGroups(): void {
+  collapsedZones.value = allZoneGroupsCollapsed.value ? new Set() : new Set(zoneGroups.value.map((group) => group.zoneName));
 }
 </script>
 
@@ -223,6 +281,10 @@ function formatCertificateCount(count: number): string {
           <option v-for="option in providerOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
         </select>
       </label>
+      <button v-if="zoneGroups.length > 0" class="icon-button" type="button" @click="toggleAllZoneGroups">
+        <component :is="allZoneGroupsCollapsed ? ChevronsUpDown : ChevronsDownUp" :size="16" aria-hidden="true" />
+        <span>{{ allZoneGroupsCollapsed ? 'Expand all' : 'Collapse all' }}</span>
+      </button>
       <button v-if="hasActiveFilters" class="icon-button" type="button" @click="clearFilters">
         <X :size="16" aria-hidden="true" />
         <span>Clear</span>
@@ -275,44 +337,53 @@ function formatCertificateCount(count: number): string {
               <tr class="zone-group-row">
                 <td colspan="6">
                   <div class="zone-group">
-                    <span class="zone-group__name">{{ group.zoneName }}</span>
-                    <span class="zone-group__meta">{{ formatCertificateCount(group.rows.length) }}</span>
+                    <button class="zone-group__toggle" type="button" :aria-expanded="!isZoneCollapsed(group.zoneName)" @click="toggleZoneGroup(group.zoneName)">
+                      <component :is="isZoneCollapsed(group.zoneName) ? ChevronRight : ChevronDown" :size="16" aria-hidden="true" />
+                      <span class="zone-group__name">{{ group.zoneName }}</span>
+                    </button>
+                    <div class="zone-group__summary">
+                      <span class="zone-group__meta">{{ formatCertificateCount(group.rows.length) }}</span>
+                      <span v-if="group.statusCounts.valid > 0" class="zone-stat zone-stat--valid">{{ group.statusCounts.valid }} valid</span>
+                      <span v-if="group.statusCounts.warning > 0" class="zone-stat zone-stat--warning">{{ group.statusCounts.warning }} expiring</span>
+                      <span v-if="group.statusCounts.expired > 0" class="zone-stat zone-stat--expired">{{ group.statusCounts.expired }} expired</span>
+                    </div>
                   </div>
                 </td>
               </tr>
-              <tr
-                v-for="row in group.rows"
-                :key="row.original.id"
-                class="certificate-row"
-                :class="{ 'is-selected': selectedCertificate?.id === row.original.id }"
-                @click="emit('select', row.original)"
-              >
-                <td>
-                  <div class="certificate-name">{{ row.original.name }}</div>
-                  <div v-if="isShortLived(row.original)" class="inline-note">Short-lived</div>
-                </td>
-                <td>
-                  <div class="dns-list">
-                    <span v-for="dnsName in row.original.dnsNames.slice(0, 3)" :key="dnsName" class="dns-chip">{{ displayDnsName(dnsName) }}</span>
-                    <span v-if="row.original.dnsNames.length > 3" class="dns-chip dns-chip--muted">+{{ row.original.dnsNames.length - 3 }}</span>
-                  </div>
-                </td>
-                <td>{{ getCategoryLabel(getCertificateCategory(row.original)) }}</td>
-                <td>
-                  <StatusBadge :certificate="row.original" />
-                  <div class="cell-subtext">{{ formatDate(row.original.expiresOn) }}</div>
-                </td>
-                <td>
-                  <span>{{ row.original.keyType ?? '-' }}</span>
-                  <span v-if="row.original.keySize" class="cell-subtext">{{ row.original.keySize }} bit</span>
-                  <span v-else-if="row.original.keyCurveName" class="cell-subtext">{{ row.original.keyCurveName }}</span>
-                </td>
-                <td>
-                  <button class="row-action" type="button" title="Open certificate details" @click.stop="emit('select', row.original)">
-                    <SlidersHorizontal :size="16" aria-hidden="true" />
-                  </button>
-                </td>
-              </tr>
+              <template v-if="!isZoneCollapsed(group.zoneName)">
+                <tr
+                  v-for="row in group.rows"
+                  :key="row.original.id"
+                  class="certificate-row"
+                  :class="{ 'is-selected': selectedCertificate?.id === row.original.id }"
+                >
+                  <td data-label="Name">
+                    <div class="certificate-name">{{ row.original.name }}</div>
+                    <div v-if="isShortLived(row.original)" class="inline-note">Short-lived</div>
+                  </td>
+                  <td data-label="DNS Names">
+                    <div class="dns-list">
+                      <span v-for="dnsName in row.original.dnsNames.slice(0, 3)" :key="dnsName" class="dns-chip">{{ displayDnsName(dnsName) }}</span>
+                      <span v-if="row.original.dnsNames.length > 3" class="dns-chip dns-chip--muted">+{{ row.original.dnsNames.length - 3 }}</span>
+                    </div>
+                  </td>
+                  <td data-label="Category">{{ getCategoryLabel(getCertificateCategory(row.original)) }}</td>
+                  <td data-label="Expires">
+                    <StatusBadge :certificate="row.original" />
+                    <div class="cell-subtext">{{ formatDate(row.original.expiresOn) }}</div>
+                  </td>
+                  <td data-label="Key">
+                    <span>{{ row.original.keyType ?? '-' }}</span>
+                    <span v-if="row.original.keySize" class="cell-subtext">{{ row.original.keySize }} bit</span>
+                    <span v-else-if="row.original.keyCurveName" class="cell-subtext">{{ row.original.keyCurveName }}</span>
+                  </td>
+                  <td class="row-actions-cell">
+                    <button class="row-action" type="button" title="Open certificate details" @click="emit('select', row.original)">
+                      <SlidersHorizontal :size="16" aria-hidden="true" />
+                    </button>
+                  </td>
+                </tr>
+              </template>
             </template>
           </template>
         </tbody>

--- a/src/Acmebot.App/ClientApp/src/components/ConfirmRevokeDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/ConfirmRevokeDialog.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { AlertTriangle } from 'lucide-vue-next';
+import {
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogRoot,
+  AlertDialogTitle
+} from 'reka-ui';
+
+defineProps<{
+  open: boolean;
+  certificateName: string;
+  busy: boolean;
+}>();
+
+const emit = defineEmits<{
+  cancel: [];
+  confirm: [];
+}>();
+
+function handleOpenChange(open: boolean): void {
+  if (!open) {
+    emit('cancel');
+  }
+}
+</script>
+
+<template>
+  <AlertDialogRoot :open="open" @update:open="handleOpenChange">
+    <AlertDialogPortal>
+      <AlertDialogOverlay class="modal-scrim" />
+      <AlertDialogContent class="confirm-panel">
+        <div class="confirm-panel__icon">
+          <AlertTriangle :size="22" aria-hidden="true" />
+        </div>
+        <div class="confirm-panel__body">
+          <AlertDialogTitle class="confirm-panel__title">Revoke certificate</AlertDialogTitle>
+          <AlertDialogDescription class="confirm-panel__description">
+            This will revoke "{{ certificateName }}". Existing bindings that depend on this certificate may stop validating.
+          </AlertDialogDescription>
+        </div>
+        <div class="confirm-panel__actions">
+          <AlertDialogCancel as-child>
+            <button class="secondary-button" type="button" :disabled="busy">Cancel</button>
+          </AlertDialogCancel>
+          <AlertDialogAction as-child>
+            <button class="danger-button" type="button" :disabled="busy" @click="emit('confirm')">Revoke</button>
+          </AlertDialogAction>
+        </div>
+      </AlertDialogContent>
+    </AlertDialogPortal>
+  </AlertDialogRoot>
+</template>

--- a/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
+++ b/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+import { AlertTriangle, CalendarDays, Copy, Fingerprint, KeyRound, RotateCw, ShieldCheck, Trash2, X } from 'lucide-vue-next';
+
+import type { CertificateItem } from '@/api/types';
+import { displayDnsName, formatDateTime, getCategoryLabel, getCertificateCategory, getValidityDays } from '@/utils/certificates';
+
+import StatusBadge from './StatusBadge.vue';
+
+const props = defineProps<{
+  certificate: CertificateItem | null;
+  open: boolean;
+  busy: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  renew: [certificate: CertificateItem];
+  revoke: [certificate: CertificateItem];
+  copy: [label: string, value: string];
+}>();
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="open && certificate" class="drawer-shell" role="dialog" aria-modal="true" aria-labelledby="certificate-details-heading">
+      <button class="drawer-scrim" type="button" title="Close details" @click="emit('close')"></button>
+      <aside class="drawer">
+        <header class="drawer__header">
+          <div>
+            <div class="eyebrow">{{ getCategoryLabel(getCertificateCategory(certificate)) }}</div>
+            <h2 id="certificate-details-heading">{{ certificate.name }}</h2>
+          </div>
+          <button class="icon-only-button" type="button" title="Close details" @click="emit('close')">
+            <X :size="18" aria-hidden="true" />
+          </button>
+        </header>
+
+        <div class="drawer__status-line">
+          <StatusBadge :certificate="certificate" />
+          <span>{{ formatDateTime(certificate.expiresOn) }}</span>
+        </div>
+
+        <section class="detail-section">
+          <div class="detail-section__heading">
+            <h3>DNS Names</h3>
+            <button class="copy-button" type="button" title="Copy DNS names" @click="emit('copy', 'DNS names', certificate.dnsNames.join('\n'))">
+              <Copy :size="15" aria-hidden="true" />
+            </button>
+          </div>
+          <div class="dns-list dns-list--stacked">
+            <span v-for="dnsName in certificate.dnsNames" :key="dnsName" class="dns-chip">{{ displayDnsName(dnsName) }}</span>
+          </div>
+        </section>
+
+        <section class="detail-grid" aria-label="Certificate metadata">
+          <div class="detail-item">
+            <CalendarDays :size="17" aria-hidden="true" />
+            <div>
+              <span>Created</span>
+              <strong>{{ formatDateTime(certificate.createdOn) }}</strong>
+            </div>
+          </div>
+          <div class="detail-item">
+            <ShieldCheck :size="17" aria-hidden="true" />
+            <div>
+              <span>Validity</span>
+              <strong>{{ getValidityDays(certificate) }} days</strong>
+            </div>
+          </div>
+          <div class="detail-item">
+            <KeyRound :size="17" aria-hidden="true" />
+            <div>
+              <span>Key</span>
+              <strong>{{ certificate.keyType ?? '-' }} {{ certificate.keySize ? `${certificate.keySize} bit` : certificate.keyCurveName ?? '' }}</strong>
+            </div>
+          </div>
+          <div class="detail-item detail-item--wide">
+            <Fingerprint :size="17" aria-hidden="true" />
+            <div class="detail-item__body">
+              <span>Thumbprint</span>
+              <strong>{{ certificate.x509Thumbprint ?? '-' }}</strong>
+            </div>
+            <button v-if="certificate.x509Thumbprint" class="copy-button" type="button" title="Copy thumbprint" @click="emit('copy', 'Thumbprint', certificate.x509Thumbprint)">
+              <Copy :size="15" aria-hidden="true" />
+            </button>
+          </div>
+        </section>
+
+        <section class="detail-section">
+          <h3>Metadata</h3>
+          <dl class="metadata-list">
+            <div class="metadata-row">
+              <dt>Issuer</dt>
+              <dd>
+                <span class="metadata-chip" :class="certificate.isIssuedByAcmebot ? 'metadata-chip--success' : 'metadata-chip--neutral'">
+                  {{ certificate.isIssuedByAcmebot ? 'Acmebot' : 'External' }}
+                </span>
+              </dd>
+            </div>
+            <div class="metadata-row">
+              <dt>Current ACME endpoint</dt>
+              <dd>
+                <span class="metadata-chip" :class="certificate.isSameEndpoint ? 'metadata-chip--success' : 'metadata-chip--warning'">
+                  {{ certificate.isSameEndpoint ? 'Current' : 'Different' }}
+                </span>
+              </dd>
+            </div>
+            <div class="metadata-row">
+              <dt>Reuse key</dt>
+              <dd>
+                <span class="metadata-chip" :class="certificate.reuseKey ? 'metadata-chip--success' : 'metadata-chip--neutral'">
+                  {{ certificate.reuseKey ? 'Enabled' : 'Disabled' }}
+                </span>
+              </dd>
+            </div>
+            <div v-if="certificate.dnsProviderName" class="metadata-row">
+              <dt>DNS provider</dt>
+              <dd>{{ certificate.dnsProviderName }}</dd>
+            </div>
+            <div v-if="certificate.dnsAlias" class="metadata-row metadata-row--stacked">
+              <dt>DNS alias</dt>
+              <dd class="metadata-value-line">
+                <span class="metadata-value">{{ displayDnsName(certificate.dnsAlias ?? '') }}</span>
+              </dd>
+            </div>
+            <div v-if="certificate.acmeEndpoint" class="metadata-row metadata-row--stacked">
+              <dt>ACME endpoint</dt>
+              <dd class="metadata-value-line">
+                <span class="metadata-value metadata-value--mono">{{ certificate.acmeEndpoint }}</span>
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <footer class="drawer__footer">
+          <button class="primary-button" type="button" :disabled="busy" @click="emit('renew', certificate)">
+            <RotateCw :size="17" aria-hidden="true" />
+            <span>Renew</span>
+          </button>
+          <button
+            v-if="certificate.isIssuedByAcmebot && certificate.isSameEndpoint && !certificate.isExpired"
+            class="danger-button"
+            type="button"
+            :disabled="busy"
+            @click="emit('revoke', certificate)"
+          >
+            <Trash2 :size="17" aria-hidden="true" />
+            <span>Revoke</span>
+          </button>
+          <div v-else class="drawer__hint">
+            <AlertTriangle :size="15" aria-hidden="true" />
+            Revoke is unavailable for this certificate.
+          </div>
+        </footer>
+      </aside>
+    </div>
+  </Teleport>
+</template>

--- a/src/Acmebot.App/ClientApp/src/components/OperationOverlay.vue
+++ b/src/Acmebot.App/ClientApp/src/components/OperationOverlay.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { LoaderCircle } from 'lucide-vue-next';
+
+defineProps<{
+  active: boolean;
+  title: string;
+  message?: string;
+}>();
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="active" class="operation-overlay" role="status" aria-live="polite">
+      <div class="operation-overlay__panel">
+        <LoaderCircle class="operation-overlay__spinner" :size="28" aria-hidden="true" />
+        <div>
+          <div class="operation-overlay__title">{{ title }}</div>
+          <div v-if="message" class="operation-overlay__message">{{ message }}</div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/src/Acmebot.App/ClientApp/src/components/SearchableZoneSelect.vue
+++ b/src/Acmebot.App/ClientApp/src/components/SearchableZoneSelect.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { Check, ChevronDown, Search } from 'lucide-vue-next';
+import {
+  ComboboxAnchor,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxItemIndicator,
+  ComboboxLabel,
+  ComboboxRoot,
+  ComboboxTrigger,
+  ComboboxViewport
+} from 'reka-ui';
+import { computed, ref, watch } from 'vue';
+
+import type { DnsZoneGroup, SelectableDnsZone } from '@/api/types';
+import { displayDnsName } from '@/utils/certificates';
+
+const props = defineProps<{
+  groups: DnsZoneGroup[];
+  selected: SelectableDnsZone | null;
+  loading?: boolean;
+}>();
+
+const emit = defineEmits<{
+  'update:selected': [zone: SelectableDnsZone | null];
+}>();
+
+interface ZoneOption extends SelectableDnsZone {
+  key: string;
+  displayName: string;
+}
+
+interface GroupedOptions {
+  providerName: string;
+  options: ZoneOption[];
+}
+
+const selectedKey = ref('');
+
+const selectedLabel = computed(() => (props.selected ? displayDnsName(props.selected.name) : ''));
+
+const allOptions = computed<ZoneOption[]>(() =>
+  props.groups.flatMap((group) =>
+    (group.dnsZones ?? []).map((zone) => ({
+      ...zone,
+      dnsProviderName: group.dnsProviderName,
+      displayName: displayDnsName(zone.name),
+      key: `${group.dnsProviderName}:${zone.name}`
+    }))
+  )
+);
+
+const groupedOptions = computed<GroupedOptions[]>(() => {
+  const map = new Map<string, ZoneOption[]>();
+
+  for (const option of allOptions.value) {
+    const options = map.get(option.dnsProviderName) ?? [];
+    options.push(option);
+    map.set(option.dnsProviderName, options);
+  }
+
+  return Array.from(map, ([providerName, options]) => ({ providerName, options }));
+});
+
+watch(
+  () => props.selected,
+  (selected) => {
+    selectedKey.value = selected ? `${selected.dnsProviderName}:${selected.name}` : '';
+  },
+  { immediate: true }
+);
+
+watch(selectedKey, (key) => {
+  const option = allOptions.value.find((candidate) => candidate.key === key);
+
+  if (!option) {
+    emit('update:selected', null);
+    return;
+  }
+
+  emit('update:selected', {
+    name: option.name,
+    dnsProviderName: option.dnsProviderName
+  });
+});
+
+function displaySelectedValue(value: unknown): string {
+  const option = allOptions.value.find((candidate) => candidate.key === value);
+
+  return option?.displayName ?? selectedLabel.value;
+}
+
+function clearSelection(): void {
+  selectedKey.value = '';
+}
+</script>
+
+<template>
+  <ComboboxRoot v-model="selectedKey" class="combobox" open-on-focus open-on-click reset-search-term-on-select>
+    <ComboboxAnchor class="combobox__control">
+      <Search class="combobox__search-icon" :size="16" aria-hidden="true" />
+      <ComboboxInput
+        class="combobox__input"
+        :display-value="displaySelectedValue"
+        placeholder="Search DNS zone"
+      />
+      <button v-if="selected" class="combobox__clear" type="button" title="Clear selected zone" @click="clearSelection">
+        Clear
+      </button>
+      <ComboboxTrigger class="combobox__toggle" title="Open DNS zone list">
+        <ChevronDown :size="16" aria-hidden="true" />
+      </ComboboxTrigger>
+    </ComboboxAnchor>
+
+    <ComboboxContent class="combobox__popover" position="popper" :side-offset="8">
+      <div v-if="loading" class="combobox__state">Loading DNS zones...</div>
+      <template v-else>
+        <ComboboxViewport>
+          <ComboboxEmpty class="combobox__state">No DNS zones found</ComboboxEmpty>
+          <ComboboxGroup v-for="group in groupedOptions" :key="group.providerName" class="combobox__group">
+            <ComboboxLabel class="combobox__group-label">{{ group.providerName }}</ComboboxLabel>
+            <ComboboxItem
+            v-for="option in group.options"
+            :key="option.key"
+            class="combobox__option"
+            :value="option.key"
+            :text-value="`${option.displayName} ${option.name} ${option.dnsProviderName}`"
+          >
+              <span>
+                <span class="combobox__option-name">{{ option.displayName }}</span>
+                <span class="combobox__option-meta">{{ option.name }}</span>
+              </span>
+              <ComboboxItemIndicator class="combobox__indicator">
+                <Check :size="15" aria-hidden="true" />
+              </ComboboxItemIndicator>
+            </ComboboxItem>
+          </ComboboxGroup>
+        </ComboboxViewport>
+      </template>
+    </ComboboxContent>
+  </ComboboxRoot>
+</template>

--- a/src/Acmebot.App/ClientApp/src/components/StatusBadge.vue
+++ b/src/Acmebot.App/ClientApp/src/components/StatusBadge.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import type { CertificateItem } from '@/api/types';
+import { getCertificateStatus } from '@/utils/certificates';
+
+const props = defineProps<{
+  certificate: CertificateItem;
+}>();
+
+const status = computed(() => getCertificateStatus(props.certificate));
+</script>
+
+<template>
+  <span class="status-badge" :class="`status-badge--${status.kind}`">
+    <span class="status-badge__dot" aria-hidden="true"></span>
+    {{ status.label }}
+  </span>
+</template>

--- a/src/Acmebot.App/ClientApp/src/components/ToastStack.vue
+++ b/src/Acmebot.App/ClientApp/src/components/ToastStack.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { AlertTriangle, CheckCircle2, Info, X, XCircle } from 'lucide-vue-next';
+
+export interface ToastMessage {
+  id: number;
+  type: 'success' | 'error' | 'warning' | 'info';
+  title: string;
+  message: string;
+}
+
+defineProps<{
+  messages: ToastMessage[];
+}>();
+
+const emit = defineEmits<{
+  dismiss: [id: number];
+}>();
+
+const icons = {
+  success: CheckCircle2,
+  error: XCircle,
+  warning: AlertTriangle,
+  info: Info
+};
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="toast-stack" aria-live="polite">
+      <div v-for="message in messages" :key="message.id" class="toast" :class="`toast--${message.type}`">
+        <component :is="icons[message.type]" class="toast__icon" :size="18" aria-hidden="true" />
+        <div class="toast__body">
+          <div class="toast__title">{{ message.title }}</div>
+          <div class="toast__message">{{ message.message }}</div>
+        </div>
+        <button class="toast__dismiss" type="button" title="Dismiss notification" @click="emit('dismiss', message.id)">
+          <X :size="16" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/src/Acmebot.App/ClientApp/src/main.ts
+++ b/src/Acmebot.App/ClientApp/src/main.ts
@@ -1,0 +1,7 @@
+import { createApp } from 'vue';
+
+import App from './App.vue';
+import './styles/tokens.css';
+import './styles/app.css';
+
+createApp(App).mount('#app');

--- a/src/Acmebot.App/ClientApp/src/styles/app.css
+++ b/src/Acmebot.App/ClientApp/src/styles/app.css
@@ -1,0 +1,1492 @@
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: rgba(255, 255, 255, 0.94);
+  border-bottom: 1px solid var(--color-border);
+  backdrop-filter: blur(14px);
+}
+
+.app-header__inner {
+  max-width: var(--content-width);
+  min-height: 64px;
+  margin: 0 auto;
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.brand-lockup,
+.header-status,
+.dashboard-pill,
+.table-toolbar__actions,
+.table-controls,
+.compound-input,
+.dns-list,
+.drawer__status-line,
+.drawer__footer,
+.metadata-value-line,
+.modal-panel__footer,
+.status-badge,
+.toast,
+.operation-overlay__panel {
+  display: flex;
+  align-items: center;
+}
+
+.brand-lockup {
+  gap: 12px;
+}
+
+.brand-mark {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-sm);
+  display: grid;
+  place-items: center;
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  border: 1px solid #c7e0f4;
+}
+
+.brand-title {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.brand-subtitle,
+.section-meta,
+.cell-subtext,
+.inline-note,
+.header-status,
+.summary-item__label,
+.combobox__option-meta,
+.drawer__hint,
+.form-error,
+.toast__message {
+  color: var(--color-muted);
+}
+
+.brand-subtitle,
+.header-status,
+.section-meta,
+.cell-subtext,
+.inline-note,
+.form-error {
+  font-size: 0.8rem;
+}
+
+.header-status {
+  gap: 8px;
+  padding: 7px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  white-space: nowrap;
+}
+
+.app-main {
+  flex: 1;
+  width: 100%;
+  max-width: var(--content-width);
+  margin: 0 auto;
+  padding: 28px 24px 56px;
+}
+
+.app-footer {
+  border-top: 1px solid var(--color-border);
+  background: var(--color-page);
+}
+
+.app-footer__inner {
+  max-width: var(--content-width);
+  min-height: 52px;
+  margin: 0 auto;
+  padding: 12px 24px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  color: var(--color-muted);
+  font-size: 0.78rem;
+}
+
+.build-metadata {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.build-metadata__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.build-metadata dt {
+  color: var(--color-faint);
+  font-weight: 700;
+}
+
+.build-metadata dd {
+  margin: 0;
+  color: var(--color-muted);
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.page-title-row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 20px;
+}
+
+.eyebrow {
+  color: var(--color-accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h1 {
+  margin-top: 5px;
+  font-size: clamp(1.55rem, 2vw, 2rem);
+  line-height: 1.2;
+}
+
+.dashboard-pill {
+  gap: 7px;
+  min-height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.summary-item {
+  min-height: 78px;
+  padding: 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+}
+
+.summary-item svg {
+  color: var(--color-muted);
+}
+
+.summary-item--good svg {
+  color: var(--color-good);
+}
+
+.summary-item--warning svg {
+  color: var(--color-warning);
+}
+
+.summary-item--danger svg {
+  color: var(--color-danger);
+}
+
+.summary-item__value {
+  font-size: 1.55rem;
+  line-height: 1;
+  font-weight: 700;
+}
+
+.summary-item__label {
+  margin-top: 4px;
+  font-size: 0.82rem;
+}
+
+.banner {
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.banner--error {
+  color: var(--color-danger);
+  border-color: #f2b8c5;
+  background: var(--color-danger-soft);
+}
+
+.table-surface {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.table-toolbar {
+  padding: 18px 18px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.section-heading {
+  font-size: 1.05rem;
+  line-height: 1.35;
+}
+
+.table-toolbar__actions {
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.primary-button,
+.secondary-button,
+.danger-button,
+.icon-button,
+.icon-only-button,
+.copy-button,
+.row-action,
+.combobox__toggle,
+.combobox__clear {
+  min-height: 34px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.primary-button,
+.secondary-button,
+.danger-button,
+.icon-button {
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  font-size: 0.86rem;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+.primary-button {
+  color: #ffffff;
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.primary-button:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+}
+
+.danger-button {
+  color: #ffffff;
+  background: var(--color-danger);
+  border-color: var(--color-danger);
+}
+
+.secondary-button:hover:not(:disabled),
+.icon-button:hover:not(:disabled),
+.row-action:hover:not(:disabled),
+.icon-only-button:hover:not(:disabled),
+.copy-button:hover:not(:disabled),
+.combobox__toggle:hover:not(:disabled),
+.combobox__clear:hover:not(:disabled) {
+  border-color: var(--color-border-strong);
+  background: var(--color-surface-subtle);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.table-controls {
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+}
+
+.search-field,
+.select-field {
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-muted);
+}
+
+.search-field {
+  flex: 1 1 260px;
+  max-width: 430px;
+  padding: 0 10px;
+}
+
+.search-field input,
+.select-field select,
+.form-field input,
+.form-field select,
+.compound-input input,
+.combobox__input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--color-text);
+}
+
+.select-field {
+  flex: 0 0 auto;
+  padding: 0 8px;
+}
+
+.select-field select {
+  min-width: 130px;
+  height: 34px;
+}
+
+.select-field select:disabled {
+  color: var(--color-faint);
+}
+
+.segmented-control {
+  display: inline-flex;
+  min-height: 36px;
+  padding: 3px;
+  gap: 2px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+}
+
+.segmented-control button {
+  min-width: 74px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--color-muted);
+  font-size: 0.84rem;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.segmented-control button.is-selected {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.certificate-table {
+  width: 100%;
+  min-width: 860px;
+  border-collapse: collapse;
+}
+
+.certificate-table th,
+.certificate-table td {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.certificate-table th {
+  color: var(--color-muted);
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  background: #fbfcfe;
+  white-space: nowrap;
+}
+
+.table-sort-button {
+  width: 100%;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-transform: inherit;
+  cursor: pointer;
+}
+
+.table-sort-button:hover {
+  color: var(--color-accent);
+}
+
+.certificate-table tbody tr.zone-group-row td {
+  padding: 8px 14px;
+  background: #eef6fc;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid #c7e0f4;
+}
+
+.zone-group {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.zone-group__name {
+  color: #124b78;
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.zone-group__meta {
+  color: var(--color-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.certificate-table tbody tr.certificate-row {
+  cursor: pointer;
+}
+
+.certificate-table tbody tr.certificate-row:hover,
+.certificate-table tbody tr.certificate-row.is-selected {
+  background: #f4f8fb;
+}
+
+.certificate-table .cell-subtext {
+  display: block;
+  margin-top: 3px;
+}
+
+.certificate-name {
+  font-weight: 700;
+  word-break: break-word;
+}
+
+.inline-note {
+  display: inline-block;
+  margin-top: 4px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--color-neutral-soft);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.dns-list {
+  gap: 5px;
+  flex-wrap: wrap;
+}
+
+.dns-list--stacked {
+  align-items: flex-start;
+}
+
+.dns-list--editable {
+  margin-top: 10px;
+}
+
+.dns-chip {
+  max-width: 100%;
+  min-height: 24px;
+  padding: 3px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border-radius: 5px;
+  background: var(--color-accent-soft);
+  color: #124b78;
+  border: 1px solid #c7e0f4;
+  font-size: 0.8rem;
+  font-weight: 650;
+  word-break: break-word;
+}
+
+.dns-chip--muted {
+  background: var(--color-neutral-soft);
+  color: var(--color-muted);
+  border-color: var(--color-border);
+}
+
+.dns-chip--removable button {
+  width: 18px;
+  height: 18px;
+  border: 0;
+  border-radius: 4px;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.status-badge {
+  width: max-content;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.status-badge__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+}
+
+.status-badge--valid {
+  color: var(--color-good);
+  background: var(--color-good-soft);
+}
+
+.status-badge--valid .status-badge__dot {
+  background: var(--color-good);
+}
+
+.status-badge--warning {
+  color: var(--color-warning);
+  background: var(--color-warning-soft);
+}
+
+.status-badge--warning .status-badge__dot {
+  background: var(--color-warning);
+}
+
+.status-badge--expired {
+  color: var(--color-danger);
+  background: var(--color-danger-soft);
+}
+
+.status-badge--expired .status-badge__dot {
+  background: var(--color-danger);
+}
+
+.row-action,
+.icon-only-button,
+.copy-button {
+  width: 34px;
+  padding: 0;
+  display: inline-grid;
+  place-items: center;
+}
+
+.table-empty {
+  min-height: 168px;
+  padding: 38px 12px;
+  color: var(--color-muted);
+  text-align: center;
+  display: grid;
+  place-items: center;
+  gap: 9px;
+}
+
+.table-empty strong {
+  color: var(--color-text);
+  font-size: 0.95rem;
+}
+
+.table-empty svg {
+  color: var(--color-faint);
+}
+
+.table-empty--compact {
+  min-height: 126px;
+}
+
+.drawer-shell,
+.modal-shell,
+.operation-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+}
+
+.drawer-scrim,
+.modal-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(15, 23, 42, 0.42);
+}
+
+.drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: min(520px, 100vw);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-panel);
+}
+
+.drawer__header,
+.modal-panel__header {
+  padding: 18px 20px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.drawer__header h2,
+.modal-panel__header h2 {
+  margin-top: 4px;
+  font-size: 1.25rem;
+  word-break: break-word;
+}
+
+.drawer__status-line {
+  gap: 10px;
+  padding: 14px 20px;
+  color: var(--color-muted);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.detail-section,
+.detail-grid {
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.detail-section h3 {
+  font-size: 0.92rem;
+}
+
+.detail-section__heading {
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.detail-item {
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-subtle);
+}
+
+.detail-item__body {
+  min-width: 0;
+  flex: 1;
+}
+
+.detail-item--wide {
+  grid-column: 1 / -1;
+}
+
+.detail-item span,
+.metadata-list dt {
+  display: block;
+  color: var(--color-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.detail-item strong,
+.metadata-list dd {
+  margin: 2px 0 0;
+  display: block;
+  font-size: 0.86rem;
+  word-break: break-word;
+}
+
+.metadata-list {
+  margin: 10px 0 0;
+  display: grid;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-subtle);
+}
+
+.metadata-row {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(118px, 0.42fr) minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  padding: 11px 12px;
+  border-top: 1px solid var(--color-border);
+}
+
+.metadata-row:first-child {
+  border-top: 0;
+}
+
+.metadata-row--stacked {
+  align-items: start;
+}
+
+.metadata-value-line {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+}
+
+.metadata-value {
+  min-width: 0;
+  flex: 1;
+  overflow-wrap: anywhere;
+}
+
+.metadata-value--mono {
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 0.78rem;
+}
+
+.metadata-chip {
+  min-height: 24px;
+  padding: 0 8px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.metadata-chip--success {
+  color: var(--color-good);
+  background: var(--color-good-soft);
+  border-color: #b8e3cd;
+}
+
+.metadata-chip--warning {
+  color: var(--color-warning);
+  background: var(--color-warning-soft);
+  border-color: #f2d18b;
+}
+
+.metadata-chip--neutral {
+  color: var(--color-muted);
+  background: var(--color-neutral-soft);
+  border-color: var(--color-border);
+}
+
+.drawer__footer {
+  position: sticky;
+  bottom: 0;
+  margin-top: auto;
+  padding: 16px 20px;
+  gap: 8px;
+  flex-wrap: wrap;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+}
+
+.drawer__hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.82rem;
+}
+
+.modal-shell {
+  display: grid;
+  place-items: center;
+  padding: 20px;
+}
+
+.modal-panel {
+  position: relative;
+  width: min(760px, 100%);
+  max-height: min(760px, calc(100vh - 40px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-panel);
+}
+
+.modal-panel--wide {
+  width: min(900px, 100%);
+}
+
+.wizard-layout {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 230px minmax(0, 1fr);
+  overflow: auto;
+}
+
+.setup-rail {
+  padding: 16px 14px;
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  border-right: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+}
+
+.setup-rail__header {
+  padding: 0 2px 4px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.setup-rail__header span {
+  color: var(--color-muted);
+  font-size: 0.74rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.setup-rail__header strong {
+  min-height: 24px;
+  padding: 0 8px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  font-size: 0.74rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.setup-step {
+  min-width: 0;
+  min-height: 76px;
+  padding: 11px;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  align-items: start;
+  gap: 9px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+}
+
+.setup-step svg {
+  margin-top: 2px;
+  color: var(--color-muted);
+}
+
+.setup-step.is-complete {
+  border-color: #c7e0f4;
+  background: #fbfdff;
+}
+
+.setup-step.is-complete svg {
+  color: var(--color-accent);
+}
+
+.setup-step__body {
+  min-width: 0;
+}
+
+.setup-step__body span,
+.setup-step__body small {
+  display: block;
+  color: var(--color-muted);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.setup-step__body strong {
+  margin-top: 2px;
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: 0.86rem;
+  line-height: 1.3;
+}
+
+.setup-step__body small {
+  margin-top: 3px;
+  font-weight: 650;
+}
+
+.wizard-body {
+  padding: 18px;
+}
+
+.form-section {
+  margin-bottom: 18px;
+}
+
+.form-section--inline {
+  margin-bottom: 14px;
+}
+
+.form-label {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--color-muted);
+  font-size: 0.8rem;
+  font-weight: 750;
+}
+
+.compound-input {
+  gap: 0;
+  align-items: stretch;
+}
+
+.compound-input input,
+.form-field input,
+.form-field select,
+.combobox__control {
+  min-height: 38px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+}
+
+.compound-input input {
+  flex: 1 1 160px;
+  border-right: 0;
+  border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+  padding: 0 10px;
+}
+
+.compound-input__suffix {
+  min-height: 38px;
+  max-width: 260px;
+  padding: 0 10px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-muted);
+  border: 1px solid var(--color-border);
+  border-left: 0;
+  background: var(--color-surface-subtle);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compound-input .icon-button {
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.form-result {
+  margin-top: 8px;
+  min-height: 30px;
+  padding: 6px 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-subtle);
+}
+
+.form-result span {
+  color: var(--color-muted);
+  font-size: 0.76rem;
+  font-weight: 750;
+}
+
+.form-result strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: 0.86rem;
+}
+
+.toggle-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.toggle-row input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--color-accent);
+}
+
+.advanced-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  padding: 14px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface-subtle);
+}
+
+.form-field input,
+.form-field select {
+  padding: 0 10px;
+}
+
+.advanced-grid__toggle {
+  align-self: end;
+  min-height: 38px;
+}
+
+.modal-panel__footer {
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+}
+
+.modal-panel__footer-meta,
+.modal-panel__footer-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.modal-panel__footer-meta {
+  color: var(--color-muted);
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+.confirm-panel {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 80;
+  width: min(440px, calc(100vw - 32px));
+  padding: 18px;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 14px;
+  transform: translate(-50%, -50%);
+  background: var(--color-surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-panel);
+}
+
+.confirm-panel__icon {
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  color: var(--color-danger);
+  background: var(--color-danger-soft);
+}
+
+.confirm-panel__body {
+  min-width: 0;
+}
+
+.confirm-panel__title {
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.confirm-panel__description {
+  margin-top: 7px;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.confirm-panel__actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.combobox {
+  position: relative;
+  display: block;
+}
+
+.combobox__control {
+  width: 100%;
+  padding: 0 4px 0 10px;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto 32px;
+  align-items: center;
+  gap: 6px;
+}
+
+.combobox__search-icon {
+  color: var(--color-muted);
+}
+
+.combobox__input {
+  height: 36px;
+}
+
+.combobox__clear {
+  min-height: 28px;
+  padding: 0 8px;
+  font-size: 0.75rem;
+  font-weight: 750;
+}
+
+.combobox__toggle {
+  width: 30px;
+  min-height: 30px;
+  display: grid;
+  place-items: center;
+  border: 0;
+}
+
+.combobox__popover {
+  z-index: 70;
+  width: var(--reka-combobox-trigger-width);
+  max-height: min(340px, var(--reka-combobox-content-available-height));
+  overflow: auto;
+  padding: 7px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-popover);
+}
+
+.combobox__state {
+  padding: 18px 10px;
+  color: var(--color-muted);
+  text-align: center;
+  font-size: 0.85rem;
+}
+
+.combobox__group + .combobox__group {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--color-border);
+}
+
+.combobox__group-label {
+  padding: 5px 8px;
+  color: var(--color-muted);
+  font-size: 0.74rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.combobox__option {
+  width: 100%;
+  min-height: 42px;
+  padding: 7px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  outline: none;
+}
+
+.combobox__option[data-highlighted] {
+  background: var(--color-accent-soft);
+}
+
+.combobox__option[data-state='checked'] {
+  color: var(--color-accent);
+}
+
+.combobox__option-name,
+.combobox__option-meta {
+  display: block;
+  text-align: left;
+  overflow-wrap: anywhere;
+}
+
+.combobox__option-name {
+  font-weight: 700;
+}
+
+.combobox__option-meta {
+  margin-top: 1px;
+  font-size: 0.75rem;
+}
+
+.combobox__indicator {
+  color: var(--color-accent);
+}
+
+.operation-overlay {
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(3px);
+}
+
+.operation-overlay__panel {
+  width: min(420px, calc(100vw - 32px));
+  gap: 14px;
+  padding: 18px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-panel);
+}
+
+.operation-overlay__spinner,
+.spin {
+  animation: spin 0.9s linear infinite;
+}
+
+.operation-overlay__title {
+  font-weight: 750;
+}
+
+.operation-overlay__message {
+  margin-top: 3px;
+  color: var(--color-muted);
+  font-size: 0.88rem;
+}
+
+.toast-stack {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 90;
+  width: min(380px, calc(100vw - 36px));
+  display: grid;
+  gap: 10px;
+}
+
+.toast {
+  gap: 10px;
+  align-items: flex-start;
+  padding: 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-popover);
+}
+
+.toast--success .toast__icon {
+  color: var(--color-good);
+}
+
+.toast--error .toast__icon {
+  color: var(--color-danger);
+}
+
+.toast--warning .toast__icon {
+  color: var(--color-warning);
+}
+
+.toast__body {
+  min-width: 0;
+  flex: 1;
+}
+
+.toast__title {
+  font-weight: 750;
+}
+
+.toast__message {
+  margin-top: 2px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 0.86rem;
+}
+
+.toast__dismiss {
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 980px) {
+  .summary-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .wizard-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .setup-rail {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    border-right: 0;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .setup-rail__header {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-header__inner,
+  .app-main,
+  .app-footer__inner {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .page-title-row,
+  .table-toolbar,
+  .app-footer__inner {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .build-metadata {
+    justify-content: flex-start;
+  }
+
+  .summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .table-controls,
+  .table-toolbar__actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .search-field,
+  .select-field,
+  .segmented-control,
+  .primary-button,
+  .secondary-button,
+  .danger-button,
+  .icon-button {
+    width: 100%;
+  }
+
+  .segmented-control {
+    overflow-x: auto;
+  }
+
+  .segmented-control button {
+    flex: 1 0 auto;
+  }
+
+  .compound-input {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .compound-input input,
+  .compound-input__suffix,
+  .compound-input .icon-button {
+    width: 100%;
+    max-width: none;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+  }
+
+  .advanced-grid,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metadata-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+
+  .setup-rail {
+    grid-template-columns: 1fr;
+  }
+
+  .metadata-value-line {
+    align-items: flex-start;
+  }
+
+  .modal-panel__footer,
+  .modal-panel__footer-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .modal-panel__footer-meta {
+    justify-content: space-between;
+  }
+
+  .modal-shell {
+    padding: 0;
+  }
+
+  .modal-panel {
+    width: 100%;
+    height: 100%;
+    max-height: none;
+    border-radius: 0;
+  }
+
+  .toast-stack {
+    right: 12px;
+    bottom: 12px;
+    width: calc(100vw - 24px);
+  }
+}

--- a/src/Acmebot.App/ClientApp/src/styles/app.css
+++ b/src/Acmebot.App/ClientApp/src/styles/app.css
@@ -26,7 +26,6 @@
 
 .brand-lockup,
 .header-status,
-.dashboard-pill,
 .table-toolbar__actions,
 .table-controls,
 .compound-input,
@@ -98,7 +97,19 @@
   width: 100%;
   max-width: var(--content-width);
   margin: 0 auto;
-  padding: 28px 24px 56px;
+  padding: 22px 24px 56px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .app-footer {
@@ -146,14 +157,6 @@
   font-weight: 700;
 }
 
-.page-title-row {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 18px;
-  margin-bottom: 20px;
-}
-
 .eyebrow {
   color: var(--color-accent);
   font-size: 0.78rem;
@@ -166,24 +169,6 @@ h2,
 h3,
 p {
   margin: 0;
-}
-
-h1 {
-  margin-top: 5px;
-  font-size: clamp(1.55rem, 2vw, 2rem);
-  line-height: 1.2;
-}
-
-.dashboard-pill {
-  gap: 7px;
-  min-height: 32px;
-  padding: 0 10px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-surface);
-  color: var(--color-muted);
-  font-size: 0.82rem;
-  font-weight: 600;
 }
 
 .summary-grid {
@@ -479,10 +464,35 @@ button:disabled {
   flex-wrap: wrap;
 }
 
+.zone-group__toggle {
+  min-width: 0;
+  padding: 2px 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 0;
+  background: transparent;
+  color: #124b78;
+  font: inherit;
+  cursor: pointer;
+}
+
+.zone-group__toggle:hover .zone-group__name {
+  text-decoration: underline;
+}
+
 .zone-group__name {
   color: #124b78;
   font-size: 0.86rem;
   font-weight: 800;
+}
+
+.zone-group__summary {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
+  flex-wrap: wrap;
 }
 
 .zone-group__meta {
@@ -491,11 +501,36 @@ button:disabled {
   font-weight: 700;
 }
 
-.certificate-table tbody tr.certificate-row {
-  cursor: pointer;
+.zone-stat {
+  min-height: 22px;
+  padding: 0 7px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 800;
+  white-space: nowrap;
 }
 
-.certificate-table tbody tr.certificate-row:hover,
+.zone-stat--valid {
+  color: var(--color-good);
+  background: var(--color-good-soft);
+  border-color: #b8e3cd;
+}
+
+.zone-stat--warning {
+  color: var(--color-warning);
+  background: var(--color-warning-soft);
+  border-color: #f2d18b;
+}
+
+.zone-stat--expired {
+  color: var(--color-danger);
+  background: var(--color-danger-soft);
+  border-color: #f2b8c5;
+}
+
 .certificate-table tbody tr.certificate-row.is-selected {
   background: #f4f8fb;
 }
@@ -1079,6 +1114,19 @@ button:disabled {
   padding: 0 10px;
 }
 
+.form-field.is-invalid input,
+.form-field.is-invalid select {
+  border-color: #f2b8c5;
+  background: var(--color-danger-soft);
+}
+
+.form-error {
+  margin-top: 7px;
+  color: var(--color-danger);
+  font-weight: 650;
+  line-height: 1.4;
+}
+
 .advanced-grid__toggle {
   align-self: end;
   min-height: 38px;
@@ -1392,7 +1440,6 @@ button:disabled {
     padding-right: 16px;
   }
 
-  .page-title-row,
   .table-toolbar,
   .app-footer__inner {
     align-items: stretch;
@@ -1461,6 +1508,90 @@ button:disabled {
 
   .metadata-value-line {
     align-items: flex-start;
+  }
+
+  .table-wrap {
+    overflow-x: visible;
+  }
+
+  .certificate-table {
+    min-width: 0;
+    display: block;
+  }
+
+  .certificate-table thead {
+    display: none;
+  }
+
+  .certificate-table tbody {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    background: var(--color-surface-subtle);
+  }
+
+  .certificate-table tbody tr,
+  .certificate-table tbody td {
+    display: block;
+  }
+
+  .certificate-table tbody tr.zone-group-row td {
+    padding: 10px;
+    border: 1px solid #c7e0f4;
+    border-radius: var(--radius-sm);
+  }
+
+  .certificate-table tbody tr.certificate-row {
+    display: grid;
+    gap: 10px;
+    padding: 12px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+  }
+
+  .certificate-table tbody tr.certificate-row:hover,
+  .certificate-table tbody tr.certificate-row.is-selected {
+    border-color: var(--color-border-strong);
+    background: var(--color-surface);
+  }
+
+  .certificate-table tbody tr.certificate-row td {
+    padding: 0;
+    display: grid;
+    grid-template-columns: minmax(86px, 0.34fr) minmax(0, 1fr);
+    gap: 10px;
+    border: 0;
+  }
+
+  .certificate-table tbody tr.certificate-row td::before {
+    content: attr(data-label);
+    color: var(--color-muted);
+    font-size: 0.72rem;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  .certificate-table tbody tr.certificate-row .row-actions-cell {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .certificate-table tbody tr.certificate-row .row-actions-cell::before {
+    content: none;
+  }
+
+  .certificate-table .status-badge {
+    white-space: normal;
+  }
+
+  .zone-group {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .zone-group__summary {
+    justify-content: flex-start;
   }
 
   .modal-panel__footer,

--- a/src/Acmebot.App/ClientApp/src/styles/tokens.css
+++ b/src/Acmebot.App/ClientApp/src/styles/tokens.css
@@ -1,0 +1,57 @@
+:root {
+  color-scheme: light;
+  --color-page: #f6f7f9;
+  --color-surface: #ffffff;
+  --color-surface-subtle: #f8fafc;
+  --color-border: #d8dee8;
+  --color-border-strong: #b9c3d0;
+  --color-text: #1d2430;
+  --color-muted: #5e6878;
+  --color-faint: #7e8998;
+  --color-accent: #0f6cbd;
+  --color-accent-hover: #115ea3;
+  --color-accent-soft: #e8f3ff;
+  --color-good: #0f7b4f;
+  --color-good-soft: #e7f6ee;
+  --color-warning: #a65f00;
+  --color-warning-soft: #fff2d6;
+  --color-danger: #c4314b;
+  --color-danger-soft: #fde7ed;
+  --color-neutral-soft: #eef2f6;
+  --shadow-panel: 0 16px 40px rgba(31, 41, 55, 0.14);
+  --shadow-popover: 0 10px 26px rgba(31, 41, 55, 0.16);
+  --radius: 8px;
+  --radius-sm: 6px;
+  --content-width: 1280px;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--color-page);
+  color: var(--color-text);
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  color: inherit;
+}
+
+svg {
+  flex-shrink: 0;
+}

--- a/src/Acmebot.App/ClientApp/src/types/punycode.d.ts
+++ b/src/Acmebot.App/ClientApp/src/types/punycode.d.ts
@@ -1,0 +1,4 @@
+declare module 'punycode/' {
+  export function toASCII(input: string): string;
+  export function toUnicode(input: string): string;
+}

--- a/src/Acmebot.App/ClientApp/src/utils/certificates.ts
+++ b/src/Acmebot.App/ClientApp/src/utils/certificates.ts
@@ -1,0 +1,124 @@
+import { toUnicode } from 'punycode/';
+
+import type { CertificateCategory, CertificateItem, CertificateStatusKind } from '@/api/types';
+
+export interface CertificateStatus {
+  kind: CertificateStatusKind;
+  label: string;
+  remainingDays: number;
+}
+
+export function displayDnsName(value: string): string {
+  try {
+    return toUnicode(value);
+  } catch {
+    return value;
+  }
+}
+
+export function getCertificateCategory(certificate: CertificateItem): CertificateCategory {
+  if (!certificate.isIssuedByAcmebot) {
+    return 'unmanaged';
+  }
+
+  return certificate.isSameEndpoint ? 'managed' : 'other-ca';
+}
+
+export function getCategoryLabel(category: CertificateCategory): string {
+  const labels: Record<CertificateCategory, string> = {
+    managed: 'Managed',
+    'other-ca': 'Other CA',
+    unmanaged: 'Unmanaged'
+  };
+
+  return labels[category];
+}
+
+export function getValidityDays(certificate: CertificateItem): number {
+  const createdOn = new Date(certificate.createdOn).getTime();
+  const expiresOn = new Date(certificate.expiresOn).getTime();
+
+  return Math.round((expiresOn - createdOn) / 86_400_000);
+}
+
+export function isShortLived(certificate: CertificateItem): boolean {
+  return getValidityDays(certificate) <= 10;
+}
+
+export function getRemainingDays(certificate: CertificateItem): number {
+  const expiresOn = new Date(certificate.expiresOn).getTime();
+
+  return Math.ceil((expiresOn - Date.now()) / 86_400_000);
+}
+
+export function getCertificateStatus(certificate: CertificateItem): CertificateStatus {
+  const expiresOn = new Date(certificate.expiresOn).getTime();
+  const diff = expiresOn - Date.now();
+  const remainingDays = Math.round(diff / 86_400_000);
+  const remainingHours = Math.round(diff / 3_600_000);
+
+  if (diff <= 0 || certificate.isExpired) {
+    return { kind: 'expired', label: 'Expired', remainingDays };
+  }
+
+  if (isShortLived(certificate)) {
+    const kind = remainingDays <= 2 ? 'warning' : 'valid';
+
+    if (remainingHours < 24) {
+      return { kind, label: `${remainingHours}h remaining`, remainingDays };
+    }
+
+    const days = Math.floor(diff / 86_400_000);
+    const hours = Math.floor((diff % 86_400_000) / 3_600_000);
+    return { kind, label: `${days}d ${hours}h remaining`, remainingDays };
+  }
+
+  if (remainingDays <= 30) {
+    return { kind: 'warning', label: `${remainingDays}d remaining`, remainingDays };
+  }
+
+  return { kind: 'valid', label: `${remainingDays} days`, remainingDays };
+}
+
+export function formatDate(value?: string | null): string {
+  if (!value) {
+    return '-';
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit'
+  }).format(new Date(value));
+}
+
+export function formatDateTime(value?: string | null): string {
+  if (!value) {
+    return '-';
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(new Date(value));
+}
+
+export function getPrimaryZone(certificate: CertificateItem): string {
+  const firstDnsName = certificate.dnsNames[0];
+
+  if (!firstDnsName) {
+    return '(unknown)';
+  }
+
+  const normalizedName = firstDnsName.startsWith('*.') ? firstDnsName.slice(2) : firstDnsName;
+  const parts = normalizedName.split('.');
+
+  if (parts.length <= 2) {
+    return displayDnsName(normalizedName);
+  }
+
+  return displayDnsName(parts.slice(-2).join('.'));
+}

--- a/src/Acmebot.App/ClientApp/src/utils/certificates.ts
+++ b/src/Acmebot.App/ClientApp/src/utils/certificates.ts
@@ -1,6 +1,6 @@
-import { toUnicode } from 'punycode/';
+import { toASCII, toUnicode } from 'punycode/';
 
-import type { CertificateCategory, CertificateItem, CertificateStatusKind } from '@/api/types';
+import type { CertificateCategory, CertificateItem, CertificateStatusKind, DnsZoneGroup } from '@/api/types';
 
 export interface CertificateStatus {
   kind: CertificateStatusKind;
@@ -106,14 +106,66 @@ export function formatDateTime(value?: string | null): string {
   }).format(new Date(value));
 }
 
-export function getPrimaryZone(certificate: CertificateItem): string {
+function normalizeDnsName(value: string): string {
+  const withoutWildcard = value.startsWith('*.') ? value.slice(2) : value;
+
+  try {
+    return toASCII(withoutWildcard.trim().replace(/\.+$/, '')).toLowerCase();
+  } catch {
+    return withoutWildcard.trim().replace(/\.+$/, '').toLowerCase();
+  }
+}
+
+function findMatchingDnsZone(certificate: CertificateItem, dnsZoneGroups: DnsZoneGroup[]): string | null {
+  const providerZoneNames = new Set<string>();
+  const allZoneNames = new Set<string>();
+
+  for (const group of dnsZoneGroups) {
+    for (const zone of group.dnsZones ?? []) {
+      const zoneName = normalizeDnsName(zone.name);
+
+      if (!zoneName) {
+        continue;
+      }
+
+      allZoneNames.add(zoneName);
+
+      if (certificate.dnsProviderName && group.dnsProviderName === certificate.dnsProviderName) {
+        providerZoneNames.add(zoneName);
+      }
+    }
+  }
+
+  const candidateZoneNames = (providerZoneNames.size > 0 ? Array.from(providerZoneNames) : Array.from(allZoneNames)).toSorted(
+    (left, right) => left.length - right.length || left.localeCompare(right)
+  );
+
+  for (const dnsName of certificate.dnsNames) {
+    const normalizedDnsName = normalizeDnsName(dnsName);
+    const matchingZoneName = candidateZoneNames.find((zoneName) => normalizedDnsName === zoneName || normalizedDnsName.endsWith(`.${zoneName}`));
+
+    if (matchingZoneName) {
+      return matchingZoneName;
+    }
+  }
+
+  return null;
+}
+
+export function getPrimaryZone(certificate: CertificateItem, dnsZoneGroups: DnsZoneGroup[] = []): string {
+  const matchingDnsZone = findMatchingDnsZone(certificate, dnsZoneGroups);
+
+  if (matchingDnsZone) {
+    return displayDnsName(matchingDnsZone);
+  }
+
   const firstDnsName = certificate.dnsNames[0];
 
   if (!firstDnsName) {
     return '(unknown)';
   }
 
-  const normalizedName = firstDnsName.startsWith('*.') ? firstDnsName.slice(2) : firstDnsName;
+  const normalizedName = normalizeDnsName(firstDnsName);
   const parts = normalizedName.split('.');
 
   if (parts.length <= 2) {

--- a/src/Acmebot.App/ClientApp/src/vite-env.d.ts
+++ b/src/Acmebot.App/ClientApp/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+declare const __ACMEBOT_DASHBOARD_VERSION__: string;
+declare const __ACMEBOT_DASHBOARD_COMMIT_HASH__: string;

--- a/src/Acmebot.App/ClientApp/tsconfig.json
+++ b/src/Acmebot.App/ClientApp/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "types": ["vite/client"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/src/Acmebot.App/ClientApp/tsconfig.node.json
+++ b/src/Acmebot.App/ClientApp/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/src/Acmebot.App/ClientApp/vite.config.ts
+++ b/src/Acmebot.App/ClientApp/vite.config.ts
@@ -1,0 +1,57 @@
+import { fileURLToPath, URL } from 'node:url';
+
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vite';
+
+const apiOrigin = process.env.ACMEBOT_API_ORIGIN;
+const buildSourceMap = process.env.ACMEBOT_BUILD_SOURCEMAP === 'true';
+const dashboardVersion = normalizeVersion(process.env.ACMEBOT_DASHBOARD_VERSION);
+const dashboardCommitHash = normalizeCommitHash(process.env.ACMEBOT_DASHBOARD_COMMIT ?? process.env.GITHUB_SHA);
+
+function normalizeVersion(value: string | undefined): string {
+  const version = value?.trim();
+
+  if (!version) {
+    return 'dev';
+  }
+
+  if (/^v?\d/i.test(version)) {
+    return version.startsWith('v') || version.startsWith('V') ? `v${version.slice(1)}` : `v${version}`;
+  }
+
+  return version;
+}
+
+function normalizeCommitHash(value: string | undefined): string {
+  return value?.trim() || 'local';
+}
+
+export default defineConfig({
+  base: '/dashboard-vnext/',
+  plugins: [vue()],
+  define: {
+    __ACMEBOT_DASHBOARD_VERSION__: JSON.stringify(dashboardVersion),
+    __ACMEBOT_DASHBOARD_COMMIT_HASH__: JSON.stringify(dashboardCommitHash)
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
+  build: {
+    outDir: '../wwwroot/dashboard-vnext',
+    emptyOutDir: true,
+    sourcemap: buildSourceMap
+  },
+  server: {
+    port: 5173,
+    proxy: apiOrigin
+      ? {
+          '/api': {
+            target: apiOrigin,
+            changeOrigin: true
+          }
+        }
+      : undefined
+  }
+});


### PR DESCRIPTION
Add a new Vite + Vue 3 + TypeScript dashboard under src/Acmebot.App/ClientApp (source, config, README, and npm metadata). Update GitHub Actions build and publish workflows to install Node.js, enable npm caching, run npm ci and npm run build during CI, and embed dashboard build metadata on publish. Update .gitignore to ignore generated wwwroot/dashboard-vnext so built static assets can be included in the Function app deployment.

Close #1014 
Close #577
Close #565 