### PR TITLE
Add support for key-value tags in certificate and policy models

### DIFF
--- a/src/Acmebot.App/ClientApp/src/api/mockData.ts
+++ b/src/Acmebot.App/ClientApp/src/api/mockData.ts
@@ -26,7 +26,8 @@ let mockCertificates: CertificateItem[] = [
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
-    dnsAlias: null
+    dnsAlias: null,
+    tags: { Customer: 'Contoso', Stage: 'production' }
   },
   {
     id: 'https://mock.vault/certificates/apex-example-co-jp',
@@ -43,7 +44,8 @@ let mockCertificates: CertificateItem[] = [
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
-    dnsAlias: null
+    dnsAlias: null,
+    tags: { Stage: 'staging' }
   },
   {
     id: 'https://mock.vault/certificates/app-www-example-co-jp',
@@ -196,7 +198,8 @@ export async function mockIssueCertificate(policy: CertificatePolicyItem): Promi
       isIssuedByAcmebot: true,
       isSameEndpoint: true,
       acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
-      dnsAlias: policy.dnsAlias
+      dnsAlias: policy.dnsAlias,
+      tags: policy.tags ? { ...policy.tags } : {}
     }
   ];
 }

--- a/src/Acmebot.App/ClientApp/src/api/types.ts
+++ b/src/Acmebot.App/ClientApp/src/api/types.ts
@@ -20,6 +20,7 @@ export interface CertificateItem {
   isSameEndpoint: boolean;
   acmeEndpoint?: string | null;
   dnsAlias?: string | null;
+  tags?: Record<string, string> | null;
 }
 
 export interface DnsZoneItem {
@@ -44,6 +45,7 @@ export interface CertificatePolicyItem {
   keyCurveName?: KeyCurveName;
   reuseKey?: boolean;
   dnsAlias?: string;
+  tags?: Record<string, string>;
 }
 
 export interface ProblemDetails {

--- a/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue';
-import { CirclePlus, KeyRound, Plus, ShieldPlus, Trash2, X } from 'lucide-vue-next';
+import { CirclePlus, KeyRound, Plus, ShieldPlus, Tag, Trash2, X } from 'lucide-vue-next';
 import { toASCII } from 'punycode/';
 
 import type { CertificatePolicyItem, DnsZoneGroup, KeyCurveName, KeyType, SelectableDnsZone } from '@/api/types';
@@ -26,10 +26,22 @@ interface ValidationOutcome {
   message: string;
 }
 
+interface CertificateTagInput {
+  id: number;
+  key: string;
+  value: string;
+}
+
+interface TagValidationOutcome {
+  tags: Record<string, string>;
+  message: string;
+}
+
 const selectedZone = ref<SelectableDnsZone | null>(null);
 const validationErrors = reactive({
   dnsName: ''
 });
+let certificateTagId = 0;
 
 const validKeySizes = [2048, 3072, 4096];
 const validKeyCurves: KeyCurveName[] = ['P-256', 'P-384', 'P-521', 'P-256K'];
@@ -44,19 +56,22 @@ const form = reactive({
   keySize: 2048,
   keyCurveName: 'P-256' as KeyCurveName,
   reuseKey: false,
-  dnsAlias: ''
+  dnsAlias: '',
+  tags: [] as CertificateTagInput[]
 });
 
 const certificateNameError = computed(() => (form.useAdvancedOptions ? validateCertificateName(form.certificateName) : ''));
 const dnsAliasValidation = computed(() => (form.useAdvancedOptions ? validateOptionalDnsAlias(form.dnsAlias) : { value: '', message: '' }));
 const dnsAliasError = computed(() => dnsAliasValidation.value.message);
 const keyOptionError = computed(() => validateKeyOptions());
+const tagValidation = computed(() => (form.useAdvancedOptions ? validateTags(form.tags) : { tags: {}, message: '' }));
+const tagError = computed(() => tagValidation.value.message);
 const submitValidationMessage = computed(() => {
   if (form.dnsNames.length === 0) {
     return 'Add at least one DNS name.';
   }
 
-  return certificateNameError.value || dnsAliasError.value || keyOptionError.value;
+  return certificateNameError.value || dnsAliasError.value || keyOptionError.value || tagError.value;
 });
 const canSubmit = computed(() => !props.sending && submitValidationMessage.value === '');
 const fullDnsName = computed(() => (selectedZone.value ? validateRecordDnsName(form.recordName, selectedZone.value).value || null : null));
@@ -86,6 +101,8 @@ const dnsNamesSummary = computed(() => {
   return `${firstDnsName} +${form.dnsNames.length - 1}`;
 });
 const dnsNameCountLabel = computed(() => `${form.dnsNames.length} ${form.dnsNames.length === 1 ? 'DNS name' : 'DNS names'}`);
+const tagCount = computed(() => Object.keys(tagValidation.value.tags).length);
+const tagCountLabel = computed(() => (tagCount.value === 0 ? 'No tags' : `${tagCount.value} ${tagCount.value === 1 ? 'tag' : 'tags'}`));
 
 watch(
   () => props.open,
@@ -107,6 +124,7 @@ watch(
       form.keyCurveName = 'P-256';
       form.reuseKey = false;
       form.dnsAlias = '';
+      form.tags = [];
     }
   }
 );
@@ -124,6 +142,11 @@ function resetForm(): void {
   form.keyCurveName = 'P-256';
   form.reuseKey = false;
   form.dnsAlias = '';
+  form.tags = [];
+}
+
+function createTagInput(): CertificateTagInput {
+  return { id: ++certificateTagId, key: '', value: '' };
 }
 
 function normalizeRecordName(recordName: string): string {
@@ -259,6 +282,51 @@ function validateKeyOptions(): string {
   return '';
 }
 
+function validateTags(items: CertificateTagInput[]): TagValidationOutcome {
+  const tags: Record<string, string> = {};
+  const seenKeys = new Set<string>();
+
+  for (const item of items) {
+    const key = item.key.trim();
+    const value = item.value.trim();
+
+    if (!key && !value) {
+      continue;
+    }
+
+    if (!key) {
+      return { tags: {}, message: 'Tag name is required.' };
+    }
+
+    if (key.toLowerCase() === 'acmebot') {
+      return { tags: {}, message: 'The Acmebot tag is managed by Acmebot.' };
+    }
+
+    const normalizedKey = key.toLowerCase();
+
+    if (seenKeys.has(normalizedKey)) {
+      return { tags: {}, message: 'Tag names must be unique.' };
+    }
+
+    seenKeys.add(normalizedKey);
+    tags[key] = value;
+  }
+
+  return { tags, message: '' };
+}
+
+function addTag(): void {
+  if (form.tags.some((tag) => !tag.key.trim() && !tag.value.trim())) {
+    return;
+  }
+
+  form.tags.push(createTagInput());
+}
+
+function removeTag(id: number): void {
+  form.tags = form.tags.filter((tag) => tag.id !== id);
+}
+
 function clearDnsNameError(): void {
   validationErrors.dnsName = '';
 }
@@ -330,6 +398,10 @@ function submit(): void {
     policy.keyCurveName = form.keyCurveName;
   }
 
+  if (form.useAdvancedOptions && tagCount.value > 0) {
+    policy.tags = tagValidation.value.tags;
+  }
+
   emit('submit', policy);
 }
 </script>
@@ -377,6 +449,14 @@ function submit(): void {
                 <span>Key</span>
                 <strong>{{ keySummary }}</strong>
                 <small>{{ form.useAdvancedOptions ? 'Custom settings' : 'Default settings' }}</small>
+              </div>
+            </div>
+            <div class="setup-step" :class="{ 'is-complete': tagCount > 0 }">
+              <Tag :size="17" aria-hidden="true" />
+              <div class="setup-step__body">
+                <span>Tags</span>
+                <strong>{{ tagCountLabel }}</strong>
+                <small>Key Vault</small>
               </div>
             </div>
           </aside>
@@ -473,6 +553,29 @@ function submit(): void {
                 <input v-model="form.reuseKey" type="checkbox" />
                 <span>Reuse key on renewal</span>
               </label>
+
+              <div class="tag-editor advanced-grid__wide">
+                <div class="tag-editor__header">
+                  <span class="form-label">Key Vault Tags</span>
+                  <button class="secondary-button" type="button" @click="addTag">
+                    <Plus :size="16" aria-hidden="true" />
+                    <span>Add tag</span>
+                  </button>
+                </div>
+                <div v-if="form.tags.length === 0" class="tag-editor__empty">No tags</div>
+                <div v-else class="tag-editor__rows">
+                  <div v-for="tagItem in form.tags" :key="tagItem.id" class="tag-row">
+                    <label class="visually-hidden" :for="`tag-key-${tagItem.id}`">Tag name</label>
+                    <input :id="`tag-key-${tagItem.id}`" v-model="tagItem.key" type="text" placeholder="Name" :aria-invalid="tagError ? 'true' : 'false'" />
+                    <label class="visually-hidden" :for="`tag-value-${tagItem.id}`">Tag value</label>
+                    <input :id="`tag-value-${tagItem.id}`" v-model="tagItem.value" type="text" placeholder="Value" :aria-invalid="tagError ? 'true' : 'false'" />
+                    <button class="icon-only-button" type="button" title="Remove tag" @click="removeTag(tagItem.id)">
+                      <Trash2 :size="15" aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
+                <span v-if="tagError" class="form-error">{{ tagError }}</span>
+              </div>
             </div>
           </div>
         </div>
@@ -481,6 +584,7 @@ function submit(): void {
           <div class="modal-panel__footer-meta">
             <span>{{ dnsNameCountLabel }}</span>
             <span>{{ keySummary }}</span>
+            <span>{{ tagCountLabel }}</span>
           </div>
           <div class="modal-panel__footer-actions">
             <button class="secondary-button" type="button" :disabled="sending" @click="emit('close')">Cancel</button>

--- a/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
+++ b/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { AlertTriangle, CalendarDays, Copy, Fingerprint, KeyRound, RotateCw, ShieldCheck, Trash2, X } from 'lucide-vue-next';
 
 import type { CertificateItem } from '@/api/types';
@@ -18,6 +19,9 @@ const emit = defineEmits<{
   revoke: [certificate: CertificateItem];
   copy: [label: string, value: string];
 }>();
+
+const customTags = computed(() => Object.entries(props.certificate?.tags ?? {}).toSorted(([left], [right]) => left.localeCompare(right)));
+const customTagsCopyText = computed(() => customTags.value.map(([key, value]) => `${key}: ${value}`).join('\n'));
 </script>
 
 <template>
@@ -127,6 +131,23 @@ const emit = defineEmits<{
               <dt>ACME endpoint</dt>
               <dd class="metadata-value-line">
                 <span class="metadata-value metadata-value--mono">{{ certificate.acmeEndpoint }}</span>
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <section v-if="customTags.length > 0" class="detail-section">
+          <div class="detail-section__heading">
+            <h3>Tags</h3>
+            <button class="copy-button" type="button" title="Copy tags" @click="emit('copy', 'Tags', customTagsCopyText)">
+              <Copy :size="15" aria-hidden="true" />
+            </button>
+          </div>
+          <dl class="metadata-list">
+            <div v-for="[key, value] in customTags" :key="key" class="metadata-row metadata-row--stacked">
+              <dt>{{ key }}</dt>
+              <dd class="metadata-value-line">
+                <span class="metadata-value">{{ value || '-' }}</span>
               </dd>
             </div>
           </dl>

--- a/src/Acmebot.App/ClientApp/src/styles/app.css
+++ b/src/Acmebot.App/ClientApp/src/styles/app.css
@@ -354,6 +354,7 @@ button:disabled {
 .select-field select,
 .form-field input,
 .form-field select,
+.tag-row input,
 .compound-input input,
 .combobox__input {
   width: 100%;
@@ -1028,6 +1029,7 @@ button:disabled {
 .compound-input input,
 .form-field input,
 .form-field select,
+.tag-row input,
 .combobox__control {
   min-height: 38px;
   border: 1px solid var(--color-border);
@@ -1110,7 +1112,8 @@ button:disabled {
 }
 
 .form-field input,
-.form-field select {
+.form-field select,
+.tag-row input {
   padding: 0 10px;
 }
 
@@ -1130,6 +1133,55 @@ button:disabled {
 .advanced-grid__toggle {
   align-self: end;
   min-height: 38px;
+}
+
+.advanced-grid__wide {
+  grid-column: 1 / -1;
+}
+
+.tag-editor {
+  min-width: 0;
+}
+
+.tag-editor__header {
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.tag-editor__header .form-label {
+  margin-bottom: 0;
+}
+
+.tag-editor__rows {
+  display: grid;
+  gap: 8px;
+}
+
+.tag-editor__empty {
+  min-height: 38px;
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
+  color: var(--color-muted);
+  border: 1px dashed var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  font-size: 0.84rem;
+  font-weight: 650;
+}
+
+.tag-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.42fr) minmax(0, 1fr) 34px;
+  gap: 8px;
+  align-items: center;
+}
+
+.tag-row input {
+  min-width: 0;
 }
 
 .modal-panel__footer {
@@ -1421,7 +1473,7 @@ button:disabled {
   }
 
   .setup-rail {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 8px;
     border-right: 0;
     border-bottom: 1px solid var(--color-border);

--- a/src/Acmebot.App/Extensions/CertificateExtensions.cs
+++ b/src/Acmebot.App/Extensions/CertificateExtensions.cs
@@ -47,7 +47,8 @@ internal static class CertificateExtensions
             ReuseKey = certificate.Policy.ReuseKey,
             IsExpired = DateTimeOffset.UtcNow > certificate.Properties.ExpiresOn.GetValueOrDefault(DateTimeOffset.MaxValue),
             AcmeEndpoint = !string.IsNullOrEmpty(metadata?.Endpoint) ? NormalizeEndpoint(metadata.Endpoint) : "",
-            DnsAlias = metadata?.DnsAlias ?? ""
+            DnsAlias = metadata?.DnsAlias ?? "",
+            Tags = certificate.Properties.Tags.GetCustomCertificateTags()
         };
     }
 
@@ -66,12 +67,28 @@ internal static class CertificateExtensions
             KeyCurveName = certificate.Policy.KeyCurveName?.ToString(),
             ReuseKey = certificate.Policy.ReuseKey,
             DnsAlias = metadata?.DnsAlias ?? "",
-            CertificateId = metadata?.CertificateId
+            CertificateId = metadata?.CertificateId,
+            Tags = certificate.Properties.Tags.GetCustomCertificateTags()
         };
     }
 
-    public static IDictionary<string, string> ToCertificateMetadata(this CertificatePolicyItem certificatePolicyItem, Uri endpoint)
+    public static IDictionary<string, string> ToCertificateTags(this CertificatePolicyItem certificatePolicyItem, Uri endpoint)
     {
+        var tags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (certificatePolicyItem.Tags is not null)
+        {
+            foreach (var tag in certificatePolicyItem.Tags)
+            {
+                if (string.IsNullOrWhiteSpace(tag.Key) || string.Equals(tag.Key.Trim(), AcmebotTagKey, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                tags[tag.Key.Trim()] = tag.Value?.Trim() ?? "";
+            }
+        }
+
         var metadata = new AcmebotCertificateMetadata
         {
             Endpoint = endpoint.Host,
@@ -79,10 +96,9 @@ internal static class CertificateExtensions
             DnsAlias = string.IsNullOrEmpty(certificatePolicyItem.DnsAlias) ? null : certificatePolicyItem.DnsAlias
         };
 
-        return new Dictionary<string, string>
-        {
-            { AcmebotTagKey, JsonSerializer.Serialize(metadata, s_jsonOptions) }
-        };
+        tags[AcmebotTagKey] = JsonSerializer.Serialize(metadata, s_jsonOptions);
+
+        return tags;
     }
 
     public static void SetCertificateId(this IDictionary<string, string> tags, string certificateId)
@@ -150,6 +166,17 @@ internal static class CertificateExtensions
         }
 
         return null;
+    }
+
+    private static Dictionary<string, string> GetCustomCertificateTags(this IDictionary<string, string> tags)
+    {
+        string[] internalTagKeys = tags.Keys.Contains(AcmebotTagKey, StringComparer.OrdinalIgnoreCase)
+            ? [AcmebotTagKey]
+            : [AcmebotTagKey, LegacyIssuerKey, LegacyEndpointKey, LegacyDnsProviderKey, LegacyDnsAliasKey];
+
+        return tags
+            .Where(tag => !internalTagKeys.Contains(tag.Key, StringComparer.OrdinalIgnoreCase))
+            .ToDictionary(tag => tag.Key, tag => tag.Value);
     }
 
     private static string NormalizeEndpoint(string endpoint) => Uri.TryCreate(endpoint, UriKind.Absolute, out var legacyEndpoint) ? legacyEndpoint.Host : endpoint;

--- a/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
@@ -108,9 +108,9 @@ public partial class AcmeOrderActivities(
         try
         {
             var certificatePolicy = certificatePolicyItem.ToCertificatePolicy();
-            var metadata = certificatePolicyItem.ToCertificateMetadata(_options.Endpoint);
+            var tags = certificatePolicyItem.ToCertificateTags(_options.Endpoint);
 
-            var certificateOperation = await certificateClient.StartCreateCertificateAsync(certificatePolicyItem.CertificateName, certificatePolicy, tags: metadata);
+            var certificateOperation = await certificateClient.StartCreateCertificateAsync(certificatePolicyItem.CertificateName, certificatePolicy, tags: tags);
 
             csr = certificateOperation.Properties.Csr;
         }

--- a/src/Acmebot.App/Models/CertificateItem.cs
+++ b/src/Acmebot.App/Models/CertificateItem.cs
@@ -51,4 +51,7 @@ public class CertificateItem
 
     [JsonProperty("dnsAlias")]
     public string? DnsAlias { get; set; }
+
+    [JsonProperty("tags")]
+    public IReadOnlyDictionary<string, string>? Tags { get; set; }
 }

--- a/src/Acmebot.App/Models/CertificatePolicyItem.cs
+++ b/src/Acmebot.App/Models/CertificatePolicyItem.cs
@@ -33,6 +33,9 @@ public class CertificatePolicyItem : IValidatableObject
     [JsonProperty("dnsAlias")]
     public string? DnsAlias { get; set; }
 
+    [JsonProperty("tags")]
+    public IDictionary<string, string>? Tags { get; set; }
+
     [JsonProperty("certificateId")]
     public string? CertificateId { get; set; }
 
@@ -57,6 +60,32 @@ public class CertificatePolicyItem : IValidatableObject
             if (KeyCurveName is not ("P-256" or "P-384" or "P-521" or "P-256K"))
             {
                 yield return new ValidationResult($"The {nameof(KeyCurveName)} must be P-256, P-384, P-521, or P-256K when {nameof(KeyType)} is EC.", [nameof(KeyCurveName)]);
+            }
+        }
+
+        if (Tags is not null)
+        {
+            var tagNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var tag in Tags)
+            {
+                if (string.IsNullOrWhiteSpace(tag.Key))
+                {
+                    yield return new ValidationResult($"The {nameof(Tags)} contains an empty tag name.", [nameof(Tags)]);
+                    continue;
+                }
+
+                var tagName = tag.Key.Trim();
+
+                if (string.Equals(tagName, "Acmebot", StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return new ValidationResult($"The Acmebot tag is reserved for internal metadata.", [nameof(Tags)]);
+                }
+
+                if (!tagNames.Add(tagName))
+                {
+                    yield return new ValidationResult($"The {nameof(Tags)} contains duplicate tag names.", [nameof(Tags)]);
+                }
             }
         }
     }


### PR DESCRIPTION
This pull request introduces support for custom Key Vault tags on certificates throughout the Acmebot application. Users can now add, validate, and view custom tags when creating or viewing certificates, and these tags are properly handled in both the frontend and backend. The UI has been updated to provide a tag editor in the certificate creation dialog and to display tags in the certificate details drawer, with appropriate validation and styling.

**Key Vault Tag Support**

* Added a tag editor to the `AddCertificateDialog.vue` component, allowing users to add, validate (including uniqueness and reserved keys), and remove custom tags when creating a certificate. Tags are included in the certificate creation policy if provided. [[1]](diffhunk://#diff-74e5b0ab07db2f541474ba8ddccd8d416f1aed6ff35c1a25b4d75940b3aff394R29-R44) [[2]](diffhunk://#diff-74e5b0ab07db2f541474ba8ddccd8d416f1aed6ff35c1a25b4d75940b3aff394L47-R74) [[3]](diffhunk://#diff-74e5b0ab07db2f541474ba8ddccd8d416f1aed6ff35c1a25b4d75940b3aff394R285-R329) [[4]](diffhunk://#diff-74e5b0ab07db2f541474ba8ddccd8d416f1aed6ff35c1a25b4d75940b3aff394R401-R404) [[5]](diffhunk://#diff-74e5b0ab07db2f541474ba8ddccd8d416f1aed6ff35c1a25b4d75940b3aff394R556-R578) [[6]](diffhunk://#diff-74e5b0ab07db2f541474ba8ddccd8d416f1aed6ff35c1a25b4d75940b3aff394R587)
* Updated the `CertificateItem` and `CertificatePolicyItem` TypeScript interfaces to support an optional `tags` property, and updated mock data and mock API to include and handle tags. [[1]](diffhunk://#diff-1dede859c5c0d96d41465cb9900058f86ebe3e95a60daa1e05e51ad7c642a254R23) [[2]](diffhunk://#diff-1dede859c5c0d96d41465cb9900058f86ebe3e95a60daa1e05e51ad7c642a254R48) [[3]](diffhunk://#diff-cdea3bb27af2a238de5655e0dc14553ed8b16d5d150abf944a09711d06256d52L29-R30) [[4]](diffhunk://#diff-cdea3bb27af2a238de5655e0dc14553ed8b16d5d150abf944a09711d06256d52L46-R48) [[5]](diffhunk://#diff-cdea3bb27af2a238de5655e0dc14553ed8b16d5d150abf944a09711d06256d52L199-R202)

**Certificate Details Display**

* Enhanced the `DetailsDrawer.vue` component to display custom tags for a certificate, including a "Copy tags" button. Tags are sorted and shown in a dedicated section if present. [[1]](diffhunk://#diff-5119876c339ea28b1c4454991fa0e4d029e5f829f61616dd43e0afc61d8f9784R2) [[2]](diffhunk://#diff-5119876c339ea28b1c4454991fa0e4d029e5f829f61616dd43e0afc61d8f9784R22-R24) [[3]](diffhunk://#diff-5119876c339ea28b1c4454991fa0e4d029e5f829f61616dd43e0afc61d8f9784R139-R155)

**Backend Tag Handling**

* Updated backend C# extension methods to extract, filter, and serialize custom tags correctly, ensuring that only user-defined tags (excluding internal Acmebot metadata) are included in certificate responses and when creating/updating certificates. [[1]](diffhunk://#diff-7d078dcb7c00987ef2311f1bd66076a5dd4290d58d44d76694cb218a203212fbL50-R51) [[2]](diffhunk://#diff-7d078dcb7c00987ef2311f1bd66076a5dd4290d58d44d76694cb218a203212fbL69-R101) [[3]](diffhunk://#diff-7d078dcb7c00987ef2311f1bd66076a5dd4290d58d44d76694cb218a203212fbR171-R181)

**UI/UX and Styling Improvements**

* Added new styles for the tag editor and tag rows, and updated the setup rail to include a tags step. Adjusted grid layouts and input styling to accommodate the new tag editor. [[1]](diffhunk://#diff-7267265ad7b148d3d512b93091b629179918742f55bb0330c1b762cd0edd22fbR357) [[2]](diffhunk://#diff-7267265ad7b148d3d512b93091b629179918742f55bb0330c1b762cd0edd22fbR1032) [[3]](diffhunk://#diff-7267265ad7b148d3d512b93091b629179918742f55bb0330c1b762cd0edd22fbL1113-R1116) [[4]](diffhunk://#diff-7267265ad7b148d3d512b93091b629179918742f55bb0330c1b762cd0edd22fbR1138-R1186) [[5]](diffhunk://#diff-7267265ad7b148d3d512b93091b629179918742f55bb0330c1b762cd0edd22fbL1424-R1476)

Close #387 