### PR TITLE
Fix DNS Made Easy zone parsing (id type mismatch)

### DIFF
--- a/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
+++ b/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
@@ -21,7 +21,7 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
     {
         var zones = await _dnsMadeEasyClient.ListDomainsAsync(cancellationToken);
 
-        return zones.Select(x => new DnsZone(this) { Id = x.Id, Name = x.Name }).ToArray();
+        return zones.Select(x => new DnsZone(this) { Id = x.Id.toString(), Name = x.Name }).ToArray();
     }
 
     public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
@@ -144,7 +144,7 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
     internal class Domain
     {
         [JsonPropertyName("id")]
-        public required string Id { get; set; }
+        public required long Id { get; set; }
 
         [JsonPropertyName("name")]
         public required string Name { get; set; }

--- a/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
+++ b/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
@@ -21,7 +21,7 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
     {
         var zones = await _dnsMadeEasyClient.ListDomainsAsync(cancellationToken);
 
-        return zones.Select(x => new DnsZone(this) { Id = x.Id.toString(), Name = x.Name }).ToArray();
+        return zones.Select(x => new DnsZone(this) { Id = x.Id.ToString(), Name = x.Name }).ToArray();
     }
 
     public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
Fix DNS Made Easy zone parsing returning empty results.

## Related Issue
- Related discussion: #1069 

## What Changed
- Updated Domain.Id from string to long to match API response
- Converted Id to string when mapping to DnsZone
- This fixes deserialization issue where zones were silently dropped

## Validation
- [x] `dotnet build -c Release ./Acmebot.slnx`
- [ ] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx`
- [ ] `az bicep build -f ./deploy/azuredeploy.bicep`
- [ ] Documentation updated if needed

## Notes
- DNS Made Easy API returns numeric IDs, causing System.Text.Json to fail mapping to string
- Verified fix: zones now return correctly (previously 0, now expected values)
- Verified against DNS Made Easy API response (sample):
```
  {
    "data": [
      {
        "id": 1234567,
        "name": "redacted.com"
      }
    ]
  }
```