### PR TITLE
Add Bicep and JSON templates for Acmebot Function App update deployment

### DIFF
--- a/deploy/azuredeploy_update.bicep
+++ b/deploy/azuredeploy_update.bicep
@@ -1,0 +1,43 @@
+targetScope = 'resourceGroup'
+
+@description('Name of the existing Acmebot Function App to update.')
+@minLength(1)
+param functionAppName string
+
+@description('Acmebot major version channel to deploy.')
+@allowed([
+  'v5'
+])
+param majorVersion string = 'v5'
+
+@description('Acmebot version to deploy. Use latest or a specific v5 version such as 5.0.0 or v5.0.0.')
+@minLength(1)
+param targetVersion string = 'latest'
+
+var versionIsLatest = toLower(targetVersion) == 'latest'
+var normalizedTargetVersion = startsWith(toLower(targetVersion), 'v')
+  ? substring(targetVersion, 1, length(targetVersion) - 1)
+  : targetVersion
+var packageFileName = versionIsLatest ? 'latest.zip' : '${normalizedTargetVersion}.zip'
+
+#disable-next-line no-hardcoded-env-urls
+var appPackageUri = 'https://stacmebotprod.blob.core.windows.net/acmebot/${majorVersion}/${packageFileName}'
+
+resource functionApp 'Microsoft.Web/sites@2025-03-01' existing = {
+  name: functionAppName
+}
+
+resource functionAppDeploy 'Microsoft.Web/sites/extensions@2025-03-01' = {
+  parent: functionApp
+  name: 'onedeploy'
+  #disable-next-line BCP187
+  properties: {
+    packageUri: appPackageUri
+    remoteBuild: false
+  }
+}
+
+output functionAppName string = functionApp.name
+output majorVersion string = majorVersion
+output targetVersion string = targetVersion
+output appPackageUri string = appPackageUri

--- a/deploy/azuredeploy_update.json
+++ b/deploy/azuredeploy_update.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.43.8.12551",
+      "templateHash": "16749310730509452827"
+    }
+  },
+  "parameters": {
+    "functionAppName": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "Name of the existing Acmebot Function App to update."
+      }
+    },
+    "majorVersion": {
+      "type": "string",
+      "defaultValue": "v5",
+      "allowedValues": [
+        "v5"
+      ],
+      "metadata": {
+        "description": "Acmebot major version channel to deploy."
+      }
+    },
+    "targetVersion": {
+      "type": "string",
+      "defaultValue": "latest",
+      "minLength": 1,
+      "metadata": {
+        "description": "Acmebot version to deploy. Use latest or a specific v5 version such as 5.0.0 or v5.0.0."
+      }
+    }
+  },
+  "variables": {
+    "versionIsLatest": "[equals(toLower(parameters('targetVersion')), 'latest')]",
+    "normalizedTargetVersion": "[if(startsWith(toLower(parameters('targetVersion')), 'v'), substring(parameters('targetVersion'), 1, sub(length(parameters('targetVersion')), 1)), parameters('targetVersion'))]",
+    "packageFileName": "[if(variables('versionIsLatest'), 'latest.zip', format('{0}.zip', variables('normalizedTargetVersion')))]",
+    "appPackageUri": "[format('https://stacmebotprod.blob.core.windows.net/acmebot/{0}/{1}', parameters('majorVersion'), variables('packageFileName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/sites/extensions",
+      "apiVersion": "2025-03-01",
+      "name": "[format('{0}/{1}', parameters('functionAppName'), 'onedeploy')]",
+      "properties": {
+        "packageUri": "[variables('appPackageUri')]",
+        "remoteBuild": false
+      }
+    }
+  ],
+  "outputs": {
+    "functionAppName": {
+      "type": "string",
+      "value": "[parameters('functionAppName')]"
+    },
+    "majorVersion": {
+      "type": "string",
+      "value": "[parameters('majorVersion')]"
+    },
+    "targetVersion": {
+      "type": "string",
+      "value": "[parameters('targetVersion')]"
+    },
+    "appPackageUri": {
+      "type": "string",
+      "value": "[variables('appPackageUri')]"
+    }
+  }
+}

--- a/deploy/uiFormDefinition_update.json
+++ b/deploy/uiFormDefinition_update.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2021-09-09/uiFormDefinition.schema.json#",
+  "view": {
+    "kind": "Form",
+    "properties": {
+      "title": "Acmebot Update",
+      "steps": [
+        {
+          "name": "basics",
+          "label": "Basics",
+          "description": "Select the existing Acmebot Function App and package version to deploy.",
+          "elements": [
+            {
+              "name": "targetSection",
+              "type": "Microsoft.Common.Section",
+              "label": "Update target",
+              "elements": [
+                {
+                  "name": "subscription",
+                  "type": "Microsoft.Common.SubscriptionSelector",
+                  "resourceProviders": [
+                    "Microsoft.Web"
+                  ],
+                  "visible": true
+                },
+                {
+                  "name": "functionAppsApi",
+                  "type": "Microsoft.Solutions.ArmApiControl",
+                  "request": {
+                    "method": "POST",
+                    "path": "providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01",
+                    "body": {
+                      "subscriptions": [
+                        "[steps('basics').targetSection.subscription.subscriptionId]"
+                      ],
+                      "query": "Resources | where type =~ 'microsoft.web/sites' | where kind contains 'functionapp' | where kind !contains 'workflowapp' | project label = tostring(name), description = strcat('Resource group: ', resourceGroup), value = strcat(id, '|', location) | order by label asc"
+                    }
+                  }
+                },
+                {
+                  "name": "functionApp",
+                  "type": "Microsoft.Common.DropDown",
+                  "label": "Function App",
+                  "placeholder": "Select existing...",
+                  "toolTip": "Existing Acmebot Function App to update. The deployment is submitted to the selected Function App's resource group.",
+                  "filter": true,
+                  "filterPlaceholder": "Type to start filtering...",
+                  "multiLine": true,
+                  "constraints": {
+                    "allowedValues": "[steps('basics').targetSection.functionAppsApi.data]",
+                    "required": true
+                  },
+                  "visible": true
+                }
+              ]
+            },
+            {
+              "name": "packageSection",
+              "type": "Microsoft.Common.Section",
+              "label": "Package",
+              "elements": [
+                {
+                  "name": "updateNotice",
+                  "type": "Microsoft.Common.InfoBox",
+                  "options": {
+                    "style": "Info",
+                    "text": "This update redeploys only the Acmebot application package. Existing Function App settings and related resources are preserved."
+                  }
+                },
+                {
+                  "name": "majorVersion",
+                  "type": "Microsoft.Common.DropDown",
+                  "label": "Major version",
+                  "placeholder": "Major version",
+                  "defaultValue": {
+                    "value": "v5"
+                  },
+                  "toolTip": "Acmebot major version channel to deploy.",
+                  "constraints": {
+                    "allowedValues": [
+                      {
+                        "label": "v5 (Preview)",
+                        "value": "v5"
+                      }
+                    ],
+                    "required": true
+                  },
+                  "visible": true
+                },
+                {
+                  "name": "targetVersionType",
+                  "type": "Microsoft.Common.OptionsGroup",
+                  "label": "Target version",
+                  "toolTip": "Deploy the latest package for the selected major version or enter a specific release version.",
+                  "defaultValue": "latest",
+                  "constraints": {
+                    "allowedValues": [
+                      {
+                        "label": "Latest",
+                        "value": "latest"
+                      },
+                      {
+                        "label": "Specific version",
+                        "value": "specific"
+                      }
+                    ],
+                    "required": true
+                  },
+                  "visible": true
+                },
+                {
+                  "name": "specificVersionNotice",
+                  "type": "Microsoft.Common.InfoBox",
+                  "options": {
+                    "style": "Warning",
+                    "text": "The specified package version must already be published. Deployment fails if the package cannot be found."
+                  },
+                  "visible": "[if(equals(steps('basics').packageSection.targetVersionType, 'specific'), true, false)]"
+                },
+                {
+                  "name": "specificVersion",
+                  "type": "Microsoft.Common.TextBox",
+                  "label": "Specific version",
+                  "placeholder": "5.0.0",
+                  "defaultValue": "",
+                  "toolTip": "Acmebot v5 release version to deploy. The leading v is optional.",
+                  "constraints": {
+                    "required": true,
+                    "validations": [
+                      {
+                        "regex": "^[vV]?5\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?(\\+[0-9A-Za-z.-]+)?$",
+                        "message": "Enter a valid v5 release version, such as 5.0.0 or v5.0.0."
+                      }
+                    ]
+                  },
+                  "visible": "[if(equals(steps('basics').packageSection.targetVersionType, 'specific'), true, false)]"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "outputs": {
+      "kind": "ResourceGroup",
+      "resourceGroupId": "[substring(first(split(steps('basics').targetSection.functionApp, '|')), 0, indexOf(toLower(first(split(steps('basics').targetSection.functionApp, '|'))), '/providers/microsoft.web/sites/'))]",
+      "location": "[last(split(steps('basics').targetSection.functionApp, '|'))]",
+      "parameters": {
+        "functionAppName": "[last(split(first(split(steps('basics').targetSection.functionApp, '|')), '/'))]",
+        "majorVersion": "[steps('basics').packageSection.majorVersion]",
+        "targetVersion": "[if(equals(steps('basics').packageSection.targetVersionType, 'latest'), 'latest', steps('basics').packageSection.specificVersion)]"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new update deployment flow for Acmebot using Azure Resource Manager templates and a UI form definition. It adds Bicep and JSON templates for updating an existing Acmebot Function App to a specified or latest version, as well as a UI form for guided deployment in Azure. The changes focus on enabling selective redeployment of the application package while preserving existing settings.

**Deployment template and logic:**

* Added `azuredeploy_update.bicep`, a Bicep template that enables updating an existing Acmebot Function App to a specified or latest v5 package version, with parameters for function app name, major version, and target version. The template constructs the appropriate package URI and triggers deployment using the `onedeploy` extension.
* Added the corresponding compiled ARM template `azuredeploy_update.json`, which implements the same update logic in JSON format for use in Azure deployments.

**UI and user experience:**

* Introduced `uiFormDefinition_update.json`, a UI form definition for Azure Portal that guides users through selecting the target Function App and package version to deploy. It includes validation, version selection (latest or specific), and informative notices about deployment behavior.