### PR TITLE
Add support for JavaScript/TypeScript in CodeQL analysis matrix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,8 @@ jobs:
           build-mode: none
         - language: csharp
           build-mode: autobuild
+        - language: javascript-typescript
+          build-mode: none
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
This pull request makes a small update to the CodeQL workflow configuration, adding support for JavaScript and TypeScript analysis. No other significant changes are included.

* Added a new entry to the CodeQL workflow to analyze `javascript-typescript` code with `build-mode: none`, enabling security scanning for JavaScript and TypeScript files.