### PR TITLE
Update Dependabot configuration for npm package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,22 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: '*'
+      - dependency-name: "*"
         update-types:
-          - version-update:semver-major
+          - "version-update:semver-major"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
           - "version-update:semver-major"
 
   - package-ecosystem: "npm"
-    directory: "/frontend"
+    directory: "/src/Acmebot.App/ClientApp"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
This pull request updates the Dependabot configuration to add support for managing dependencies in the `/frontend` directory using the npm package ecosystem. It also standardizes the formatting of dependency ignore patterns.

**Dependabot configuration enhancements:**

* Added a new npm configuration for the `/frontend` directory to enable weekly dependency update checks, grouping all dependencies and ignoring major version updates.
* Standardized the formatting of dependency ignore patterns and update types by using double quotes for consistency.