### PR TITLE
Add Bicep and JSON deployment templates for Acmebot migration

### DIFF
--- a/deploy/azuredeploy_migrate.bicep
+++ b/deploy/azuredeploy_migrate.bicep
@@ -1,0 +1,44 @@
+targetScope = 'resourceGroup'
+
+@description('Name of the existing Acmebot Function App to update.')
+@minLength(1)
+param functionAppName string
+
+#disable-next-line no-hardcoded-env-urls
+var appPackageUri = 'https://stacmebotprod.blob.core.windows.net/acmebot/v5/latest.zip'
+
+resource functionApp 'Microsoft.Web/sites@2025-03-01' existing = {
+  name: functionAppName
+}
+
+resource functionAppRuntimeConfig 'Microsoft.Web/sites/config@2025-03-01' = {
+  parent: functionApp
+  name: 'web'
+  properties: {
+    netFrameworkVersion: 'v10.0'
+  }
+}
+
+resource functionAppAppSettings 'Microsoft.Web/sites/config@2025-03-01' = {
+  parent: functionApp
+  name: 'appsettings'
+  properties: union(list('${functionApp.id}/config/appsettings', '2025-03-01').properties, {
+    FUNCTIONS_EXTENSION_VERSION: '~4'
+    FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
+    WEBSITE_RUN_FROM_PACKAGE: '1'
+  })
+}
+
+resource functionAppDeploy 'Microsoft.Web/sites/extensions@2025-03-01' = {
+  parent: functionApp
+  name: 'onedeploy'
+  #disable-next-line BCP187
+  properties: {
+    packageUri: appPackageUri
+    remoteBuild: false
+  }
+  dependsOn: [
+    functionAppAppSettings
+    functionAppRuntimeConfig
+  ]
+}

--- a/deploy/azuredeploy_migrate.json
+++ b/deploy/azuredeploy_migrate.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.43.8.12551",
+      "templateHash": "17574436574139873436"
+    }
+  },
+  "parameters": {
+    "functionAppName": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "Name of the existing Acmebot Function App to update."
+      }
+    }
+  },
+  "variables": {
+    "appPackageUri": "https://stacmebotprod.blob.core.windows.net/acmebot/v5/latest.zip"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/sites/config",
+      "apiVersion": "2025-03-01",
+      "name": "[format('{0}/{1}', parameters('functionAppName'), 'web')]",
+      "properties": {
+        "netFrameworkVersion": "v10.0"
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites/config",
+      "apiVersion": "2025-03-01",
+      "name": "[format('{0}/{1}', parameters('functionAppName'), 'appsettings')]",
+      "properties": "[union(list(format('{0}/config/appsettings', resourceId('Microsoft.Web/sites', parameters('functionAppName'))), '2025-03-01').properties, createObject('FUNCTIONS_EXTENSION_VERSION', '~4', 'FUNCTIONS_WORKER_RUNTIME', 'dotnet-isolated', 'WEBSITE_RUN_FROM_PACKAGE', '1'))]"
+    },
+    {
+      "type": "Microsoft.Web/sites/extensions",
+      "apiVersion": "2025-03-01",
+      "name": "[format('{0}/{1}', parameters('functionAppName'), 'onedeploy')]",
+      "properties": {
+        "packageUri": "[variables('appPackageUri')]",
+        "remoteBuild": false
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites/config', parameters('functionAppName'), 'appsettings')]",
+        "[resourceId('Microsoft.Web/sites/config', parameters('functionAppName'), 'web')]"
+      ]
+    }
+  ]
+}

--- a/deploy/uiFormDefinition_migrate.json
+++ b/deploy/uiFormDefinition_migrate.json
@@ -8,7 +8,7 @@
         {
           "name": "basics",
           "label": "Basics",
-          "description": "Select the existing Acmebot Function App and package version to deploy.",
+          "description": "Select the existing Acmebot Function App.",
           "elements": [
             {
               "name": "targetSection",

--- a/deploy/uiFormDefinition_migrate.json
+++ b/deploy/uiFormDefinition_migrate.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2021-09-09/uiFormDefinition.schema.json#",
+  "view": {
+    "kind": "Form",
+    "properties": {
+      "title": "Acmebot Update",
+      "steps": [
+        {
+          "name": "basics",
+          "label": "Basics",
+          "description": "Select the existing Acmebot Function App and package version to deploy.",
+          "elements": [
+            {
+              "name": "targetSection",
+              "type": "Microsoft.Common.Section",
+              "label": "Migrate target",
+              "elements": [
+                {
+                  "name": "subscription",
+                  "type": "Microsoft.Common.SubscriptionSelector",
+                  "resourceProviders": [
+                    "Microsoft.Web"
+                  ],
+                  "visible": true
+                },
+                {
+                  "name": "functionApp",
+                  "type": "Microsoft.Solutions.ResourceSelector",
+                  "label": "Function App",
+                  "toolTip": "Existing Acmebot Function App to update. The deployment is submitted to the selected Function App's resource group.",
+                  "resourceType": "Microsoft.Web/sites",
+                  "constraints": {
+                    "required": true
+                  },
+                  "scope": {
+                    "subscriptionId": "[steps('basics').targetSection.subscription.subscriptionId]"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "outputs": {
+      "kind": "ResourceGroup",
+      "resourceGroupId": "[substring(steps('basics').targetSection.functionApp.id, 0, indexOf(steps('basics').targetSection.functionApp.id, '/providers/Microsoft.Web/sites/'))]",
+      "location": "[steps('basics').targetSection.functionApp.location]",
+      "parameters": {
+        "functionAppName": "[steps('basics').targetSection.functionApp.name]"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new migration deployment process for updating an existing Acmebot Function App in Azure. It adds the necessary infrastructure-as-code templates and a UI definition to guide users through selecting the target app and deploying the latest package version.

Key changes include:

**Deployment Templates:**

* Added `azuredeploy_migrate.bicep` Bicep template to automate updating an existing Function App, including setting the runtime to .NET 10, updating app settings, and deploying the latest Acmebot package.
* Added the corresponding compiled `azuredeploy_migrate.json` ARM template for use in Azure deployments.

**User Interface:**

* Added `uiFormDefinition_migrate.json` to provide a guided UI in the Azure Portal, allowing users to select the subscription and Function App to update, and ensuring deployment targets the correct resource group and app.