### PR TITLE
Refactor DNS challenge handling to ensure cleanup occurs in a finally block

### DIFF
--- a/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
@@ -35,22 +35,27 @@ public partial class CertificateIssuanceOrchestrator
                 // ACME DNS-01 Challenge を実行
                 var (challengeResults, propagationSeconds) = await context.CallDns01AuthorizationAsync((certificatePolicyItem.DnsProviderName, certificatePolicyItem.DnsAlias, orderDetails.Payload.Authorizations));
 
-                // DNS Provider が指定した分だけ後続の処理を遅延させる
-                LogDnsChallengePropagationDelay(logger, certificatePolicyItem.CertificateName, propagationSeconds);
+                try
+                {
+                    // DNS Provider が指定した分だけ後続の処理を遅延させる
+                    LogDnsChallengePropagationDelay(logger, certificatePolicyItem.CertificateName, propagationSeconds);
 
-                await context.CreateTimer(context.CurrentUtcDateTime.AddSeconds(propagationSeconds), CancellationToken.None);
+                    await context.CreateTimer(context.CurrentUtcDateTime.AddSeconds(propagationSeconds), CancellationToken.None);
 
-                // 正しく追加した DNS TXT レコードが引けるか確認
-                await context.CallCheckDnsChallengeAsync(challengeResults, TaskOptions.FromRetryPolicy(_retryPolicy));
+                    // 正しく追加した DNS TXT レコードが引けるか確認
+                    await context.CallCheckDnsChallengeAsync(challengeResults, TaskOptions.FromRetryPolicy(_retryPolicy));
 
-                // ACME Answer Challenge を実行
-                await context.CallAnswerChallengesAsync(challengeResults);
+                    // ACME Answer Challenge を実行
+                    await context.CallAnswerChallengesAsync(challengeResults);
 
-                // ACME Order のステータスが ready になるまで 60 秒待機
-                await context.CallCheckIsReadyAsync((orderDetails, challengeResults), TaskOptions.FromRetryPolicy(_retryPolicy));
-
-                // 作成した DNS レコードを削除
-                await context.CallCleanupDnsChallengeAsync((certificatePolicyItem.DnsProviderName, challengeResults));
+                    // ACME Order のステータスが ready になるまで 60 秒待機
+                    await context.CallCheckIsReadyAsync((orderDetails, challengeResults), TaskOptions.FromRetryPolicy(_retryPolicy));
+                }
+                finally
+                {
+                    // 作成した DNS レコードを削除
+                    await context.CallCleanupDnsChallengeAsync((certificatePolicyItem.DnsProviderName ?? "", challengeResults));
+                }
             }
 
             // Key Vault で CSR を作成し Finalize を実行


### PR DESCRIPTION
This pull request introduces a small but important change to the certificate issuance orchestration logic. The main improvement is ensuring that DNS challenge cleanup always occurs, even if an error happens during the DNS challenge or readiness checks.

**Reliability improvements for DNS challenge cleanup:**

* Wrapped the DNS challenge and readiness check logic in a `try` block, and moved the DNS record cleanup to a `finally` block in the `IssueCertificate` orchestration. This guarantees that temporary DNS records are always cleaned up, even if an exception is thrown during the process. [[1]](diffhunk://#diff-35b98ac32d04b0cdc95744f3e4d99860b77f9161a53d148acb0706cdec814281R38-R39) [[2]](diffhunk://#diff-35b98ac32d04b0cdc95744f3e4d99860b77f9161a53d148acb0706cdec814281L51-R58)
* Updated the DNS provider name parameter for cleanup to default to an empty string if it is `null`, improving robustness.