### PR TITLE
Use replay-safe logger in Orchestrator for certificate renewal process

### DIFF
--- a/src/Acmebot.App/Functions/Orchestration/RenewCertificates.cs
+++ b/src/Acmebot.App/Functions/Orchestration/RenewCertificates.cs
@@ -10,28 +10,30 @@ public partial class RenewCertificates(ILogger<RenewCertificates> logger)
     [Function($"{nameof(RenewCertificates)}_{nameof(Orchestrator)}")]
     public async Task Orchestrator([OrchestrationTrigger] TaskOrchestrationContext context)
     {
+        var replaySafeLogger = context.CreateReplaySafeLogger<RenewCertificates>();
+
         // 更新が必要な証明書の一覧を取得する
         var certificates = await context.CallGetRenewalCertificatesAsync(null!);
 
         // 更新対象となる証明書がない場合は終わる
         if (certificates.Count == 0)
         {
-            LogCertificatesNotFound(logger);
+            LogCertificatesNotFound(replaySafeLogger);
 
             return;
         }
 
         // スロットリング対策として 600 秒以内でジッターを追加する
-        var jitter = (uint)context.NewGuid().GetHashCode() % 600;
+        var jitter = BitConverter.ToUInt32(context.NewGuid().ToByteArray(), 0) % 600;
 
-        LogAddingRandomDelay(logger, jitter);
+        LogAddingRandomDelay(replaySafeLogger, jitter);
 
         await context.CreateTimer(context.CurrentUtcDateTime.AddSeconds(jitter), CancellationToken.None);
 
         // 証明書の更新を行う
         foreach (var certificate in certificates)
         {
-            LogRenewingCertificate(logger, certificate.Name, certificate.ExpiresOn);
+            LogRenewingCertificate(replaySafeLogger, certificate.Name, certificate.ExpiresOn);
 
             try
             {
@@ -43,7 +45,7 @@ public partial class RenewCertificates(ILogger<RenewCertificates> logger)
             catch (Exception ex)
             {
                 // 失敗した場合はログに詳細を書き出して続きを実行する
-                LogFailedSubOrchestration(logger, ex, certificate.Name, string.Join(",", certificate.DnsNames));
+                LogFailedSubOrchestration(replaySafeLogger, ex, certificate.Name, string.Join(",", certificate.DnsNames));
             }
         }
     }


### PR DESCRIPTION
This pull request makes improvements to the logging approach in the `RenewCertificates` orchestration function to ensure logs are safe for replay scenarios in Durable Functions. The main change is the replacement of the standard logger with a replay-safe logger throughout the orchestration method, along with a minor update to how jitter is calculated.

**Logging improvements:**

* Replaced usage of the standard `logger` with a replay-safe logger (`replaySafeLogger`) created via `context.CreateReplaySafeLogger<RenewCertificates>()` for all logging calls within the `Orchestrator` method, ensuring logs are not duplicated during orchestrator replays. [[1]](diffhunk://#diff-2ff43b6472ce24fca8b7474d27af9f1fb3148028440baf2a674e54619cc92cebR13-R36) [[2]](diffhunk://#diff-2ff43b6472ce24fca8b7474d27af9f1fb3148028440baf2a674e54619cc92cebL46-R48)

**Jitter calculation:**

* Changed the jitter calculation to use `BitConverter.ToUInt32(context.NewGuid().ToByteArray(), 0) % 600` instead of relying on `GetHashCode()`, providing a more robust and less collision-prone random delay.