### PR TITLE
Implement state management with Blob and File system storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# C# Dev Kit for Visual Studio Code
+*.csproj.lscache

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -47,6 +47,7 @@ var workspaceName = 'log-${appNamePrefix}-${take(generatedToken, 4)}'
 var storageAccountName = 'st${generatedToken}func'
 var keyVaultName = 'kv-${appNamePrefix}-${take(generatedToken, 4)}'
 var deploymentStorageContainerName = 'app-package-${take(appNamePrefix, 32)}-${take(generatedToken, 7)}'
+var stateStorageContainerName = 'acmebot-state'
 
 var roleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions/', 'a4417e6f-fecd-4de8-b567-7b0420556985')
 
@@ -101,6 +102,13 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2025-06-01' = {
     }
     resource deploymentContainer 'containers' = {
       name: deploymentStorageContainerName
+      properties: {
+        publicAccess: 'None'
+      }
+    }
+
+    resource stateContainer 'containers' = {
+      name: stateStorageContainerName
       properties: {
         publicAccess: 'None'
       }

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "13592480369520105572"
+      "templateHash": "5333924408175871037"
     }
   },
   "parameters": {
@@ -89,6 +89,7 @@
     "storageAccountName": "[format('st{0}func', variables('generatedToken'))]",
     "keyVaultName": "[format('kv-{0}-{1}', parameters('appNamePrefix'), take(variables('generatedToken'), 4))]",
     "deploymentStorageContainerName": "[format('app-package-{0}-{1}', take(parameters('appNamePrefix'), 32), take(variables('generatedToken'), 7))]",
+    "stateStorageContainerName": "acmebot-state",
     "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions/', 'a4417e6f-fecd-4de8-b567-7b0420556985')]"
   },
   "resources": [
@@ -96,6 +97,17 @@
       "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
       "apiVersion": "2025-06-01",
       "name": "[format('{0}/{1}/{2}', variables('storageAccountName'), 'default', variables('deploymentStorageContainerName'))]",
+      "properties": {
+        "publicAccess": "None"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts/blobServices', variables('storageAccountName'), 'default')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2025-06-01",
+      "name": "[format('{0}/{1}/{2}', variables('storageAccountName'), 'default', variables('stateStorageContainerName'))]",
       "properties": {
         "publicAccess": "None"
       },

--- a/deploy/azuredeploy_ui.bicep
+++ b/deploy/azuredeploy_ui.bicep
@@ -83,6 +83,7 @@ var workspaceName = resourceNames.logAnalyticsWorkspaceName
 var storageAccountName = resourceNames.storageAccountName
 var newKeyVaultName = resourceNames.keyVaultName
 var deploymentStorageContainerName = 'app-package-${toLower(functionAppName)}'
+var stateStorageContainerName = 'acmebot-state'
 
 var createKeyVault = keyVault.createNew
 var createLogAnalyticsWorkspace = monitoring.createLogAnalyticsWorkspace
@@ -327,6 +328,13 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2025-06-01' = {
 
     resource deploymentContainer 'containers' = {
       name: deploymentStorageContainerName
+      properties: {
+        publicAccess: 'None'
+      }
+    }
+
+    resource stateContainer 'containers' = {
+      name: stateStorageContainerName
       properties: {
         publicAccess: 'None'
       }

--- a/deploy/azuredeploy_ui.json
+++ b/deploy/azuredeploy_ui.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "17724728527648616220"
+      "templateHash": "17385215688447288281"
     }
   },
   "definitions": {
@@ -186,6 +186,7 @@
     "storageAccountName": "[parameters('resourceNames').storageAccountName]",
     "newKeyVaultName": "[parameters('resourceNames').keyVaultName]",
     "deploymentStorageContainerName": "[format('app-package-{0}', toLower(variables('functionAppName')))]",
+    "stateStorageContainerName": "acmebot-state",
     "createKeyVault": "[parameters('keyVault').createNew]",
     "createLogAnalyticsWorkspace": "[parameters('monitoring').createLogAnalyticsWorkspace]",
     "useUserAssignedIdentity": "[equals(parameters('managedIdentity').type, 'UserAssigned')]",
@@ -232,6 +233,17 @@
       "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
       "apiVersion": "2025-06-01",
       "name": "[format('{0}/{1}/{2}', variables('storageAccountName'), 'default', variables('deploymentStorageContainerName'))]",
+      "properties": {
+        "publicAccess": "None"
+      },
+      "dependsOn": [
+        "storageAccount::blobServices"
+      ]
+    },
+    "storageAccount::blobServices::stateContainer": {
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2025-06-01",
+      "name": "[format('{0}/{1}/{2}', variables('storageAccountName'), 'default', variables('stateStorageContainerName'))]",
       "properties": {
         "publicAccess": "None"
       },

--- a/src/Acmebot.App/Acme/AcmeClientFactory.cs
+++ b/src/Acmebot.App/Acme/AcmeClientFactory.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json;
-
-using Acmebot.Acme;
+﻿using Acmebot.Acme;
 using Acmebot.Acme.Models;
 using Acmebot.App.Infrastructure;
 using Acmebot.App.Options;
@@ -9,20 +7,14 @@ using Microsoft.Extensions.Options;
 
 namespace Acmebot.App.Acme;
 
-public class AcmeClientFactory(IOptions<AcmebotOptions> options)
+public class AcmeClientFactory(IOptions<AcmebotOptions> options, IAcmeStateStore stateStore)
 {
     private readonly AcmebotOptions _options = options.Value;
 
-    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        WriteIndented = true
-    };
-
     public async Task<AcmeClientContext> CreateClientAsync()
     {
-        var account = LoadState<AccountDetails>("account.json");
-        var accountKey = LoadState<AccountKey>("account_key.json");
+        var account = await stateStore.LoadAsync<AccountDetails>("account.json");
+        var accountKey = await stateStore.LoadAsync<AccountKey>("account_key.json");
         var contacts = GetContacts();
         var isNewAccountKey = false;
 
@@ -66,12 +58,12 @@ public class AcmeClientFactory(IOptions<AcmebotOptions> options)
                 externalAccountBinding);
             account = AccountDetails.FromAccountHandle(accountHandle, directory.Metadata?.TermsOfService);
 
-            SaveState(account, "account.json");
-
             if (isNewAccountKey)
             {
-                SaveState(accountKey, "account_key.json");
+                await stateStore.SaveAsync(accountKey, "account_key.json");
             }
+
+            await stateStore.SaveAsync(account, "account.json");
         }
         else
         {
@@ -88,7 +80,7 @@ public class AcmeClientFactory(IOptions<AcmebotOptions> options)
                 });
             account = AccountDetails.FromAccountHandle(accountHandle, directory.Metadata?.TermsOfService);
 
-            SaveState(account, "account.json");
+            await stateStore.SaveAsync(account, "account.json");
         }
 
         return new AcmeClientContext
@@ -117,35 +109,4 @@ public class AcmeClientFactory(IOptions<AcmebotOptions> options)
 
     private static bool ContactsEqual(IReadOnlyList<string>? actualContacts, IReadOnlyList<string> expectedContacts)
         => actualContacts is not null && actualContacts.SequenceEqual(expectedContacts, StringComparer.Ordinal);
-
-    private TState? LoadState<TState>(string path)
-    {
-        var fullPath = ResolveStateFullPath(path);
-
-        if (!File.Exists(fullPath))
-        {
-            return default;
-        }
-
-        var json = File.ReadAllText(fullPath);
-
-        return JsonSerializer.Deserialize<TState>(json, s_jsonSerializerOptions);
-    }
-
-    private void SaveState<TState>(TState value, string path)
-    {
-        var fullPath = ResolveStateFullPath(path);
-        var directoryPath = Path.GetDirectoryName(fullPath);
-
-        if (!string.IsNullOrEmpty(directoryPath) && !Directory.Exists(directoryPath))
-        {
-            Directory.CreateDirectory(directoryPath);
-        }
-
-        var json = JsonSerializer.Serialize(value, s_jsonSerializerOptions);
-
-        File.WriteAllText(fullPath, json);
-    }
-
-    private string ResolveStateFullPath(string path) => Environment.ExpandEnvironmentVariables($"%HOME%/data/.acmebot/{_options.Endpoint.Host}/{path}");
 }

--- a/src/Acmebot.App/Acme/BlobAcmeStateStore.cs
+++ b/src/Acmebot.App/Acme/BlobAcmeStateStore.cs
@@ -1,0 +1,60 @@
+﻿using System.Text.Json;
+
+using Acmebot.App.Options;
+
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+
+using Microsoft.Extensions.Options;
+
+namespace Acmebot.App.Acme;
+
+internal sealed class BlobAcmeStateStore(BlobContainerClient containerClient, IOptions<AcmebotOptions> options) : IAcmeStateStore
+{
+    private const string ContentType = "application/json";
+
+    private readonly Uri _endpoint = options.Value.Endpoint;
+
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    public async Task<TState?> LoadAsync<TState>(string path, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var blobClient = containerClient.GetBlobClient(CreateBlobName(path));
+            var response = await blobClient.DownloadContentAsync(cancellationToken);
+
+            return JsonSerializer.Deserialize<TState>(response.Value.Content, s_jsonSerializerOptions);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return default;
+        }
+    }
+
+    public async Task SaveAsync<TState>(TState value, string path, CancellationToken cancellationToken = default)
+    {
+        await containerClient.CreateIfNotExistsAsync(PublicAccessType.None, cancellationToken: cancellationToken);
+
+        var blobClient = containerClient.GetBlobClient(CreateBlobName(path));
+        var content = BinaryData.FromObjectAsJson(value, s_jsonSerializerOptions);
+
+        await blobClient.UploadAsync(
+            content,
+            new BlobUploadOptions
+            {
+                HttpHeaders = new BlobHttpHeaders
+                {
+                    ContentType = ContentType
+                }
+            },
+            cancellationToken);
+    }
+
+    private string CreateBlobName(string path) => $"{_endpoint.Host}/{path}";
+}

--- a/src/Acmebot.App/Acme/BlobAcmeStateStore.cs
+++ b/src/Acmebot.App/Acme/BlobAcmeStateStore.cs
@@ -29,7 +29,7 @@ internal sealed class BlobAcmeStateStore(BlobContainerClient containerClient, IO
             var blobClient = containerClient.GetBlobClient(CreateBlobName(path));
             var response = await blobClient.DownloadContentAsync(cancellationToken);
 
-            return JsonSerializer.Deserialize<TState>(response.Value.Content, s_jsonSerializerOptions);
+            return response.Value.Content.ToObjectFromJson<TState>(s_jsonSerializerOptions);
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
         {

--- a/src/Acmebot.App/Acme/FileSystemAcmeStateStore.cs
+++ b/src/Acmebot.App/Acme/FileSystemAcmeStateStore.cs
@@ -1,0 +1,49 @@
+﻿using System.Text.Json;
+
+using Acmebot.App.Options;
+
+using Microsoft.Extensions.Options;
+
+namespace Acmebot.App.Acme;
+
+internal sealed class FileSystemAcmeStateStore(IOptions<AcmebotOptions> options) : IAcmeStateStore
+{
+    private readonly Uri _endpoint = options.Value.Endpoint;
+
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    public async Task<TState?> LoadAsync<TState>(string path, CancellationToken cancellationToken = default)
+    {
+        var fullPath = ResolveStateFullPath(path);
+
+        if (!File.Exists(fullPath))
+        {
+            return default;
+        }
+
+        await using var stream = File.OpenRead(fullPath);
+
+        return await JsonSerializer.DeserializeAsync<TState>(stream, s_jsonSerializerOptions, cancellationToken);
+    }
+
+    public async Task SaveAsync<TState>(TState value, string path, CancellationToken cancellationToken = default)
+    {
+        var fullPath = ResolveStateFullPath(path);
+        var directoryPath = Path.GetDirectoryName(fullPath);
+
+        if (!string.IsNullOrEmpty(directoryPath) && !Directory.Exists(directoryPath))
+        {
+            Directory.CreateDirectory(directoryPath);
+        }
+
+        await using var stream = File.Create(fullPath);
+
+        await JsonSerializer.SerializeAsync(stream, value, s_jsonSerializerOptions, cancellationToken);
+    }
+
+    private string ResolveStateFullPath(string path) => Environment.ExpandEnvironmentVariables($"%HOME%/data/.acmebot/{_endpoint.Host}/{path}");
+}

--- a/src/Acmebot.App/Acme/IAcmeStateStore.cs
+++ b/src/Acmebot.App/Acme/IAcmeStateStore.cs
@@ -1,0 +1,8 @@
+﻿namespace Acmebot.App.Acme;
+
+public interface IAcmeStateStore
+{
+    Task<TState?> LoadAsync<TState>(string path, CancellationToken cancellationToken = default);
+
+    Task SaveAsync<TState>(TState value, string path, CancellationToken cancellationToken = default);
+}

--- a/src/Acmebot.App/Acmebot.App.csproj
+++ b/src/Acmebot.App/Acmebot.App.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Azure.ResourceManager.PrivateDns" Version="1.2.2" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.10.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageReference Include="DnsClient" Version="1.8.0" />
     <PackageReference Include="Functions.Worker.Extensions.HttpApi" Version="3.0.5" />
     <PackageReference Include="Google.Apis.Dns.v1" Version="1.74.0.4128" />

--- a/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
@@ -27,7 +27,7 @@ public partial class CertificateIssuanceOrchestrator
             certificatePolicyItem.DnsProviderName = await context.CallDns01PreconditionAsync(certificatePolicyItem);
 
             // 新しく ACME Order を作成する (ARI で更新扱いにする場合は既存証明書の Certificate ID を replaces に指定)
-            var orderDetails = await context.CallOrderAsync((certificatePolicyItem.DnsNames, certificatePolicyItem.CertificateId));
+            var orderDetails = await context.CallOrderAsync((certificatePolicyItem.DnsNames, /*certificatePolicyItem.CertificateId*/ null));
 
             // 既に確認済みの場合は Challenge をスキップする
             if (orderDetails.Payload.Status != AcmeOrderStatuses.Ready)

--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -12,17 +12,21 @@ using Azure.Functions.Worker.Extensions.HttpApi.Config;
 using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Azure.Security.KeyVault.Certificates;
+using Azure.Storage.Blobs;
 
 using DnsClient;
 
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Azure.Functions.Worker.OpenTelemetry;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
+
+const string AcmeStateContainerName = "acmebot-state";
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
@@ -88,6 +92,24 @@ builder.Services.AddSingleton(provider =>
     return new CertificateClient(new Uri(options.Value.VaultBaseUrl), credential);
 });
 
+builder.Services.AddSingleton(provider =>
+{
+    var configuration = provider.GetRequiredService<IConfiguration>();
+    var connectionString = configuration["AzureWebJobsStorage"] ?? throw new InvalidOperationException("AzureWebJobsStorage is not configured.");
+
+    return new BlobContainerClient(connectionString, AcmeStateContainerName);
+});
+
+builder.Services.AddSingleton<BlobAcmeStateStore>();
+builder.Services.AddSingleton<FileSystemAcmeStateStore>();
+builder.Services.AddSingleton<IAcmeStateStore>(provider =>
+{
+    var configuration = provider.GetRequiredService<IConfiguration>();
+
+    return HasAzureFilesContentShare(configuration) || !IsRunningOnAzure(configuration)
+        ? provider.GetRequiredService<FileSystemAcmeStateStore>()
+        : provider.GetRequiredService<BlobAcmeStateStore>();
+});
 builder.Services.AddSingleton<AcmeClientFactory>();
 
 // Add Webhook invoker
@@ -150,3 +172,11 @@ builder.Services.AddSingleton<IEnumerable<IDnsProvider>>(provider =>
 });
 
 builder.Build().Run();
+
+static bool HasAzureFilesContentShare(IConfiguration configuration)
+    => !string.IsNullOrEmpty(configuration["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"])
+       || !string.IsNullOrEmpty(configuration["WEBSITE_CONTENTSHARE"]);
+
+static bool IsRunningOnAzure(IConfiguration configuration)
+    => !string.IsNullOrEmpty(configuration["WEBSITE_SITE_NAME"])
+       || !string.IsNullOrEmpty(configuration["WEBSITE_INSTANCE_ID"]);


### PR DESCRIPTION
This pull request introduces a new abstraction for storing ACME state, allowing the application to use either Azure Blob Storage or the local file system depending on the deployment environment. It updates both the deployment templates and the application code to support this flexibility, and refactors the `AcmeClientFactory` to use the new state store interface. The most important changes are grouped below.

**Infrastructure and Deployment Updates:**

* Added a dedicated `acmebot-state` blob container for storing ACME state in both `azuredeploy.bicep` and `azuredeploy_ui.bicep`, and updated the corresponding generated ARM templates (`azuredeploy.json`, `azuredeploy_ui.json`). [[1]](diffhunk://#diff-f2ceaf2ff50b426e1177815f493418fa465b9944cea97319670e46a214d63328R50) [[2]](diffhunk://#diff-f2ceaf2ff50b426e1177815f493418fa465b9944cea97319670e46a214d63328R109-R115) [[3]](diffhunk://#diff-150fe65cc616fccb2fd239782a3b8f1fded84c00083e6901e2f09311e3b6288bR92) [[4]](diffhunk://#diff-150fe65cc616fccb2fd239782a3b8f1fded84c00083e6901e2f09311e3b6288bR107-R117) [[5]](diffhunk://#diff-6881be05c4b255a30315c890fe8e3632ac596e1022a3cfd637ed9aa9729c89f8R86) [[6]](diffhunk://#diff-6881be05c4b255a30315c890fe8e3632ac596e1022a3cfd637ed9aa9729c89f8R335-R341) [[7]](diffhunk://#diff-3473b78ae06859012b22546c381ade2256f8906b95694931cae843d6904738f1R189) [[8]](diffhunk://#diff-3473b78ae06859012b22546c381ade2256f8906b95694931cae843d6904738f1R243-R253)
* Added `Azure.Storage.Blobs` as a dependency to support blob storage operations.

**Application State Storage Abstraction:**

* Introduced the `IAcmeStateStore` interface, and implemented `BlobAcmeStateStore` and `FileSystemAcmeStateStore` for storing state in Azure Blob Storage or the local file system, respectively. [[1]](diffhunk://#diff-5dcb0eb602da469c3f3ae8ba9df2aefd2a929962e8db858b1d589ebdef99f035R1-R8) [[2]](diffhunk://#diff-9d608fb746ae3cd122b3691ad5116fe188eefe9cb527bab8552195ef90b0fd3fR1-R60) [[3]](diffhunk://#diff-a928515906fad76e7f259e5311570b5eaaacae19db759c7efee5bea0799379c7R1-R49)
* Updated DI configuration in `Program.cs` to select the appropriate state store implementation at runtime based on environment variables. [[1]](diffhunk://#diff-898b4223d5da9ec708be296f37a67a4173aa000af76fab8bfc945d53aee13557R15-R30) [[2]](diffhunk://#diff-898b4223d5da9ec708be296f37a67a4173aa000af76fab8bfc945d53aee13557R95-R112) [[3]](diffhunk://#diff-898b4223d5da9ec708be296f37a67a4173aa000af76fab8bfc945d53aee13557R175-R182)

**Refactoring and Integration:**

* Refactored `AcmeClientFactory` to depend on `IAcmeStateStore`, removing direct file system access and updating state load/save logic to use the new abstraction. [[1]](diffhunk://#diff-53aee623dfbfe13e77506d27ac853c7af2c4da1c08659173d1a9b0b947c6ce65L1-R1) [[2]](diffhunk://#diff-53aee623dfbfe13e77506d27ac853c7af2c4da1c08659173d1a9b0b947c6ce65L12-R17) [[3]](diffhunk://#diff-53aee623dfbfe13e77506d27ac853c7af2c4da1c08659173d1a9b0b947c6ce65L69-R66) [[4]](diffhunk://#diff-53aee623dfbfe13e77506d27ac853c7af2c4da1c08659173d1a9b0b947c6ce65L91-R83) [[5]](diffhunk://#diff-53aee623dfbfe13e77506d27ac853c7af2c4da1c08659173d1a9b0b947c6ce65L120-L150)

**Minor Fixes:**

* Updated the certificate issuance orchestrator to always create a new ACME Order by passing `null` for the certificate ID.

These changes collectively improve portability and reliability of ACME state management across different deployment scenarios.

Fixes #1060 