### PR TITLE
Refactor dashboard versioning and upgrade notification system

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,8 +42,8 @@ jobs:
     - name: Build Dashboard
       working-directory: ./src/Acmebot.App/ClientApp
       env:
-        ACMEBOT_DASHBOARD_VERSION: ${{ steps.setup_version.outputs.version }}
-        ACMEBOT_DASHBOARD_COMMIT: ${{ github.sha }}
+        ACMEBOT_VERSION: ${{ steps.setup_version.outputs.version }}
+        ACMEBOT_COMMIT_HASH: ${{ github.sha }}
       run: |
         npm ci
         npm run build

--- a/src/Acmebot.App/ClientApp/README.md
+++ b/src/Acmebot.App/ClientApp/README.md
@@ -19,7 +19,9 @@ Production builds always call the same-origin `/api/*` Azure Functions endpoints
 
 Source maps are disabled by default for deployable output. Set `ACMEBOT_BUILD_SOURCEMAP=true` before `npm run build` when you need browser debugging symbols.
 
-The dashboard footer displays build metadata embedded by Vite at build time. Set `ACMEBOT_DASHBOARD_VERSION` to the release version and `ACMEBOT_DASHBOARD_COMMIT` to the source commit hash before `npm run build`; when the commit variable is omitted, GitHub Actions `GITHUB_SHA` is used if available.
+The dashboard footer displays Acmebot build metadata embedded by Vite at build time. Set `ACMEBOT_VERSION` to the Acmebot release version and `ACMEBOT_COMMIT_HASH` to the source commit hash before `npm run build`; when the version variable is omitted, `v1.0.0` is used, and when the commit hash variable is omitted, GitHub Actions `GITHUB_SHA` is used if available. Version and commit values link to the matching GitHub release and commit when possible.
+
+When the embedded Acmebot version is a release-like value such as `v5.0.0`, the dashboard checks Acmebot GitHub releases, including prereleases, and shows an upgrade notification when a newer version is available. Non-version values such as `dev` skip this check.
 
 For local API proxying during Vite development, set `ACMEBOT_API_ORIGIN` to an Azure Functions host, for example `http://localhost:7071`.
 

--- a/src/Acmebot.App/ClientApp/eslint.config.js
+++ b/src/Acmebot.App/ClientApp/eslint.config.js
@@ -24,8 +24,8 @@ export default defineConfig([
       sourceType: 'module',
       globals: {
         ...globals.browser,
-        __ACMEBOT_DASHBOARD_COMMIT_HASH__: 'readonly',
-        __ACMEBOT_DASHBOARD_VERSION__: 'readonly',
+        __ACMEBOT_COMMIT_HASH__: 'readonly',
+        __ACMEBOT_VERSION__: 'readonly',
       },
     },
   },

--- a/src/Acmebot.App/ClientApp/src/App.vue
+++ b/src/Acmebot.App/ClientApp/src/App.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue';
-import { Activity, AlertTriangle, BadgeCheck, CircleSlash, Shield, ShieldAlert, ShieldCheck } from 'lucide-vue-next';
+import { Activity, AlertTriangle, BadgeCheck, CircleSlash, ExternalLink, Info, Shield, ShieldAlert, ShieldCheck, X } from 'lucide-vue-next';
 
 import { formatApiError, getCertificates, getDnsZones, issueCertificate, renewCertificate, revokeCertificate } from '@/api/acmebotApi';
-import type { CertificateItem, CertificatePolicyItem, DnsZoneGroup } from '@/api/types';
+import { getLatestRelease } from '@/api/releases';
+import type { CertificateItem, CertificatePolicyItem, DnsZoneGroup, ReleaseInfo } from '@/api/types';
 import AddCertificateDialog from '@/components/AddCertificateDialog.vue';
 import CertificateTable from '@/components/CertificateTable.vue';
 import ConfirmRevokeDialog from '@/components/ConfirmRevokeDialog.vue';
@@ -11,6 +12,7 @@ import DetailsDrawer from '@/components/DetailsDrawer.vue';
 import OperationOverlay from '@/components/OperationOverlay.vue';
 import ToastStack, { type ToastMessage } from '@/components/ToastStack.vue';
 import { getCertificateCategory, getCertificateStatus } from '@/utils/certificates';
+import { isNewerVersion, isVersionLike } from '@/utils/versions';
 
 const certificates = ref<CertificateItem[]>([]);
 const dnsZoneGroups = ref<DnsZoneGroup[]>([]);
@@ -19,9 +21,12 @@ const pendingRevokeCertificate = ref<CertificateItem | null>(null);
 const addDialogOpen = ref(false);
 const detailsBusy = ref(false);
 const toasts = ref<ToastMessage[]>([]);
+const upgradeNotice = ref<ReleaseInfo | null>(null);
 let toastId = 0;
-const dashboardVersion = __ACMEBOT_DASHBOARD_VERSION__;
-const dashboardCommitHash = __ACMEBOT_DASHBOARD_COMMIT_HASH__;
+const acmebotVersion = __ACMEBOT_VERSION__;
+const acmebotCommitHash = __ACMEBOT_COMMIT_HASH__;
+const acmebotRepositoryUrl = 'https://github.com/polymind-inc/acmebot';
+const dismissedUpgradeStorageKey = 'acmebot.dismissedUpgradeVersion';
 
 const certificateState = reactive({
   loading: false,
@@ -66,12 +71,65 @@ const summaryItems = computed(() => [
   { label: 'Unmanaged', value: summary.value.unmanaged, tone: 'neutral', icon: CircleSlash },
 ]);
 
-const dashboardCommitLabel = computed(() => (dashboardCommitHash.length > 7 ? dashboardCommitHash.slice(0, 7) : dashboardCommitHash));
+const acmebotCommitLabel = computed(() => (acmebotCommitHash.length > 7 ? acmebotCommitHash.slice(0, 7) : acmebotCommitHash));
+const acmebotVersionUrl = computed(() => (isVersionLike(acmebotVersion) ? `${acmebotRepositoryUrl}/releases/tag/${encodeURIComponent(acmebotVersion)}` : null));
+const acmebotCommitUrl = computed(() => (isCommitHashLike(acmebotCommitHash) ? `${acmebotRepositoryUrl}/commit/${encodeURIComponent(acmebotCommitHash)}` : null));
 
 onMounted(async () => {
+  void loadUpgradeNotice();
   await loadCertificates();
   await loadDnsZones(false);
 });
+
+async function loadUpgradeNotice(): Promise<void> {
+  if (!isVersionLike(acmebotVersion)) {
+    return;
+  }
+
+  try {
+    const latestRelease = await getLatestRelease();
+
+    if (!latestRelease || !isNewerVersion(latestRelease.version, acmebotVersion)) {
+      return;
+    }
+
+    if (getDismissedUpgradeVersion() === latestRelease.version) {
+      return;
+    }
+
+    upgradeNotice.value = latestRelease;
+  } catch {
+    return;
+  }
+}
+
+function getDismissedUpgradeVersion(): string | null {
+  try {
+    return window.localStorage.getItem(dismissedUpgradeStorageKey);
+  } catch {
+    return null;
+  }
+}
+
+function rememberDismissedUpgradeVersion(version: string): void {
+  try {
+    window.localStorage.setItem(dismissedUpgradeStorageKey, version);
+  } catch {
+    return;
+  }
+}
+
+function dismissUpgradeNotice(): void {
+  if (upgradeNotice.value) {
+    rememberDismissedUpgradeVersion(upgradeNotice.value.version);
+  }
+
+  upgradeNotice.value = null;
+}
+
+function isCommitHashLike(value: string): boolean {
+  return /^[0-9a-f]{7,40}$/i.test(value.trim());
+}
 
 function pushToast(type: ToastMessage['type'], title: string, message: string): void {
   const id = ++toastId;
@@ -217,6 +275,44 @@ async function confirmRevokeCertificate(): Promise<void> {
         Certificate Operations
       </h1>
 
+      <div
+        v-if="upgradeNotice"
+        class="banner banner--upgrade"
+        role="status"
+      >
+        <Info
+          :size="17"
+          aria-hidden="true"
+        />
+        <div class="banner__body">
+          <span class="banner__title">Acmebot {{ upgradeNotice.version }} is available</span>
+          <span class="banner__message">This Acmebot installation is running {{ acmebotVersion }}.</span>
+        </div>
+        <a
+          class="secondary-button banner__action"
+          :href="upgradeNotice.releaseUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <ExternalLink
+            :size="15"
+            aria-hidden="true"
+          />
+          Release notes
+        </a>
+        <button
+          class="icon-only-button banner__dismiss"
+          type="button"
+          title="Dismiss upgrade notification"
+          @click="dismissUpgradeNotice"
+        >
+          <X
+            :size="16"
+            aria-hidden="true"
+          />
+        </button>
+      </div>
+
       <section
         class="summary-grid"
         aria-label="Certificate summary"
@@ -268,19 +364,39 @@ async function confirmRevokeCertificate(): Promise<void> {
 
     <footer
       class="app-footer"
-      aria-label="Dashboard build metadata"
+      aria-label="Acmebot build metadata"
     >
       <div class="app-footer__inner">
-        <span>Acmebot Dashboard</span>
+        <span>Acmebot</span>
         <dl class="build-metadata">
           <div class="build-metadata__item">
             <dt>Version</dt>
-            <dd>{{ dashboardVersion }}</dd>
+            <dd>
+              <a
+                v-if="acmebotVersionUrl"
+                class="build-metadata__link"
+                :href="acmebotVersionUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+              >{{ acmebotVersion }}</a>
+              <span v-else>{{ acmebotVersion }}</span>
+            </dd>
           </div>
           <div class="build-metadata__item">
             <dt>Commit</dt>
-            <dd :title="dashboardCommitHash">
-              {{ dashboardCommitLabel }}
+            <dd>
+              <a
+                v-if="acmebotCommitUrl"
+                class="build-metadata__link"
+                :href="acmebotCommitUrl"
+                :title="acmebotCommitHash"
+                target="_blank"
+                rel="noopener noreferrer"
+              >{{ acmebotCommitLabel }}</a>
+              <span
+                v-else
+                :title="acmebotCommitHash"
+              >{{ acmebotCommitLabel }}</span>
             </dd>
           </div>
         </dl>

--- a/src/Acmebot.App/ClientApp/src/api/releases.ts
+++ b/src/Acmebot.App/ClientApp/src/api/releases.ts
@@ -1,0 +1,40 @@
+import type { ReleaseInfo } from './types';
+import { isNewerVersion, isVersionLike } from '@/utils/versions';
+
+const releasesEndpoint = 'https://api.github.com/repos/polymind-inc/acmebot/releases?per_page=10';
+
+interface GitHubReleaseResponse {
+  tag_name?: unknown;
+  html_url?: unknown;
+}
+
+export async function getLatestRelease(): Promise<ReleaseInfo | null> {
+  const response = await fetch(releasesEndpoint, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+    },
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const releases = await response.json() as GitHubReleaseResponse[];
+
+  return releases.reduce<ReleaseInfo | null>((latestRelease, release) => {
+    if (typeof release.tag_name !== 'string' || typeof release.html_url !== 'string' || !isVersionLike(release.tag_name)) {
+      return latestRelease;
+    }
+
+    const releaseInfo = {
+      version: release.tag_name,
+      releaseUrl: release.html_url,
+    };
+
+    if (!latestRelease || isNewerVersion(releaseInfo.version, latestRelease.version)) {
+      return releaseInfo;
+    }
+
+    return latestRelease;
+  }, null);
+}

--- a/src/Acmebot.App/ClientApp/src/api/types.ts
+++ b/src/Acmebot.App/ClientApp/src/api/types.ts
@@ -54,3 +54,8 @@ export interface ProblemDetails {
   output?: string;
   errors?: Record<string, string[]>;
 }
+
+export interface ReleaseInfo {
+  version: string;
+  releaseUrl: string;
+}

--- a/src/Acmebot.App/ClientApp/src/styles/app.css
+++ b/src/Acmebot.App/ClientApp/src/styles/app.css
@@ -157,6 +157,16 @@
   font-weight: 700;
 }
 
+.build-metadata__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.build-metadata__link:hover {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+
 .eyebrow {
   color: var(--color-accent);
   font-size: 0.78rem;
@@ -225,6 +235,44 @@ p {
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
   background: var(--color-surface);
+}
+
+.banner__body {
+  min-width: 0;
+  flex: 1;
+  display: grid;
+  gap: 2px;
+}
+
+.banner__title {
+  font-size: 0.9rem;
+  font-weight: 750;
+  overflow-wrap: anywhere;
+}
+
+.banner__message {
+  color: var(--color-muted);
+  font-size: 0.82rem;
+  overflow-wrap: anywhere;
+}
+
+.banner__action {
+  margin-left: auto;
+  text-decoration: none;
+}
+
+.banner__dismiss {
+  flex: 0 0 auto;
+}
+
+.banner--upgrade {
+  color: var(--color-accent);
+  border-color: #c7e0f4;
+  background: #fbfdff;
+}
+
+.banner--upgrade .banner__body {
+  color: var(--color-text);
 }
 
 .banner--error {
@@ -1671,5 +1719,17 @@ button:disabled {
     right: 12px;
     bottom: 12px;
     width: calc(100vw - 24px);
+  }
+
+  .banner--upgrade {
+    align-items: flex-start;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .banner__action.secondary-button {
+    grid-column: 2 / -1;
+    margin-left: 0;
+    width: max-content;
   }
 }

--- a/src/Acmebot.App/ClientApp/src/utils/versions.ts
+++ b/src/Acmebot.App/ClientApp/src/utils/versions.ts
@@ -1,0 +1,121 @@
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+const semanticVersionPattern = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export function isVersionLike(value: string): boolean {
+  return parseVersion(value) !== null;
+}
+
+export function isNewerVersion(candidate: string, current: string): boolean {
+  const candidateVersion = parseVersion(candidate);
+  const currentVersion = parseVersion(current);
+
+  if (!candidateVersion || !currentVersion) {
+    return false;
+  }
+
+  const numericComparison = compareNumericVersion(candidateVersion, currentVersion);
+
+  if (numericComparison !== 0) {
+    return numericComparison > 0;
+  }
+
+  return comparePrerelease(candidateVersion.prerelease, currentVersion.prerelease) > 0;
+}
+
+function parseVersion(value: string): ParsedVersion | null {
+  const match = semanticVersionPattern.exec(value.trim());
+
+  if (!match) {
+    return null;
+  }
+
+  const [, major, minor = '0', patch = '0', prerelease = ''] = match;
+
+  return {
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+    prerelease: prerelease ? prerelease.split('.') : [],
+  };
+}
+
+function compareNumericVersion(candidate: ParsedVersion, current: ParsedVersion): number {
+  const candidateParts = [candidate.major, candidate.minor, candidate.patch];
+  const currentParts = [current.major, current.minor, current.patch];
+
+  for (const [index, candidatePart] of candidateParts.entries()) {
+    const difference = candidatePart - currentParts[index];
+
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+function comparePrerelease(candidate: string[], current: string[]): number {
+  if (candidate.length === 0 && current.length > 0) {
+    return 1;
+  }
+
+  if (candidate.length > 0 && current.length === 0) {
+    return -1;
+  }
+
+  const length = Math.max(candidate.length, current.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const candidateIdentifier = candidate[index];
+    const currentIdentifier = current[index];
+
+    if (candidateIdentifier === undefined) {
+      return -1;
+    }
+
+    if (currentIdentifier === undefined) {
+      return 1;
+    }
+
+    const comparison = comparePrereleaseIdentifier(candidateIdentifier, currentIdentifier);
+
+    if (comparison !== 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+function comparePrereleaseIdentifier(candidate: string, current: string): number {
+  const candidateNumber = parseNumericIdentifier(candidate);
+  const currentNumber = parseNumericIdentifier(current);
+
+  if (candidateNumber !== null && currentNumber !== null) {
+    return candidateNumber - currentNumber;
+  }
+
+  if (candidateNumber !== null) {
+    return -1;
+  }
+
+  if (currentNumber !== null) {
+    return 1;
+  }
+
+  return candidate.localeCompare(current);
+}
+
+function parseNumericIdentifier(value: string): number | null {
+  if (!/^\d+$/.test(value)) {
+    return null;
+  }
+
+  return Number(value);
+}

--- a/src/Acmebot.App/ClientApp/src/vite-env.d.ts
+++ b/src/Acmebot.App/ClientApp/src/vite-env.d.ts
@@ -1,4 +1,4 @@
 /// <reference types="vite/client" />
 
-declare const __ACMEBOT_DASHBOARD_VERSION__: string;
-declare const __ACMEBOT_DASHBOARD_COMMIT_HASH__: string;
+declare const __ACMEBOT_VERSION__: string;
+declare const __ACMEBOT_COMMIT_HASH__: string;

--- a/src/Acmebot.App/ClientApp/vite.config.ts
+++ b/src/Acmebot.App/ClientApp/vite.config.ts
@@ -5,14 +5,14 @@ import { defineConfig } from 'vite';
 
 const apiOrigin = process.env.ACMEBOT_API_ORIGIN;
 const buildSourceMap = process.env.ACMEBOT_BUILD_SOURCEMAP === 'true';
-const dashboardVersion = normalizeVersion(process.env.ACMEBOT_DASHBOARD_VERSION);
-const dashboardCommitHash = normalizeCommitHash(process.env.ACMEBOT_DASHBOARD_COMMIT ?? process.env.GITHUB_SHA);
+const acmebotVersion = normalizeVersion(process.env.ACMEBOT_VERSION);
+const acmebotCommitHash = normalizeCommitHash(process.env.ACMEBOT_COMMIT_HASH ?? process.env.GITHUB_SHA);
 
 function normalizeVersion(value: string | undefined): string {
   const version = value?.trim();
 
   if (!version) {
-    return 'dev';
+    return 'v1.0.0';
   }
 
   if (/^v?\d/i.test(version)) {
@@ -30,8 +30,8 @@ export default defineConfig({
   base: '/dashboard-vnext/',
   plugins: [vue()],
   define: {
-    __ACMEBOT_DASHBOARD_VERSION__: JSON.stringify(dashboardVersion),
-    __ACMEBOT_DASHBOARD_COMMIT_HASH__: JSON.stringify(dashboardCommitHash),
+    __ACMEBOT_VERSION__: JSON.stringify(acmebotVersion),
+    __ACMEBOT_COMMIT_HASH__: JSON.stringify(acmebotCommitHash),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
This pull request introduces a user-visible upgrade notification system to the Acmebot dashboard, informing users when a newer release is available. It also standardizes and improves the handling and display of build metadata (version and commit hash) throughout the dashboard, replacing previous variable names and logic with more consistent and robust implementations. Additionally, the changes include improvements to version parsing and comparison utilities, and related updates to documentation and styling.

**Upgrade notification and version handling improvements:**

* Added a new upgrade notification banner to `App.vue` that checks GitHub releases and informs users when a newer Acmebot version is available; users can dismiss the notification, which is remembered in local storage. [[1]](diffhunk://#diff-fe59cab7dd39721786e8226aba25fd58919aada2efdd29328917b0066612788cL69-R133) [[2]](diffhunk://#diff-fe59cab7dd39721786e8226aba25fd58919aada2efdd29328917b0066612788cR278-R315) [[3]](diffhunk://#diff-fe59cab7dd39721786e8226aba25fd58919aada2efdd29328917b0066612788cR24-R29) [[4]](diffhunk://#diff-2aa42f85b9c02c18420919b7d984d8e876279e8eacbf837e7e10290c727ababbR1-R40) [[5]](diffhunk://#diff-1dede859c5c0d96d41465cb9900058f86ebe3e95a60daa1e05e51ad7c642a254R57-R61)
* Implemented new utility functions in `utils/versions.ts` for parsing, validating, and comparing semantic versions, including prerelease handling, to reliably determine if an upgrade is available.

**Build metadata and environment variable standardization:**

* Replaced `ACMEBOT_DASHBOARD_VERSION` and `ACMEBOT_DASHBOARD_COMMIT` with `ACMEBOT_VERSION` and `ACMEBOT_COMMIT_HASH` across the codebase, including in build scripts, environment variables, and global definitions. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L45-R46) [[2]](diffhunk://#diff-98b1f656854a01dddae4f6fb92f1f5b2ba2f73d17c8e2139dfc5e06df3ca03e5L8-R15) [[3]](diffhunk://#diff-98b1f656854a01dddae4f6fb92f1f5b2ba2f73d17c8e2139dfc5e06df3ca03e5L33-R34) [[4]](diffhunk://#diff-05560d99203faa918ba039e8b64716ff7f532093fe90f6d75bc4843d24a20cfeL27-R28)
* Updated the dashboard footer to display Acmebot version and commit as clickable links to the corresponding GitHub release and commit, when possible. [[1]](diffhunk://#diff-fe59cab7dd39721786e8226aba25fd58919aada2efdd29328917b0066612788cL271-R399) [[2]](diffhunk://#diff-7267265ad7b148d3d512b93091b629179918742f55bb0330c1b762cd0edd22fbR160-R169)

**Documentation and styling updates:**

* Revised the `README.md` to document the new environment variable names, the default versioning behavior, and the upgrade notification feature.
* Added and improved CSS for the upgrade notification banner and build metadata links to ensure clear and accessible presentation. [[1]](diffhunk://#diff-7267265ad7b148d3d512b93091b629179918742f55bb0330c1b762cd0edd22fbR240-R277) [[2]](diffhunk://#diff-7267265ad7b148d3d512b93091b629179918742f55bb0330c1b762cd0edd22fbR1723-R1734)