### PR TITLE
Add ESLint config and run lint in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
       working-directory: ./src/Acmebot.App/ClientApp
       run: |
         npm ci
+        npm run lint
         npm run build
 
     - name: Lint C# code

--- a/src/Acmebot.App/ClientApp/README.md
+++ b/src/Acmebot.App/ClientApp/README.md
@@ -9,10 +9,9 @@ npm install
 npm run dev
 npm run build
 npm run lint
-npm run format
 ```
 
-Linting and formatting are handled by ESLint flat config with ESLint Stylistic. `npm run lint` checks Vue and TypeScript files, while `npm run format` applies layout fixes with `eslint --fix --fix-type layout`.
+Linting is handled by ESLint flat config with ESLint Stylistic. `npm run lint` checks Vue and TypeScript files.
 
 `npm run build` writes the static dashboard assets to `../wwwroot/dashboard-vnext` so they can be served by the existing Azure Functions static page endpoint while the current `/dashboard` UI remains available.
 

--- a/src/Acmebot.App/ClientApp/README.md
+++ b/src/Acmebot.App/ClientApp/README.md
@@ -8,7 +8,11 @@ This folder contains the Vite + Vue 3 + TypeScript implementation of the Acmebot
 npm install
 npm run dev
 npm run build
+npm run lint
+npm run format
 ```
+
+Linting and formatting are handled by ESLint flat config with ESLint Stylistic. `npm run lint` checks Vue and TypeScript files, while `npm run format` applies layout fixes with `eslint --fix --fix-type layout`.
 
 `npm run build` writes the static dashboard assets to `../wwwroot/dashboard-vnext` so they can be served by the existing Azure Functions static page endpoint while the current `/dashboard` UI remains available.
 

--- a/src/Acmebot.App/ClientApp/eslint.config.js
+++ b/src/Acmebot.App/ClientApp/eslint.config.js
@@ -1,0 +1,108 @@
+import js from '@eslint/js';
+import stylistic from '@stylistic/eslint-plugin';
+import { defineConfig, globalIgnores } from 'eslint/config';
+import vue from 'eslint-plugin-vue';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+const sourceFiles = ['**/*.{js,ts,vue}'];
+
+export default defineConfig([
+  globalIgnores(['dist/', '../wwwroot/dashboard-vnext/']),
+  {
+    name: 'acmebot-dashboard/linter-options',
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+      reportUnusedInlineConfigs: 'error',
+    },
+  },
+  {
+    name: 'acmebot-dashboard/browser-source',
+    files: sourceFiles,
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        __ACMEBOT_DASHBOARD_COMMIT_HASH__: 'readonly',
+        __ACMEBOT_DASHBOARD_VERSION__: 'readonly',
+      },
+    },
+  },
+  {
+    name: 'acmebot-dashboard/node-config',
+    files: ['eslint.config.js', 'vite.config.ts'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
+  {
+    name: 'acmebot-dashboard/recommended-rules',
+    files: sourceFiles,
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.strict,
+      ...tseslint.configs.stylistic,
+      ...vue.configs['flat/recommended'],
+      stylistic.configs.customize({
+        indent: 2,
+        quotes: 'single',
+        semi: true,
+        arrowParens: true,
+        commaDangle: 'always-multiline',
+        braceStyle: '1tbs',
+        quoteProps: 'as-needed',
+        jsx: false,
+      }),
+    ],
+    rules: {
+      '@stylistic/member-delimiter-style': [
+        'error',
+        {
+          multiline: {
+            delimiter: 'semi',
+            requireLast: true,
+          },
+          singleline: {
+            delimiter: 'semi',
+            requireLast: false,
+          },
+        },
+      ],
+      '@stylistic/operator-linebreak': [
+        'error',
+        'after',
+        {
+          overrides: {
+            '?': 'before',
+            ':': 'before',
+          },
+        },
+      ],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+        },
+      ],
+      'vue/multi-word-component-names': [
+        'error',
+        {
+          ignores: ['App'],
+        },
+      ],
+    },
+  },
+  {
+    name: 'acmebot-dashboard/vue-typescript-parser',
+    files: ['**/*.vue'],
+    languageOptions: {
+      parserOptions: {
+        parser: tseslint.parser,
+      },
+    },
+  },
+]);

--- a/src/Acmebot.App/ClientApp/package-lock.json
+++ b/src/Acmebot.App/ClientApp/package-lock.json
@@ -15,10 +15,17 @@
         "vue": "3.5.34"
       },
       "devDependencies": {
+        "@eslint/js": "10.0.1",
+        "@stylistic/eslint-plugin": "5.10.0",
         "@types/node": "25.6.2",
         "@vitejs/plugin-vue": "6.0.6",
+        "eslint": "10.3.0",
+        "eslint-plugin-vue": "10.9.1",
+        "globals": "17.6.0",
         "typescript": "6.0.3",
+        "typescript-eslint": "8.59.2",
         "vite": "8.0.11",
+        "vue-eslint-parser": "10.4.0",
         "vue-tsc": "3.2.8"
       }
     },
@@ -102,6 +109,134 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -162,6 +297,72 @@
         "@vue/composition-api": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@internationalized/date": {
@@ -499,6 +700,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.56.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
@@ -577,6 +799,27 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
@@ -592,6 +835,249 @@
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
       "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/type-utils": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.2",
+        "@typescript-eslint/types": "^8.59.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.2",
+        "@typescript-eslint/tsconfig-utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.6",
@@ -793,6 +1279,46 @@
         "vue": "^3.5.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/alien-signals": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
@@ -812,10 +1338,93 @@
         "node": ">=10"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/defu": {
@@ -846,10 +1455,259 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-vue": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.1.tgz",
+      "integrity": "sha512-cHB0Tf4Duvzwecwd/AqWzZvF/QszE13BhjVUpVXWCy9AeMR5GjkAjP3i85vqgLgOuTmkHR1OJ5oMeqLHtuw8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "natural-compare": "^1.4.0",
+        "nth-check": "^2.1.1",
+        "postcss-selector-parser": "^7.1.0",
+        "semver": "^7.6.3",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+        "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "vue-eslint-parser": "^10.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@stylistic/eslint-plugin": {
+          "optional": true
+        },
+        "@typescript-eslint/parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
@@ -870,6 +1728,57 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -883,6 +1792,127 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -1158,6 +2188,22 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lucide-vue-next": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
@@ -1175,6 +2221,29 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
@@ -1201,11 +2270,81 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
@@ -1213,6 +2352,26 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1259,6 +2418,30 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/punycode": {
@@ -1336,6 +2519,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1362,11 +2581,37 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -1382,10 +2627,51 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
+      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.2",
+        "@typescript-eslint/parser": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1495,6 +2781,30 @@
         }
       }
     },
+    "node_modules/vue-eslint-parser": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.4.0.tgz",
+      "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "eslint-scope": "^8.2.0 || ^9.0.0",
+        "eslint-visitor-keys": "^4.2.0 || ^5.0.0",
+        "espree": "^10.3.0 || ^11.0.0",
+        "esquery": "^1.6.0",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/vue-tsc": {
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.8.tgz",
@@ -1510,6 +2820,55 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/src/Acmebot.App/ClientApp/package.json
+++ b/src/Acmebot.App/ClientApp/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --fix",
+    "format": "eslint . --fix --fix-type layout",
+    "format:check": "eslint . --max-warnings=0",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview --host 127.0.0.1"
   },
@@ -16,10 +20,17 @@
     "vue": "3.5.34"
   },
   "devDependencies": {
+    "@eslint/js": "10.0.1",
+    "@stylistic/eslint-plugin": "5.10.0",
     "@types/node": "25.6.2",
     "@vitejs/plugin-vue": "6.0.6",
+    "eslint": "10.3.0",
+    "eslint-plugin-vue": "10.9.1",
+    "globals": "17.6.0",
     "typescript": "6.0.3",
+    "typescript-eslint": "8.59.2",
     "vite": "8.0.11",
+    "vue-eslint-parser": "10.4.0",
     "vue-tsc": "3.2.8"
   }
 }

--- a/src/Acmebot.App/ClientApp/package.json
+++ b/src/Acmebot.App/ClientApp/package.json
@@ -7,8 +7,6 @@
     "dev": "vite --host 127.0.0.1",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",
-    "format": "eslint . --fix --fix-type layout",
-    "format:check": "eslint . --max-warnings=0",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview --host 127.0.0.1"
   },

--- a/src/Acmebot.App/ClientApp/src/App.vue
+++ b/src/Acmebot.App/ClientApp/src/App.vue
@@ -25,18 +25,18 @@ const dashboardCommitHash = __ACMEBOT_DASHBOARD_COMMIT_HASH__;
 
 const certificateState = reactive({
   loading: false,
-  error: ''
+  error: '',
 });
 
 const dnsZoneState = reactive({
   loading: false,
-  loaded: false
+  loaded: false,
 });
 
 const operation = reactive({
   active: false,
   title: '',
-  message: ''
+  message: '',
 });
 
 const summary = computed(() => {
@@ -46,7 +46,7 @@ const summary = computed(() => {
       counts[status.kind] += 1;
       return counts;
     },
-    { valid: 0, warning: 0, expired: 0 }
+    { valid: 0, warning: 0, expired: 0 },
   );
 
   return {
@@ -54,7 +54,7 @@ const summary = computed(() => {
     managed: certificates.value.filter((certificate) => getCertificateCategory(certificate) === 'managed').length,
     otherCa: certificates.value.filter((certificate) => getCertificateCategory(certificate) === 'other-ca').length,
     unmanaged: certificates.value.filter((certificate) => getCertificateCategory(certificate) === 'unmanaged').length,
-    ...statusCounts
+    ...statusCounts,
   };
 });
 
@@ -63,7 +63,7 @@ const summaryItems = computed(() => [
   { label: 'Expiring soon', value: summary.value.warning, tone: 'warning', icon: ShieldAlert },
   { label: 'Expired', value: summary.value.expired, tone: 'danger', icon: AlertTriangle },
   { label: 'Other CA', value: summary.value.otherCa, tone: 'neutral', icon: BadgeCheck },
-  { label: 'Unmanaged', value: summary.value.unmanaged, tone: 'neutral', icon: CircleSlash }
+  { label: 'Unmanaged', value: summary.value.unmanaged, tone: 'neutral', icon: CircleSlash },
 ]);
 
 const dashboardCommitLabel = computed(() => (dashboardCommitHash.length > 7 ? dashboardCommitHash.slice(0, 7) : dashboardCommitHash));
@@ -184,36 +184,74 @@ async function confirmRevokeCertificate(): Promise<void> {
     <header class="app-header">
       <div class="app-header__inner">
         <div class="brand-lockup">
-          <div class="brand-mark" aria-hidden="true">
+          <div
+            class="brand-mark"
+            aria-hidden="true"
+          >
             <Shield :size="21" />
           </div>
           <div>
-            <div class="brand-title">Acmebot</div>
-            <div class="brand-subtitle">Certificate automation</div>
+            <div class="brand-title">
+              Acmebot
+            </div>
+            <div class="brand-subtitle">
+              Certificate automation
+            </div>
           </div>
         </div>
         <div class="header-status">
-          <Activity :size="16" aria-hidden="true" />
+          <Activity
+            :size="16"
+            aria-hidden="true"
+          />
           <span>{{ summary.total }} certificates</span>
         </div>
       </div>
     </header>
 
     <main class="app-main">
-      <h1 id="page-heading" class="visually-hidden">Certificate Operations</h1>
+      <h1
+        id="page-heading"
+        class="visually-hidden"
+      >
+        Certificate Operations
+      </h1>
 
-      <section class="summary-grid" aria-label="Certificate summary">
-        <div v-for="item in summaryItems" :key="item.label" class="summary-item" :class="`summary-item--${item.tone}`">
-          <component :is="item.icon" :size="18" aria-hidden="true" />
+      <section
+        class="summary-grid"
+        aria-label="Certificate summary"
+      >
+        <div
+          v-for="item in summaryItems"
+          :key="item.label"
+          class="summary-item"
+          :class="`summary-item--${item.tone}`"
+        >
+          <component
+            :is="item.icon"
+            :size="18"
+            aria-hidden="true"
+          />
           <div>
-            <div class="summary-item__value">{{ item.value }}</div>
-            <div class="summary-item__label">{{ item.label }}</div>
+            <div class="summary-item__value">
+              {{ item.value }}
+            </div>
+            <div class="summary-item__label">
+              {{ item.label }}
+            </div>
           </div>
         </div>
       </section>
 
-      <div v-if="certificateState.error" class="banner banner--error" role="alert">
-        <AlertTriangle :size="17" aria-hidden="true" />
+      <div
+        v-if="certificateState.error"
+        class="banner banner--error"
+        role="alert"
+      >
+        <AlertTriangle
+          :size="17"
+          aria-hidden="true"
+        />
         <span>{{ certificateState.error }}</span>
       </div>
 
@@ -228,7 +266,10 @@ async function confirmRevokeCertificate(): Promise<void> {
       />
     </main>
 
-    <footer class="app-footer" aria-label="Dashboard build metadata">
+    <footer
+      class="app-footer"
+      aria-label="Dashboard build metadata"
+    >
       <div class="app-footer__inner">
         <span>Acmebot Dashboard</span>
         <dl class="build-metadata">
@@ -238,7 +279,9 @@ async function confirmRevokeCertificate(): Promise<void> {
           </div>
           <div class="build-metadata__item">
             <dt>Commit</dt>
-            <dd :title="dashboardCommitHash">{{ dashboardCommitLabel }}</dd>
+            <dd :title="dashboardCommitHash">
+              {{ dashboardCommitLabel }}
+            </dd>
           </div>
         </dl>
       </div>
@@ -272,7 +315,14 @@ async function confirmRevokeCertificate(): Promise<void> {
       @confirm="confirmRevokeCertificate"
     />
 
-    <OperationOverlay :active="operation.active" :title="operation.title" :message="operation.message" />
-    <ToastStack :messages="toasts" @dismiss="dismissToast" />
+    <OperationOverlay
+      :active="operation.active"
+      :title="operation.title"
+      :message="operation.message"
+    />
+    <ToastStack
+      :messages="toasts"
+      @dismiss="dismissToast"
+    />
   </div>
 </template>

--- a/src/Acmebot.App/ClientApp/src/api/acmebotApi.ts
+++ b/src/Acmebot.App/ClientApp/src/api/acmebotApi.ts
@@ -6,7 +6,7 @@ export class ApiError extends Error {
   constructor(
     message: string,
     public readonly status: number,
-    public readonly problem?: ProblemDetails
+    public readonly problem?: ProblemDetails,
   ) {
     super(message);
     this.name = 'ApiError';
@@ -45,9 +45,9 @@ async function requestJson<T>(input: RequestInfo | URL, init?: RequestInit): Pro
   const response = await fetch(input, {
     headers: {
       Accept: 'application/json',
-      ...init?.headers
+      ...init?.headers,
     },
-    ...init
+    ...init,
   });
   const body = await parseResponseBody(response);
 
@@ -62,9 +62,9 @@ async function startOperation(input: RequestInfo | URL, init?: RequestInit): Pro
   const response = await fetch(input, {
     headers: {
       Accept: 'application/json',
-      ...init?.headers
+      ...init?.headers,
     },
-    ...init
+    ...init,
   });
   const body = await parseResponseBody(response);
 
@@ -128,7 +128,7 @@ export async function issueCertificate(policy: CertificatePolicyItem): Promise<v
   const location = await startOperation('/api/certificate', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(policy)
+    body: JSON.stringify(policy),
   });
 
   await pollOperation(location);
@@ -142,7 +142,7 @@ export async function renewCertificate(certificateName: string): Promise<void> {
   }
 
   const location = await startOperation(`/api/certificate/${encodeURIComponent(certificateName)}/renew`, {
-    method: 'POST'
+    method: 'POST',
   });
 
   await pollOperation(location);
@@ -155,8 +155,8 @@ export async function revokeCertificate(certificateName: string): Promise<void> 
     return;
   }
 
-  await requestJson<void>(`/api/certificate/${encodeURIComponent(certificateName)}/revoke`, {
-    method: 'POST'
+  await requestJson(`/api/certificate/${encodeURIComponent(certificateName)}/revoke`, {
+    method: 'POST',
   });
 }
 

--- a/src/Acmebot.App/ClientApp/src/api/mockData.ts
+++ b/src/Acmebot.App/ClientApp/src/api/mockData.ts
@@ -26,7 +26,7 @@ let mockCertificates: CertificateItem[] = [
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
-    dnsAlias: null
+    dnsAlias: null,
   },
   {
     id: 'https://mock.vault/certificates/apex-example-co-jp',
@@ -43,7 +43,7 @@ let mockCertificates: CertificateItem[] = [
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
-    dnsAlias: null
+    dnsAlias: null,
   },
   {
     id: 'https://mock.vault/certificates/app-www-example-co-jp',
@@ -60,7 +60,7 @@ let mockCertificates: CertificateItem[] = [
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
-    dnsAlias: null
+    dnsAlias: null,
   },
   {
     id: 'https://mock.vault/certificates/api-contoso-com',
@@ -77,7 +77,7 @@ let mockCertificates: CertificateItem[] = [
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
-    dnsAlias: null
+    dnsAlias: null,
   },
   {
     id: 'https://mock.vault/certificates/edge-adatum-io',
@@ -94,7 +94,7 @@ let mockCertificates: CertificateItem[] = [
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
-    dnsAlias: null
+    dnsAlias: null,
   },
   {
     id: 'https://mock.vault/certificates/wildcard-fabrikam-net',
@@ -111,7 +111,7 @@ let mockCertificates: CertificateItem[] = [
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
-    dnsAlias: 'dns-alias.fabrikam.net'
+    dnsAlias: 'dns-alias.fabrikam.net',
   },
   {
     id: 'https://mock.vault/certificates/portal-example-org',
@@ -128,7 +128,7 @@ let mockCertificates: CertificateItem[] = [
     isIssuedByAcmebot: true,
     isSameEndpoint: false,
     acmeEndpoint: 'https://acme.zerossl.com/v2/DV90',
-    dnsAlias: null
+    dnsAlias: null,
   },
   {
     id: 'https://mock.vault/certificates/imported-legacy-net',
@@ -145,23 +145,23 @@ let mockCertificates: CertificateItem[] = [
     isIssuedByAcmebot: false,
     isSameEndpoint: false,
     acmeEndpoint: null,
-    dnsAlias: null
-  }
+    dnsAlias: null,
+  },
 ];
 
 const mockDnsZoneGroups: DnsZoneGroup[] = [
   {
     dnsProviderName: 'Azure DNS',
-    dnsZones: [{ name: 'example.com' }, { name: 'example.co.jp' }, { name: 'www.example.co.jp' }, { name: 'example.org' }, { name: 'fabrikam.net' }]
+    dnsZones: [{ name: 'example.com' }, { name: 'example.co.jp' }, { name: 'www.example.co.jp' }, { name: 'example.org' }, { name: 'fabrikam.net' }],
   },
   {
     dnsProviderName: 'Cloudflare',
-    dnsZones: [{ name: 'contoso.com' }, { name: 'adatum.io' }]
+    dnsZones: [{ name: 'contoso.com' }, { name: 'adatum.io' }],
   },
   {
     dnsProviderName: 'Route 53',
-    dnsZones: [{ name: 'wingtiptoys.com' }]
-  }
+    dnsZones: [{ name: 'wingtiptoys.com' }],
+  },
 ];
 
 export async function getMockCertificates(): Promise<CertificateItem[]> {
@@ -196,8 +196,8 @@ export async function mockIssueCertificate(policy: CertificatePolicyItem): Promi
       isIssuedByAcmebot: true,
       isSameEndpoint: true,
       acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
-      dnsAlias: policy.dnsAlias
-    }
+      dnsAlias: policy.dnsAlias,
+    },
   ];
 }
 
@@ -209,9 +209,9 @@ export async function mockRenewCertificate(certificateName: string): Promise<voi
           ...certificate,
           createdOn: new Date().toISOString(),
           expiresOn: dateFromNow(90),
-          isExpired: false
+          isExpired: false,
         }
-      : certificate
+      : certificate,
   );
 }
 

--- a/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
@@ -497,8 +497,14 @@ function submit(): void {
                 <small>{{ form.useAdvancedOptions ? 'Custom settings' : 'Default settings' }}</small>
               </div>
             </div>
-            <div class="setup-step" :class="{ 'is-complete': tagCount > 0 }">
-              <Tag :size="17" aria-hidden="true" />
+            <div
+              class="setup-step"
+              :class="{ 'is-complete': tagCount > 0 }"
+            >
+              <Tag
+                :size="17"
+                aria-hidden="true"
+              />
               <div class="setup-step__body">
                 <span>Tags</span>
                 <strong>{{ tagCountLabel }}</strong>
@@ -680,24 +686,72 @@ function submit(): void {
               <div class="tag-editor advanced-grid__wide">
                 <div class="tag-editor__header">
                   <span class="form-label">Key Vault Tags</span>
-                  <button class="secondary-button" type="button" @click="addTag">
-                    <Plus :size="16" aria-hidden="true" />
+                  <button
+                    class="secondary-button"
+                    type="button"
+                    @click="addTag"
+                  >
+                    <Plus
+                      :size="16"
+                      aria-hidden="true"
+                    />
                     <span>Add tag</span>
                   </button>
                 </div>
-                <div v-if="form.tags.length === 0" class="tag-editor__empty">No tags</div>
-                <div v-else class="tag-editor__rows">
-                  <div v-for="tagItem in form.tags" :key="tagItem.id" class="tag-row">
-                    <label class="visually-hidden" :for="`tag-key-${tagItem.id}`">Tag name</label>
-                    <input :id="`tag-key-${tagItem.id}`" v-model="tagItem.key" type="text" placeholder="Name" :aria-invalid="tagError ? 'true' : 'false'" />
-                    <label class="visually-hidden" :for="`tag-value-${tagItem.id}`">Tag value</label>
-                    <input :id="`tag-value-${tagItem.id}`" v-model="tagItem.value" type="text" placeholder="Value" :aria-invalid="tagError ? 'true' : 'false'" />
-                    <button class="icon-only-button" type="button" title="Remove tag" @click="removeTag(tagItem.id)">
-                      <Trash2 :size="15" aria-hidden="true" />
+                <div
+                  v-if="form.tags.length === 0"
+                  class="tag-editor__empty"
+                >
+                  No tags
+                </div>
+                <div
+                  v-else
+                  class="tag-editor__rows"
+                >
+                  <div
+                    v-for="tagItem in form.tags"
+                    :key="tagItem.id"
+                    class="tag-row"
+                  >
+                    <label
+                      class="visually-hidden"
+                      :for="`tag-key-${tagItem.id}`"
+                    >Tag name</label>
+                    <input
+                      :id="`tag-key-${tagItem.id}`"
+                      v-model="tagItem.key"
+                      type="text"
+                      placeholder="Name"
+                      :aria-invalid="tagError ? 'true' : 'false'"
+                    >
+                    <label
+                      class="visually-hidden"
+                      :for="`tag-value-${tagItem.id}`"
+                    >Tag value</label>
+                    <input
+                      :id="`tag-value-${tagItem.id}`"
+                      v-model="tagItem.value"
+                      type="text"
+                      placeholder="Value"
+                      :aria-invalid="tagError ? 'true' : 'false'"
+                    >
+                    <button
+                      class="icon-only-button"
+                      type="button"
+                      title="Remove tag"
+                      @click="removeTag(tagItem.id)"
+                    >
+                      <Trash2
+                        :size="15"
+                        aria-hidden="true"
+                      />
                     </button>
                   </div>
                 </div>
-                <span v-if="tagError" class="form-error">{{ tagError }}</span>
+                <span
+                  v-if="tagError"
+                  class="form-error"
+                >{{ tagError }}</span>
               </div>
             </div>
           </div>

--- a/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
@@ -28,7 +28,7 @@ interface ValidationOutcome {
 
 const selectedZone = ref<SelectableDnsZone | null>(null);
 const validationErrors = reactive({
-  dnsName: ''
+  dnsName: '',
 });
 
 const validKeySizes = [2048, 3072, 4096];
@@ -44,7 +44,7 @@ const form = reactive({
   keySize: 2048,
   keyCurveName: 'P-256' as KeyCurveName,
   reuseKey: false,
-  dnsAlias: ''
+  dnsAlias: '',
 });
 
 const certificateNameError = computed(() => (form.useAdvancedOptions ? validateCertificateName(form.certificateName) : ''));
@@ -94,7 +94,7 @@ watch(
       resetForm();
       emit('load-zones');
     }
-  }
+  },
 );
 
 watch(
@@ -108,7 +108,7 @@ watch(
       form.reuseKey = false;
       form.dnsAlias = '';
     }
-  }
+  },
 );
 
 function resetForm(): void {
@@ -321,7 +321,7 @@ function submit(): void {
     certificateName: normalizedCertificateName || undefined,
     keyType: form.keyType,
     reuseKey: form.useAdvancedOptions ? form.reuseKey : false,
-    dnsAlias: normalizedDnsAlias || undefined
+    dnsAlias: normalizedDnsAlias || undefined,
   };
 
   if (form.keyType === 'RSA') {
@@ -336,43 +336,89 @@ function submit(): void {
 
 <template>
   <Teleport to="body">
-    <div v-if="open" class="modal-shell" role="dialog" aria-modal="true" aria-labelledby="add-certificate-heading">
-      <button class="modal-scrim" type="button" title="Close issue certificate" :disabled="sending" @click="emit('close')"></button>
+    <div
+      v-if="open"
+      class="modal-shell"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="add-certificate-heading"
+    >
+      <button
+        class="modal-scrim"
+        type="button"
+        title="Close issue certificate"
+        :disabled="sending"
+        @click="emit('close')"
+      />
       <section class="modal-panel modal-panel--wide">
         <header class="modal-panel__header">
           <div>
-            <div class="eyebrow">Certificate issuance</div>
-            <h2 id="add-certificate-heading">Issue Certificate</h2>
+            <div class="eyebrow">
+              Certificate issuance
+            </div>
+            <h2 id="add-certificate-heading">
+              Issue Certificate
+            </h2>
           </div>
-          <button class="icon-only-button" type="button" title="Close issue certificate" :disabled="sending" @click="emit('close')">
-            <X :size="18" aria-hidden="true" />
+          <button
+            class="icon-only-button"
+            type="button"
+            title="Close issue certificate"
+            :disabled="sending"
+            @click="emit('close')"
+          >
+            <X
+              :size="18"
+              aria-hidden="true"
+            />
           </button>
         </header>
 
         <div class="wizard-layout">
-          <aside class="setup-rail" aria-label="Certificate issue setup">
+          <aside
+            class="setup-rail"
+            aria-label="Certificate issue setup"
+          >
             <div class="setup-rail__header">
               <span>Issue setup</span>
               <strong>{{ issueStatusLabel }}</strong>
             </div>
-            <div class="setup-step" :class="{ 'is-complete': selectedZone }">
-              <ShieldPlus :size="17" aria-hidden="true" />
+            <div
+              class="setup-step"
+              :class="{ 'is-complete': selectedZone }"
+            >
+              <ShieldPlus
+                :size="17"
+                aria-hidden="true"
+              />
               <div class="setup-step__body">
                 <span>Zone</span>
                 <strong>{{ selectedZone ? displayDnsName(selectedZone.name) : 'Not selected' }}</strong>
                 <small v-if="selectedZone">{{ selectedZone.dnsProviderName }}</small>
               </div>
             </div>
-            <div class="setup-step" :class="{ 'is-complete': form.dnsNames.length > 0 }">
-              <CirclePlus :size="17" aria-hidden="true" />
+            <div
+              class="setup-step"
+              :class="{ 'is-complete': form.dnsNames.length > 0 }"
+            >
+              <CirclePlus
+                :size="17"
+                aria-hidden="true"
+              />
               <div class="setup-step__body">
                 <span>Names</span>
                 <strong>{{ dnsNamesSummary }}</strong>
                 <small>{{ dnsNameCountLabel }}</small>
               </div>
             </div>
-            <div class="setup-step" :class="{ 'is-complete': form.useAdvancedOptions }">
-              <KeyRound :size="17" aria-hidden="true" />
+            <div
+              class="setup-step"
+              :class="{ 'is-complete': form.useAdvancedOptions }"
+            >
+              <KeyRound
+                :size="17"
+                aria-hidden="true"
+              />
               <div class="setup-step__body">
                 <span>Key</span>
                 <strong>{{ keySummary }}</strong>
@@ -384,11 +430,18 @@ function submit(): void {
           <div class="wizard-body">
             <div class="form-section">
               <label class="form-label">DNS Zone</label>
-              <SearchableZoneSelect v-model:selected="selectedZone" :groups="zones" :loading="loadingZones" />
+              <SearchableZoneSelect
+                v-model:selected="selectedZone"
+                :groups="zones"
+                :loading="loadingZones"
+              />
             </div>
 
             <div class="form-section">
-              <label class="form-label" for="record-name">DNS Name</label>
+              <label
+                class="form-label"
+                for="record-name"
+              >DNS Name</label>
               <div class="compound-input">
                 <input
                   id="record-name"
@@ -399,23 +452,50 @@ function submit(): void {
                   :aria-invalid="validationErrors.dnsName ? 'true' : 'false'"
                   @keydown.enter.prevent="addDnsName"
                   @input="clearDnsNameError"
-                />
+                >
                 <span class="compound-input__suffix">.{{ selectedZone ? displayDnsName(selectedZone.name) : 'zone' }}</span>
-                <button class="icon-button" type="button" :disabled="!selectedZone" @click="addDnsName">
-                  <Plus :size="16" aria-hidden="true" />
+                <button
+                  class="icon-button"
+                  type="button"
+                  :disabled="!selectedZone"
+                  @click="addDnsName"
+                >
+                  <Plus
+                    :size="16"
+                    aria-hidden="true"
+                  />
                   <span>Add</span>
                 </button>
               </div>
-              <div v-if="fullDnsName" class="form-result">
+              <div
+                v-if="fullDnsName"
+                class="form-result"
+              >
                 <span>Full DNS name</span>
                 <strong>{{ displayDnsName(fullDnsName) }}</strong>
               </div>
-              <p v-if="validationErrors.dnsName" class="form-error">{{ validationErrors.dnsName }}</p>
+              <p
+                v-if="validationErrors.dnsName"
+                class="form-error"
+              >
+                {{ validationErrors.dnsName }}
+              </p>
               <div class="dns-list dns-list--editable">
-                <span v-for="dnsName in form.dnsNames" :key="dnsName" class="dns-chip dns-chip--removable">
+                <span
+                  v-for="dnsName in form.dnsNames"
+                  :key="dnsName"
+                  class="dns-chip dns-chip--removable"
+                >
                   {{ displayDnsName(dnsName) }}
-                  <button type="button" title="Remove DNS name" @click="removeDnsName(dnsName)">
-                    <Trash2 :size="13" aria-hidden="true" />
+                  <button
+                    type="button"
+                    title="Remove DNS name"
+                    @click="removeDnsName(dnsName)"
+                  >
+                    <Trash2
+                      :size="13"
+                      aria-hidden="true"
+                    />
                   </button>
                 </span>
               </div>
@@ -423,28 +503,54 @@ function submit(): void {
 
             <div class="form-section form-section--inline">
               <label class="toggle-row">
-                <input v-model="form.useAdvancedOptions" type="checkbox" />
+                <input
+                  v-model="form.useAdvancedOptions"
+                  type="checkbox"
+                >
                 <span>Advanced options</span>
               </label>
             </div>
 
-            <div v-if="form.useAdvancedOptions" class="advanced-grid">
-              <label class="form-field" :class="{ 'is-invalid': certificateNameError }">
+            <div
+              v-if="form.useAdvancedOptions"
+              class="advanced-grid"
+            >
+              <label
+                class="form-field"
+                :class="{ 'is-invalid': certificateNameError }"
+              >
                 <span class="form-label">Certificate Name</span>
-                <input v-model="form.certificateName" type="text" placeholder="Optional certificate name" :aria-invalid="certificateNameError ? 'true' : 'false'" />
-                <span v-if="certificateNameError" class="form-error">{{ certificateNameError }}</span>
+                <input
+                  v-model="form.certificateName"
+                  type="text"
+                  placeholder="Optional certificate name"
+                  :aria-invalid="certificateNameError ? 'true' : 'false'"
+                >
+                <span
+                  v-if="certificateNameError"
+                  class="form-error"
+                >{{ certificateNameError }}</span>
               </label>
 
-              <label class="form-field" :class="{ 'is-invalid': keyOptionError }">
+              <label
+                class="form-field"
+                :class="{ 'is-invalid': keyOptionError }"
+              >
                 <span class="form-label">Key Type</span>
                 <select v-model="form.keyType">
                   <option value="RSA">RSA</option>
                   <option value="EC">EC</option>
                 </select>
-                <span v-if="keyOptionError" class="form-error">{{ keyOptionError }}</span>
+                <span
+                  v-if="keyOptionError"
+                  class="form-error"
+                >{{ keyOptionError }}</span>
               </label>
 
-              <label v-if="form.keyType === 'RSA'" class="form-field">
+              <label
+                v-if="form.keyType === 'RSA'"
+                class="form-field"
+              >
                 <span class="form-label">Key Size</span>
                 <select v-model.number="form.keySize">
                   <option :value="2048">2048</option>
@@ -453,7 +559,10 @@ function submit(): void {
                 </select>
               </label>
 
-              <label v-else class="form-field">
+              <label
+                v-else
+                class="form-field"
+              >
                 <span class="form-label">Curve</span>
                 <select v-model="form.keyCurveName">
                   <option value="P-256">P-256</option>
@@ -463,14 +572,28 @@ function submit(): void {
                 </select>
               </label>
 
-              <label class="form-field" :class="{ 'is-invalid': dnsAliasError }">
+              <label
+                class="form-field"
+                :class="{ 'is-invalid': dnsAliasError }"
+              >
                 <span class="form-label">DNS Alias</span>
-                <input v-model="form.dnsAlias" type="text" placeholder="alias.example.com" :aria-invalid="dnsAliasError ? 'true' : 'false'" />
-                <span v-if="dnsAliasError" class="form-error">{{ dnsAliasError }}</span>
+                <input
+                  v-model="form.dnsAlias"
+                  type="text"
+                  placeholder="alias.example.com"
+                  :aria-invalid="dnsAliasError ? 'true' : 'false'"
+                >
+                <span
+                  v-if="dnsAliasError"
+                  class="form-error"
+                >{{ dnsAliasError }}</span>
               </label>
 
               <label class="toggle-row advanced-grid__toggle">
-                <input v-model="form.reuseKey" type="checkbox" />
+                <input
+                  v-model="form.reuseKey"
+                  type="checkbox"
+                >
                 <span>Reuse key on renewal</span>
               </label>
             </div>
@@ -483,9 +606,24 @@ function submit(): void {
             <span>{{ keySummary }}</span>
           </div>
           <div class="modal-panel__footer-actions">
-            <button class="secondary-button" type="button" :disabled="sending" @click="emit('close')">Cancel</button>
-            <button class="primary-button" type="button" :disabled="!canSubmit" @click="submit">
-              <ShieldPlus :size="17" aria-hidden="true" />
+            <button
+              class="secondary-button"
+              type="button"
+              :disabled="sending"
+              @click="emit('close')"
+            >
+              Cancel
+            </button>
+            <button
+              class="primary-button"
+              type="button"
+              :disabled="!canSubmit"
+              @click="submit"
+            >
+              <ShieldPlus
+                :size="17"
+                aria-hidden="true"
+              />
               <span>Issue Certificate</span>
             </button>
           </div>

--- a/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
+++ b/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
@@ -17,7 +17,7 @@ import {
   SearchX,
   ServerCog,
   SlidersHorizontal,
-  X
+  X,
 } from 'lucide-vue-next';
 
 import type { CertificateCategory, CertificateItem, CertificateStatusKind, DnsZoneGroup } from '@/api/types';
@@ -28,7 +28,7 @@ import {
   getCertificateCategory,
   getCertificateStatus,
   getPrimaryZone,
-  isShortLived
+  isShortLived,
 } from '@/utils/certificates';
 
 import StatusBadge from './StatusBadge.vue';
@@ -61,7 +61,7 @@ const filters = reactive({
   query: '',
   category: 'managed' as CategoryFilter,
   status: 'all' as StatusFilter,
-  provider: 'all'
+  provider: 'all',
 });
 const sorting = ref<SortingState>([{ id: 'expiresOn', desc: false }]);
 const collapsedZones = ref<Set<string>>(new Set());
@@ -73,14 +73,14 @@ const columns = [
   columnHelper.accessor((certificate) => getCategoryLabel(getCertificateCategory(certificate)), { id: 'category', header: 'Category' }),
   columnHelper.accessor('expiresOn', { header: 'Expires' }),
   columnHelper.accessor((certificate) => `${certificate.keyType ?? ''} ${certificate.keySize ?? certificate.keyCurveName ?? ''}`, { id: 'key', header: 'Key' }),
-  columnHelper.display({ id: 'actions', header: '', enableSorting: false })
+  columnHelper.display({ id: 'actions', header: '', enableSorting: false }),
 ];
 
 const categoryOptions: { label: string; value: CategoryFilter }[] = [
   { label: 'All', value: 'all' },
   { label: 'Managed', value: 'managed' },
   { label: 'Other CA', value: 'other-ca' },
-  { label: 'Unmanaged', value: 'unmanaged' }
+  { label: 'Unmanaged', value: 'unmanaged' },
 ];
 
 const providerOptions = computed(() => {
@@ -107,7 +107,7 @@ const providerOptions = computed(() => {
 });
 
 const hasActiveFilters = computed(
-  () => filters.query.trim() !== '' || filters.category !== 'managed' || filters.status !== 'all' || filters.provider !== 'all'
+  () => filters.query.trim() !== '' || filters.category !== 'managed' || filters.status !== 'all' || filters.provider !== 'all',
 );
 
 const filteredCertificates = computed(() => {
@@ -145,13 +145,13 @@ const table = useVueTable({
   state: {
     get sorting() {
       return sorting.value;
-    }
+    },
   },
   onSortingChange: (updaterOrValue) => {
     sorting.value = typeof updaterOrValue === 'function' ? updaterOrValue(sorting.value) : updaterOrValue;
   },
   getCoreRowModel: getCoreRowModel(),
-  getSortedRowModel: getSortedRowModel()
+  getSortedRowModel: getSortedRowModel(),
 });
 
 const zoneGroups = computed<ZoneGroup[]>(() => {
@@ -171,8 +171,8 @@ const zoneGroups = computed<ZoneGroup[]>(() => {
         statusCounts: {
           valid: statusKind === 'valid' ? 1 : 0,
           warning: statusKind === 'warning' ? 1 : 0,
-          expired: statusKind === 'expired' ? 1 : 0
-        }
+          expired: statusKind === 'expired' ? 1 : 0,
+        },
       });
     } else {
       const group = groups[groupIndex];
@@ -231,19 +231,46 @@ function toggleAllZoneGroups(): void {
 </script>
 
 <template>
-  <section class="table-surface" aria-labelledby="certificate-table-heading">
+  <section
+    class="table-surface"
+    aria-labelledby="certificate-table-heading"
+  >
     <div class="table-toolbar">
       <div>
-        <h2 id="certificate-table-heading" class="section-heading">{{ tableTitle }}</h2>
-        <div class="section-meta">{{ filteredCertificates.length }} of {{ certificates.length }}</div>
+        <h2
+          id="certificate-table-heading"
+          class="section-heading"
+        >
+          {{ tableTitle }}
+        </h2>
+        <div class="section-meta">
+          {{ filteredCertificates.length }} of {{ certificates.length }}
+        </div>
       </div>
       <div class="table-toolbar__actions">
-        <button class="icon-button" type="button" title="Refresh certificates" :disabled="loading" @click="emit('refresh')">
-          <RefreshCw :class="{ 'spin': loading }" :size="17" aria-hidden="true" />
+        <button
+          class="icon-button"
+          type="button"
+          title="Refresh certificates"
+          :disabled="loading"
+          @click="emit('refresh')"
+        >
+          <RefreshCw
+            :class="{ 'spin': loading }"
+            :size="17"
+            aria-hidden="true"
+          />
           <span>Refresh</span>
         </button>
-        <button class="primary-button" type="button" @click="emit('add')">
-          <CirclePlus :size="17" aria-hidden="true" />
+        <button
+          class="primary-button"
+          type="button"
+          @click="emit('add')"
+        >
+          <CirclePlus
+            :size="17"
+            aria-hidden="true"
+          />
           <span>Issue Certificate</span>
         </button>
       </div>
@@ -251,10 +278,20 @@ function toggleAllZoneGroups(): void {
 
     <div class="table-controls">
       <label class="search-field">
-        <Search :size="16" aria-hidden="true" />
-        <input v-model="filters.query" type="search" placeholder="Search certificates or domains" />
+        <Search
+          :size="16"
+          aria-hidden="true"
+        />
+        <input
+          v-model="filters.query"
+          type="search"
+          placeholder="Search certificates or domains"
+        >
       </label>
-      <div class="segmented-control" aria-label="Certificate category">
+      <div
+        class="segmented-control"
+        aria-label="Certificate category"
+      >
         <button
           v-for="option in categoryOptions"
           :key="option.value"
@@ -266,7 +303,10 @@ function toggleAllZoneGroups(): void {
         </button>
       </div>
       <label class="select-field">
-        <Filter :size="15" aria-hidden="true" />
+        <Filter
+          :size="15"
+          aria-hidden="true"
+        />
         <select v-model="filters.status">
           <option value="all">Any status</option>
           <option value="valid">Valid</option>
@@ -275,18 +315,45 @@ function toggleAllZoneGroups(): void {
         </select>
       </label>
       <label class="select-field">
-        <ServerCog :size="15" aria-hidden="true" />
-        <select v-model="filters.provider" :disabled="providerOptions.length === 0">
+        <ServerCog
+          :size="15"
+          aria-hidden="true"
+        />
+        <select
+          v-model="filters.provider"
+          :disabled="providerOptions.length === 0"
+        >
           <option value="all">Any provider</option>
-          <option v-for="option in providerOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
+          <option
+            v-for="option in providerOptions"
+            :key="option.value"
+            :value="option.value"
+          >{{ option.label }}</option>
         </select>
       </label>
-      <button v-if="zoneGroups.length > 0" class="icon-button" type="button" @click="toggleAllZoneGroups">
-        <component :is="allZoneGroupsCollapsed ? ChevronsUpDown : ChevronsDownUp" :size="16" aria-hidden="true" />
+      <button
+        v-if="zoneGroups.length > 0"
+        class="icon-button"
+        type="button"
+        @click="toggleAllZoneGroups"
+      >
+        <component
+          :is="allZoneGroupsCollapsed ? ChevronsUpDown : ChevronsDownUp"
+          :size="16"
+          aria-hidden="true"
+        />
         <span>{{ allZoneGroupsCollapsed ? 'Expand all' : 'Collapse all' }}</span>
       </button>
-      <button v-if="hasActiveFilters" class="icon-button" type="button" @click="clearFilters">
-        <X :size="16" aria-hidden="true" />
+      <button
+        v-if="hasActiveFilters"
+        class="icon-button"
+        type="button"
+        @click="clearFilters"
+      >
+        <X
+          :size="16"
+          aria-hidden="true"
+        />
         <span>Clear</span>
       </button>
     </div>
@@ -294,18 +361,35 @@ function toggleAllZoneGroups(): void {
     <div class="table-wrap">
       <table class="certificate-table">
         <thead>
-          <tr v-for="headerGroup in table.getHeaderGroups()" :key="headerGroup.id">
-            <th v-for="header in headerGroup.headers" :key="header.id">
+          <tr
+            v-for="headerGroup in table.getHeaderGroups()"
+            :key="headerGroup.id"
+          >
+            <th
+              v-for="header in headerGroup.headers"
+              :key="header.id"
+            >
               <button
                 v-if="!header.isPlaceholder && header.column.getCanSort()"
                 class="table-sort-button"
                 type="button"
                 @click="header.column.getToggleSortingHandler()?.($event)"
               >
-                <FlexRender :render="header.column.columnDef.header" :props="header.getContext()" />
-                <component :is="getSortIcon(header.column.getIsSorted())" :size="14" aria-hidden="true" />
+                <FlexRender
+                  :render="header.column.columnDef.header"
+                  :props="header.getContext()"
+                />
+                <component
+                  :is="getSortIcon(header.column.getIsSorted())"
+                  :size="14"
+                  aria-hidden="true"
+                />
               </button>
-              <FlexRender v-else-if="!header.isPlaceholder" :render="header.column.columnDef.header" :props="header.getContext()" />
+              <FlexRender
+                v-else-if="!header.isPlaceholder"
+                :render="header.column.columnDef.header"
+                :props="header.getContext()"
+              />
             </th>
           </tr>
         </thead>
@@ -313,7 +397,11 @@ function toggleAllZoneGroups(): void {
           <tr v-if="loading">
             <td colspan="6">
               <div class="table-empty table-empty--compact">
-                <LoaderCircle class="spin" :size="24" aria-hidden="true" />
+                <LoaderCircle
+                  class="spin"
+                  :size="24"
+                  aria-hidden="true"
+                />
                 <strong>Loading certificates</strong>
               </div>
             </td>
@@ -321,31 +409,70 @@ function toggleAllZoneGroups(): void {
           <tr v-else-if="filteredCertificates.length === 0">
             <td colspan="6">
               <div class="table-empty">
-                <SearchX :size="28" aria-hidden="true" />
+                <SearchX
+                  :size="28"
+                  aria-hidden="true"
+                />
                 <strong>No certificates found</strong>
                 <span>{{ hasActiveFilters ? 'No rows match the current filters.' : 'No certificates are available yet.' }}</span>
-                <button v-if="hasActiveFilters" class="secondary-button" type="button" @click="clearFilters">Clear filters</button>
-                <button v-else class="primary-button" type="button" @click="emit('add')">
-                  <CirclePlus :size="17" aria-hidden="true" />
+                <button
+                  v-if="hasActiveFilters"
+                  class="secondary-button"
+                  type="button"
+                  @click="clearFilters"
+                >
+                  Clear filters
+                </button>
+                <button
+                  v-else
+                  class="primary-button"
+                  type="button"
+                  @click="emit('add')"
+                >
+                  <CirclePlus
+                    :size="17"
+                    aria-hidden="true"
+                  />
                   <span>Issue Certificate</span>
                 </button>
               </div>
             </td>
           </tr>
           <template v-else>
-            <template v-for="group in zoneGroups" :key="group.zoneName">
+            <template
+              v-for="group in zoneGroups"
+              :key="group.zoneName"
+            >
               <tr class="zone-group-row">
                 <td colspan="6">
                   <div class="zone-group">
-                    <button class="zone-group__toggle" type="button" :aria-expanded="!isZoneCollapsed(group.zoneName)" @click="toggleZoneGroup(group.zoneName)">
-                      <component :is="isZoneCollapsed(group.zoneName) ? ChevronRight : ChevronDown" :size="16" aria-hidden="true" />
+                    <button
+                      class="zone-group__toggle"
+                      type="button"
+                      :aria-expanded="!isZoneCollapsed(group.zoneName)"
+                      @click="toggleZoneGroup(group.zoneName)"
+                    >
+                      <component
+                        :is="isZoneCollapsed(group.zoneName) ? ChevronRight : ChevronDown"
+                        :size="16"
+                        aria-hidden="true"
+                      />
                       <span class="zone-group__name">{{ group.zoneName }}</span>
                     </button>
                     <div class="zone-group__summary">
                       <span class="zone-group__meta">{{ formatCertificateCount(group.rows.length) }}</span>
-                      <span v-if="group.statusCounts.valid > 0" class="zone-stat zone-stat--valid">{{ group.statusCounts.valid }} valid</span>
-                      <span v-if="group.statusCounts.warning > 0" class="zone-stat zone-stat--warning">{{ group.statusCounts.warning }} expiring</span>
-                      <span v-if="group.statusCounts.expired > 0" class="zone-stat zone-stat--expired">{{ group.statusCounts.expired }} expired</span>
+                      <span
+                        v-if="group.statusCounts.valid > 0"
+                        class="zone-stat zone-stat--valid"
+                      >{{ group.statusCounts.valid }} valid</span>
+                      <span
+                        v-if="group.statusCounts.warning > 0"
+                        class="zone-stat zone-stat--warning"
+                      >{{ group.statusCounts.warning }} expiring</span>
+                      <span
+                        v-if="group.statusCounts.expired > 0"
+                        class="zone-stat zone-stat--expired"
+                      >{{ group.statusCounts.expired }} expired</span>
                     </div>
                   </div>
                 </td>
@@ -358,28 +485,60 @@ function toggleAllZoneGroups(): void {
                   :class="{ 'is-selected': selectedCertificate?.id === row.original.id }"
                 >
                   <td data-label="Name">
-                    <div class="certificate-name">{{ row.original.name }}</div>
-                    <div v-if="isShortLived(row.original)" class="inline-note">Short-lived</div>
+                    <div class="certificate-name">
+                      {{ row.original.name }}
+                    </div>
+                    <div
+                      v-if="isShortLived(row.original)"
+                      class="inline-note"
+                    >
+                      Short-lived
+                    </div>
                   </td>
                   <td data-label="DNS Names">
                     <div class="dns-list">
-                      <span v-for="dnsName in row.original.dnsNames.slice(0, 3)" :key="dnsName" class="dns-chip">{{ displayDnsName(dnsName) }}</span>
-                      <span v-if="row.original.dnsNames.length > 3" class="dns-chip dns-chip--muted">+{{ row.original.dnsNames.length - 3 }}</span>
+                      <span
+                        v-for="dnsName in row.original.dnsNames.slice(0, 3)"
+                        :key="dnsName"
+                        class="dns-chip"
+                      >{{ displayDnsName(dnsName) }}</span>
+                      <span
+                        v-if="row.original.dnsNames.length > 3"
+                        class="dns-chip dns-chip--muted"
+                      >+{{ row.original.dnsNames.length - 3 }}</span>
                     </div>
                   </td>
-                  <td data-label="Category">{{ getCategoryLabel(getCertificateCategory(row.original)) }}</td>
+                  <td data-label="Category">
+                    {{ getCategoryLabel(getCertificateCategory(row.original)) }}
+                  </td>
                   <td data-label="Expires">
                     <StatusBadge :certificate="row.original" />
-                    <div class="cell-subtext">{{ formatDate(row.original.expiresOn) }}</div>
+                    <div class="cell-subtext">
+                      {{ formatDate(row.original.expiresOn) }}
+                    </div>
                   </td>
                   <td data-label="Key">
                     <span>{{ row.original.keyType ?? '-' }}</span>
-                    <span v-if="row.original.keySize" class="cell-subtext">{{ row.original.keySize }} bit</span>
-                    <span v-else-if="row.original.keyCurveName" class="cell-subtext">{{ row.original.keyCurveName }}</span>
+                    <span
+                      v-if="row.original.keySize"
+                      class="cell-subtext"
+                    >{{ row.original.keySize }} bit</span>
+                    <span
+                      v-else-if="row.original.keyCurveName"
+                      class="cell-subtext"
+                    >{{ row.original.keyCurveName }}</span>
                   </td>
                   <td class="row-actions-cell">
-                    <button class="row-action" type="button" title="Open certificate details" @click="emit('select', row.original)">
-                      <SlidersHorizontal :size="16" aria-hidden="true" />
+                    <button
+                      class="row-action"
+                      type="button"
+                      title="Open certificate details"
+                      @click="emit('select', row.original)"
+                    >
+                      <SlidersHorizontal
+                        :size="16"
+                        aria-hidden="true"
+                      />
                     </button>
                   </td>
                 </tr>

--- a/src/Acmebot.App/ClientApp/src/components/ConfirmRevokeDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/ConfirmRevokeDialog.vue
@@ -8,7 +8,7 @@ import {
   AlertDialogOverlay,
   AlertDialogPortal,
   AlertDialogRoot,
-  AlertDialogTitle
+  AlertDialogTitle,
 } from 'reka-ui';
 
 defineProps<{
@@ -30,25 +30,46 @@ function handleOpenChange(open: boolean): void {
 </script>
 
 <template>
-  <AlertDialogRoot :open="open" @update:open="handleOpenChange">
+  <AlertDialogRoot
+    :open="open"
+    @update:open="handleOpenChange"
+  >
     <AlertDialogPortal>
       <AlertDialogOverlay class="modal-scrim" />
       <AlertDialogContent class="confirm-panel">
         <div class="confirm-panel__icon">
-          <AlertTriangle :size="22" aria-hidden="true" />
+          <AlertTriangle
+            :size="22"
+            aria-hidden="true"
+          />
         </div>
         <div class="confirm-panel__body">
-          <AlertDialogTitle class="confirm-panel__title">Revoke certificate</AlertDialogTitle>
+          <AlertDialogTitle class="confirm-panel__title">
+            Revoke certificate
+          </AlertDialogTitle>
           <AlertDialogDescription class="confirm-panel__description">
             This will revoke "{{ certificateName }}". Existing bindings that depend on this certificate may stop validating.
           </AlertDialogDescription>
         </div>
         <div class="confirm-panel__actions">
           <AlertDialogCancel as-child>
-            <button class="secondary-button" type="button" :disabled="busy">Cancel</button>
+            <button
+              class="secondary-button"
+              type="button"
+              :disabled="busy"
+            >
+              Cancel
+            </button>
           </AlertDialogCancel>
           <AlertDialogAction as-child>
-            <button class="danger-button" type="button" :disabled="busy" @click="emit('confirm')">Revoke</button>
+            <button
+              class="danger-button"
+              type="button"
+              :disabled="busy"
+              @click="emit('confirm')"
+            >
+              Revoke
+            </button>
           </AlertDialogAction>
         </div>
       </AlertDialogContent>

--- a/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
+++ b/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
@@ -6,7 +6,7 @@ import { displayDnsName, formatDateTime, getCategoryLabel, getCertificateCategor
 
 import StatusBadge from './StatusBadge.vue';
 
-const props = defineProps<{
+defineProps<{
   certificate: CertificateItem | null;
   open: boolean;
   busy: boolean;
@@ -22,16 +22,39 @@ const emit = defineEmits<{
 
 <template>
   <Teleport to="body">
-    <div v-if="open && certificate" class="drawer-shell" role="dialog" aria-modal="true" aria-labelledby="certificate-details-heading">
-      <button class="drawer-scrim" type="button" title="Close details" @click="emit('close')"></button>
+    <div
+      v-if="open && certificate"
+      class="drawer-shell"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="certificate-details-heading"
+    >
+      <button
+        class="drawer-scrim"
+        type="button"
+        title="Close details"
+        @click="emit('close')"
+      />
       <aside class="drawer">
         <header class="drawer__header">
           <div>
-            <div class="eyebrow">{{ getCategoryLabel(getCertificateCategory(certificate)) }}</div>
-            <h2 id="certificate-details-heading">{{ certificate.name }}</h2>
+            <div class="eyebrow">
+              {{ getCategoryLabel(getCertificateCategory(certificate)) }}
+            </div>
+            <h2 id="certificate-details-heading">
+              {{ certificate.name }}
+            </h2>
           </div>
-          <button class="icon-only-button" type="button" title="Close details" @click="emit('close')">
-            <X :size="18" aria-hidden="true" />
+          <button
+            class="icon-only-button"
+            type="button"
+            title="Close details"
+            @click="emit('close')"
+          >
+            <X
+              :size="18"
+              aria-hidden="true"
+            />
           </button>
         </header>
 
@@ -43,45 +66,81 @@ const emit = defineEmits<{
         <section class="detail-section">
           <div class="detail-section__heading">
             <h3>DNS Names</h3>
-            <button class="copy-button" type="button" title="Copy DNS names" @click="emit('copy', 'DNS names', certificate.dnsNames.join('\n'))">
-              <Copy :size="15" aria-hidden="true" />
+            <button
+              class="copy-button"
+              type="button"
+              title="Copy DNS names"
+              @click="emit('copy', 'DNS names', certificate.dnsNames.join('\n'))"
+            >
+              <Copy
+                :size="15"
+                aria-hidden="true"
+              />
             </button>
           </div>
           <div class="dns-list dns-list--stacked">
-            <span v-for="dnsName in certificate.dnsNames" :key="dnsName" class="dns-chip">{{ displayDnsName(dnsName) }}</span>
+            <span
+              v-for="dnsName in certificate.dnsNames"
+              :key="dnsName"
+              class="dns-chip"
+            >{{ displayDnsName(dnsName) }}</span>
           </div>
         </section>
 
-        <section class="detail-grid" aria-label="Certificate metadata">
+        <section
+          class="detail-grid"
+          aria-label="Certificate metadata"
+        >
           <div class="detail-item">
-            <CalendarDays :size="17" aria-hidden="true" />
+            <CalendarDays
+              :size="17"
+              aria-hidden="true"
+            />
             <div>
               <span>Created</span>
               <strong>{{ formatDateTime(certificate.createdOn) }}</strong>
             </div>
           </div>
           <div class="detail-item">
-            <ShieldCheck :size="17" aria-hidden="true" />
+            <ShieldCheck
+              :size="17"
+              aria-hidden="true"
+            />
             <div>
               <span>Validity</span>
               <strong>{{ getValidityDays(certificate) }} days</strong>
             </div>
           </div>
           <div class="detail-item">
-            <KeyRound :size="17" aria-hidden="true" />
+            <KeyRound
+              :size="17"
+              aria-hidden="true"
+            />
             <div>
               <span>Key</span>
               <strong>{{ certificate.keyType ?? '-' }} {{ certificate.keySize ? `${certificate.keySize} bit` : certificate.keyCurveName ?? '' }}</strong>
             </div>
           </div>
           <div class="detail-item detail-item--wide">
-            <Fingerprint :size="17" aria-hidden="true" />
+            <Fingerprint
+              :size="17"
+              aria-hidden="true"
+            />
             <div class="detail-item__body">
               <span>Thumbprint</span>
               <strong>{{ certificate.x509Thumbprint ?? '-' }}</strong>
             </div>
-            <button v-if="certificate.x509Thumbprint" class="copy-button" type="button" title="Copy thumbprint" @click="emit('copy', 'Thumbprint', certificate.x509Thumbprint)">
-              <Copy :size="15" aria-hidden="true" />
+            <button
+              v-if="certificate.x509Thumbprint"
+              class="copy-button"
+              type="button"
+              title="Copy thumbprint"
+              @click="emit('copy', 'Thumbprint', certificate.x509Thumbprint)"
+            >
+              <Copy
+                :size="15"
+                aria-hidden="true"
+              />
             </button>
           </div>
         </section>
@@ -92,7 +151,10 @@ const emit = defineEmits<{
             <div class="metadata-row">
               <dt>Issuer</dt>
               <dd>
-                <span class="metadata-chip" :class="certificate.isIssuedByAcmebot ? 'metadata-chip--success' : 'metadata-chip--neutral'">
+                <span
+                  class="metadata-chip"
+                  :class="certificate.isIssuedByAcmebot ? 'metadata-chip--success' : 'metadata-chip--neutral'"
+                >
                   {{ certificate.isIssuedByAcmebot ? 'Acmebot' : 'External' }}
                 </span>
               </dd>
@@ -100,7 +162,10 @@ const emit = defineEmits<{
             <div class="metadata-row">
               <dt>Current ACME endpoint</dt>
               <dd>
-                <span class="metadata-chip" :class="certificate.isSameEndpoint ? 'metadata-chip--success' : 'metadata-chip--warning'">
+                <span
+                  class="metadata-chip"
+                  :class="certificate.isSameEndpoint ? 'metadata-chip--success' : 'metadata-chip--warning'"
+                >
                   {{ certificate.isSameEndpoint ? 'Current' : 'Different' }}
                 </span>
               </dd>
@@ -108,22 +173,34 @@ const emit = defineEmits<{
             <div class="metadata-row">
               <dt>Reuse key</dt>
               <dd>
-                <span class="metadata-chip" :class="certificate.reuseKey ? 'metadata-chip--success' : 'metadata-chip--neutral'">
+                <span
+                  class="metadata-chip"
+                  :class="certificate.reuseKey ? 'metadata-chip--success' : 'metadata-chip--neutral'"
+                >
                   {{ certificate.reuseKey ? 'Enabled' : 'Disabled' }}
                 </span>
               </dd>
             </div>
-            <div v-if="certificate.dnsProviderName" class="metadata-row">
+            <div
+              v-if="certificate.dnsProviderName"
+              class="metadata-row"
+            >
               <dt>DNS provider</dt>
               <dd>{{ certificate.dnsProviderName }}</dd>
             </div>
-            <div v-if="certificate.dnsAlias" class="metadata-row metadata-row--stacked">
+            <div
+              v-if="certificate.dnsAlias"
+              class="metadata-row metadata-row--stacked"
+            >
               <dt>DNS alias</dt>
               <dd class="metadata-value-line">
                 <span class="metadata-value">{{ displayDnsName(certificate.dnsAlias ?? '') }}</span>
               </dd>
             </div>
-            <div v-if="certificate.acmeEndpoint" class="metadata-row metadata-row--stacked">
+            <div
+              v-if="certificate.acmeEndpoint"
+              class="metadata-row metadata-row--stacked"
+            >
               <dt>ACME endpoint</dt>
               <dd class="metadata-value-line">
                 <span class="metadata-value metadata-value--mono">{{ certificate.acmeEndpoint }}</span>
@@ -133,8 +210,16 @@ const emit = defineEmits<{
         </section>
 
         <footer class="drawer__footer">
-          <button class="primary-button" type="button" :disabled="busy" @click="emit('renew', certificate)">
-            <RotateCw :size="17" aria-hidden="true" />
+          <button
+            class="primary-button"
+            type="button"
+            :disabled="busy"
+            @click="emit('renew', certificate)"
+          >
+            <RotateCw
+              :size="17"
+              aria-hidden="true"
+            />
             <span>Renew</span>
           </button>
           <button
@@ -144,11 +229,20 @@ const emit = defineEmits<{
             :disabled="busy"
             @click="emit('revoke', certificate)"
           >
-            <Trash2 :size="17" aria-hidden="true" />
+            <Trash2
+              :size="17"
+              aria-hidden="true"
+            />
             <span>Revoke</span>
           </button>
-          <div v-else class="drawer__hint">
-            <AlertTriangle :size="15" aria-hidden="true" />
+          <div
+            v-else
+            class="drawer__hint"
+          >
+            <AlertTriangle
+              :size="15"
+              aria-hidden="true"
+            />
             Revoke is unavailable for this certificate.
           </div>
         </footer>

--- a/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
+++ b/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
@@ -7,7 +7,7 @@ import { displayDnsName, formatDateTime, getCategoryLabel, getCertificateCategor
 
 import StatusBadge from './StatusBadge.vue';
 
-defineProps<{
+const props = defineProps<{
   certificate: CertificateItem | null;
   open: boolean;
   busy: boolean;
@@ -213,15 +213,30 @@ const customTagsCopyText = computed(() => customTags.value.map(([key, value]) =>
           </dl>
         </section>
 
-        <section v-if="customTags.length > 0" class="detail-section">
+        <section
+          v-if="customTags.length > 0"
+          class="detail-section"
+        >
           <div class="detail-section__heading">
             <h3>Tags</h3>
-            <button class="copy-button" type="button" title="Copy tags" @click="emit('copy', 'Tags', customTagsCopyText)">
-              <Copy :size="15" aria-hidden="true" />
+            <button
+              class="copy-button"
+              type="button"
+              title="Copy tags"
+              @click="emit('copy', 'Tags', customTagsCopyText)"
+            >
+              <Copy
+                :size="15"
+                aria-hidden="true"
+              />
             </button>
           </div>
           <dl class="metadata-list">
-            <div v-for="[key, value] in customTags" :key="key" class="metadata-row metadata-row--stacked">
+            <div
+              v-for="[key, value] in customTags"
+              :key="key"
+              class="metadata-row metadata-row--stacked"
+            >
               <dt>{{ key }}</dt>
               <dd class="metadata-value-line">
                 <span class="metadata-value">{{ value || '-' }}</span>

--- a/src/Acmebot.App/ClientApp/src/components/OperationOverlay.vue
+++ b/src/Acmebot.App/ClientApp/src/components/OperationOverlay.vue
@@ -10,12 +10,28 @@ defineProps<{
 
 <template>
   <Teleport to="body">
-    <div v-if="active" class="operation-overlay" role="status" aria-live="polite">
+    <div
+      v-if="active"
+      class="operation-overlay"
+      role="status"
+      aria-live="polite"
+    >
       <div class="operation-overlay__panel">
-        <LoaderCircle class="operation-overlay__spinner" :size="28" aria-hidden="true" />
+        <LoaderCircle
+          class="operation-overlay__spinner"
+          :size="28"
+          aria-hidden="true"
+        />
         <div>
-          <div class="operation-overlay__title">{{ title }}</div>
-          <div v-if="message" class="operation-overlay__message">{{ message }}</div>
+          <div class="operation-overlay__title">
+            {{ title }}
+          </div>
+          <div
+            v-if="message"
+            class="operation-overlay__message"
+          >
+            {{ message }}
+          </div>
         </div>
       </div>
     </div>

--- a/src/Acmebot.App/ClientApp/src/components/SearchableZoneSelect.vue
+++ b/src/Acmebot.App/ClientApp/src/components/SearchableZoneSelect.vue
@@ -11,7 +11,7 @@ import {
   ComboboxLabel,
   ComboboxRoot,
   ComboboxTrigger,
-  ComboboxViewport
+  ComboboxViewport,
 } from 'reka-ui';
 import { computed, ref, watch } from 'vue';
 
@@ -48,9 +48,9 @@ const allOptions = computed<ZoneOption[]>(() =>
       ...zone,
       dnsProviderName: group.dnsProviderName,
       displayName: displayDnsName(zone.name),
-      key: `${group.dnsProviderName}:${zone.name}`
-    }))
-  )
+      key: `${group.dnsProviderName}:${zone.name}`,
+    })),
+  ),
 );
 
 const groupedOptions = computed<GroupedOptions[]>(() => {
@@ -70,7 +70,7 @@ watch(
   (selected) => {
     selectedKey.value = selected ? `${selected.dnsProviderName}:${selected.name}` : '';
   },
-  { immediate: true }
+  { immediate: true },
 );
 
 watch(selectedKey, (key) => {
@@ -83,7 +83,7 @@ watch(selectedKey, (key) => {
 
   emit('update:selected', {
     name: option.name,
-    dnsProviderName: option.dnsProviderName
+    dnsProviderName: option.dnsProviderName,
   });
 });
 
@@ -99,42 +99,84 @@ function clearSelection(): void {
 </script>
 
 <template>
-  <ComboboxRoot v-model="selectedKey" class="combobox" open-on-focus open-on-click reset-search-term-on-select>
+  <ComboboxRoot
+    v-model="selectedKey"
+    class="combobox"
+    open-on-focus
+    open-on-click
+    reset-search-term-on-select
+  >
     <ComboboxAnchor class="combobox__control">
-      <Search class="combobox__search-icon" :size="16" aria-hidden="true" />
+      <Search
+        class="combobox__search-icon"
+        :size="16"
+        aria-hidden="true"
+      />
       <ComboboxInput
         class="combobox__input"
         :display-value="displaySelectedValue"
         placeholder="Search DNS zone"
       />
-      <button v-if="selected" class="combobox__clear" type="button" title="Clear selected zone" @click="clearSelection">
+      <button
+        v-if="selected"
+        class="combobox__clear"
+        type="button"
+        title="Clear selected zone"
+        @click="clearSelection"
+      >
         Clear
       </button>
-      <ComboboxTrigger class="combobox__toggle" title="Open DNS zone list">
-        <ChevronDown :size="16" aria-hidden="true" />
+      <ComboboxTrigger
+        class="combobox__toggle"
+        title="Open DNS zone list"
+      >
+        <ChevronDown
+          :size="16"
+          aria-hidden="true"
+        />
       </ComboboxTrigger>
     </ComboboxAnchor>
 
-    <ComboboxContent class="combobox__popover" position="popper" :side-offset="8">
-      <div v-if="loading" class="combobox__state">Loading DNS zones...</div>
+    <ComboboxContent
+      class="combobox__popover"
+      position="popper"
+      :side-offset="8"
+    >
+      <div
+        v-if="loading"
+        class="combobox__state"
+      >
+        Loading DNS zones...
+      </div>
       <template v-else>
         <ComboboxViewport>
-          <ComboboxEmpty class="combobox__state">No DNS zones found</ComboboxEmpty>
-          <ComboboxGroup v-for="group in groupedOptions" :key="group.providerName" class="combobox__group">
-            <ComboboxLabel class="combobox__group-label">{{ group.providerName }}</ComboboxLabel>
-            <ComboboxItem
-            v-for="option in group.options"
-            :key="option.key"
-            class="combobox__option"
-            :value="option.key"
-            :text-value="`${option.displayName} ${option.name} ${option.dnsProviderName}`"
+          <ComboboxEmpty class="combobox__state">
+            No DNS zones found
+          </ComboboxEmpty>
+          <ComboboxGroup
+            v-for="group in groupedOptions"
+            :key="group.providerName"
+            class="combobox__group"
           >
+            <ComboboxLabel class="combobox__group-label">
+              {{ group.providerName }}
+            </ComboboxLabel>
+            <ComboboxItem
+              v-for="option in group.options"
+              :key="option.key"
+              class="combobox__option"
+              :value="option.key"
+              :text-value="`${option.displayName} ${option.name} ${option.dnsProviderName}`"
+            >
               <span>
                 <span class="combobox__option-name">{{ option.displayName }}</span>
                 <span class="combobox__option-meta">{{ option.name }}</span>
               </span>
               <ComboboxItemIndicator class="combobox__indicator">
-                <Check :size="15" aria-hidden="true" />
+                <Check
+                  :size="15"
+                  aria-hidden="true"
+                />
               </ComboboxItemIndicator>
             </ComboboxItem>
           </ComboboxGroup>

--- a/src/Acmebot.App/ClientApp/src/components/StatusBadge.vue
+++ b/src/Acmebot.App/ClientApp/src/components/StatusBadge.vue
@@ -12,8 +12,14 @@ const status = computed(() => getCertificateStatus(props.certificate));
 </script>
 
 <template>
-  <span class="status-badge" :class="`status-badge--${status.kind}`">
-    <span class="status-badge__dot" aria-hidden="true"></span>
+  <span
+    class="status-badge"
+    :class="`status-badge--${status.kind}`"
+  >
+    <span
+      class="status-badge__dot"
+      aria-hidden="true"
+    />
     {{ status.label }}
   </span>
 </template>

--- a/src/Acmebot.App/ClientApp/src/components/ToastStack.vue
+++ b/src/Acmebot.App/ClientApp/src/components/ToastStack.vue
@@ -20,21 +20,46 @@ const icons = {
   success: CheckCircle2,
   error: XCircle,
   warning: AlertTriangle,
-  info: Info
+  info: Info,
 };
 </script>
 
 <template>
   <Teleport to="body">
-    <div class="toast-stack" aria-live="polite">
-      <div v-for="message in messages" :key="message.id" class="toast" :class="`toast--${message.type}`">
-        <component :is="icons[message.type]" class="toast__icon" :size="18" aria-hidden="true" />
+    <div
+      class="toast-stack"
+      aria-live="polite"
+    >
+      <div
+        v-for="message in messages"
+        :key="message.id"
+        class="toast"
+        :class="`toast--${message.type}`"
+      >
+        <component
+          :is="icons[message.type]"
+          class="toast__icon"
+          :size="18"
+          aria-hidden="true"
+        />
         <div class="toast__body">
-          <div class="toast__title">{{ message.title }}</div>
-          <div class="toast__message">{{ message.message }}</div>
+          <div class="toast__title">
+            {{ message.title }}
+          </div>
+          <div class="toast__message">
+            {{ message.message }}
+          </div>
         </div>
-        <button class="toast__dismiss" type="button" title="Dismiss notification" @click="emit('dismiss', message.id)">
-          <X :size="16" aria-hidden="true" />
+        <button
+          class="toast__dismiss"
+          type="button"
+          title="Dismiss notification"
+          @click="emit('dismiss', message.id)"
+        >
+          <X
+            :size="16"
+            aria-hidden="true"
+          />
         </button>
       </div>
     </div>

--- a/src/Acmebot.App/ClientApp/src/utils/certificates.ts
+++ b/src/Acmebot.App/ClientApp/src/utils/certificates.ts
@@ -28,7 +28,7 @@ export function getCategoryLabel(category: CertificateCategory): string {
   const labels: Record<CertificateCategory, string> = {
     managed: 'Managed',
     'other-ca': 'Other CA',
-    unmanaged: 'Unmanaged'
+    unmanaged: 'Unmanaged',
   };
 
   return labels[category];
@@ -88,7 +88,7 @@ export function formatDate(value?: string | null): string {
   return new Intl.DateTimeFormat(undefined, {
     year: 'numeric',
     month: 'short',
-    day: '2-digit'
+    day: '2-digit',
   }).format(new Date(value));
 }
 
@@ -102,7 +102,7 @@ export function formatDateTime(value?: string | null): string {
     month: 'short',
     day: '2-digit',
     hour: '2-digit',
-    minute: '2-digit'
+    minute: '2-digit',
   }).format(new Date(value));
 }
 
@@ -137,7 +137,7 @@ function findMatchingDnsZone(certificate: CertificateItem, dnsZoneGroups: DnsZon
   }
 
   const candidateZoneNames = (providerZoneNames.size > 0 ? Array.from(providerZoneNames) : Array.from(allZoneNames)).toSorted(
-    (left, right) => left.length - right.length || left.localeCompare(right)
+    (left, right) => left.length - right.length || left.localeCompare(right),
   );
 
   for (const dnsName of certificate.dnsNames) {

--- a/src/Acmebot.App/ClientApp/vite.config.ts
+++ b/src/Acmebot.App/ClientApp/vite.config.ts
@@ -31,17 +31,17 @@ export default defineConfig({
   plugins: [vue()],
   define: {
     __ACMEBOT_DASHBOARD_VERSION__: JSON.stringify(dashboardVersion),
-    __ACMEBOT_DASHBOARD_COMMIT_HASH__: JSON.stringify(dashboardCommitHash)
+    __ACMEBOT_DASHBOARD_COMMIT_HASH__: JSON.stringify(dashboardCommitHash),
   },
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
-    }
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
   },
   build: {
     outDir: '../wwwroot/dashboard-vnext',
     emptyOutDir: true,
-    sourcemap: buildSourceMap
+    sourcemap: buildSourceMap,
   },
   server: {
     port: 5173,
@@ -49,9 +49,9 @@ export default defineConfig({
       ? {
           '/api': {
             target: apiOrigin,
-            changeOrigin: true
-          }
+            changeOrigin: true,
+          },
         }
-      : undefined
-  }
+      : undefined,
+  },
 });

--- a/src/Acmebot.App/Extensions/CertificateExtensions.cs
+++ b/src/Acmebot.App/Extensions/CertificateExtensions.cs
@@ -170,6 +170,11 @@ internal static class CertificateExtensions
 
     private static Dictionary<string, string> GetCustomCertificateTags(this IDictionary<string, string> tags)
     {
+        if (tags is null)
+        {
+            return [];
+        }
+
         string[] internalTagKeys = tags.Keys.Contains(AcmebotTagKey, StringComparer.OrdinalIgnoreCase)
             ? [AcmebotTagKey]
             : [AcmebotTagKey, LegacyIssuerKey, LegacyEndpointKey, LegacyDnsProviderKey, LegacyDnsAliasKey];


### PR DESCRIPTION
This pull request introduces linting and formatting support for the Vite + Vue 3 + TypeScript Acmebot dashboard, along with code style improvements and documentation updates. The main changes add ESLint with a flat config and stylistic rules, integrate lint and format scripts into the workflow and documentation, and apply consistent code formatting across the codebase.

**Linting and formatting infrastructure:**

* Added ESLint flat config with ESLint Stylistic and Vue/TypeScript support via a new `eslint.config.js` file, and updated `package.json` to include ESLint and related plugins in `devDependencies`. [[1]](diffhunk://#diff-05560d99203faa918ba039e8b64716ff7f532093fe90f6d75bc4843d24a20cfeR1-R108) [[2]](diffhunk://#diff-7a1939297b19e29a5c2ae8685bd565b826037f849890c6abc6b45ed396be9f46R23-R33)
* Introduced `npm run lint`, `npm run lint:fix`, `npm run format`, and `npm run format:check` scripts in `package.json` for linting and formatting tasks.
* Updated the build workflow (`.github/workflows/build.yml`) to run `npm run lint` as part of the CI process.

**Documentation updates:**

* Updated `README.md` to document the new linting and formatting commands, and explain how ESLint flat config is used for code quality.

**Formatting and code style improvements:**

* Applied consistent trailing commas and formatting to JavaScript/TypeScript/Vue files, including `App.vue`, `acmebotApi.ts`, and `mockData.ts`, to comply with the new linting rules. [[1]](diffhunk://#diff-fe59cab7dd39721786e8226aba25fd58919aada2efdd29328917b0066612788cL28-R39) [[2]](diffhunk://#diff-a1703ffb391c4f0c11cc63f6a69da4a05e193152ad28eddeb492cd735f6e0b77L9-R9) [[3]](diffhunk://#diff-cdea3bb27af2a238de5655e0dc14553ed8b16d5d150abf944a09711d06256d52L29-R29)
* Improved template formatting and attribute layout in `App.vue` for better readability and consistency. [[1]](diffhunk://#diff-fe59cab7dd39721786e8226aba25fd58919aada2efdd29328917b0066612788cL187-R254) [[2]](diffhunk://#diff-fe59cab7dd39721786e8226aba25fd58919aada2efdd29328917b0066612788cL231-R272) [[3]](diffhunk://#diff-fe59cab7dd39721786e8226aba25fd58919aada2efdd29328917b0066612788cL241-R284) [[4]](diffhunk://#diff-fe59cab7dd39721786e8226aba25fd58919aada2efdd29328917b0066612788cL275-R326)