### PR TITLE
Refactor DNS providers for improved ID handling and record management

### DIFF
--- a/src/Acmebot.App/Functions/Orchestration/DnsChallengeActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/DnsChallengeActivities.cs
@@ -149,7 +149,7 @@ public class DnsChallengeActivities(
                 throw new PreconditionException($"No DNS zone was found for record '{dnsRecordName}'.");
             }
 
-            var acmeDnsRecordName = dnsRecordName.Replace($".{zone.Name}", "", StringComparison.OrdinalIgnoreCase);
+            var acmeDnsRecordName = GetRelativeRecordName(dnsRecordName, zone);
 
             await zone.DnsProvider.DeleteTxtRecordAsync(zone, acmeDnsRecordName, cancellationToken);
             await zone.DnsProvider.CreateTxtRecordAsync(zone, acmeDnsRecordName, lookup.Select(x => x.DnsRecordValue).ToArray(), cancellationToken);
@@ -210,9 +210,23 @@ public class DnsChallengeActivities(
                 continue;
             }
 
-            var acmeDnsRecordName = dnsRecordName.Replace($".{zone.Name}", "", StringComparison.OrdinalIgnoreCase);
+            var acmeDnsRecordName = GetRelativeRecordName(dnsRecordName, zone);
 
             await zone.DnsProvider.DeleteTxtRecordAsync(zone, acmeDnsRecordName, cancellationToken);
         }
+    }
+
+    private static string GetRelativeRecordName(string dnsRecordName, DnsZone zone)
+    {
+        if (string.Equals(dnsRecordName, zone.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            return "";
+        }
+
+        var zoneSuffix = $".{zone.Name}";
+
+        return dnsRecordName.EndsWith(zoneSuffix, StringComparison.OrdinalIgnoreCase)
+            ? dnsRecordName[..^zoneSuffix.Length]
+            : dnsRecordName;
     }
 }

--- a/src/Acmebot.App/Options/OvhOptions.cs
+++ b/src/Acmebot.App/Options/OvhOptions.cs
@@ -2,6 +2,8 @@
 
 public class OvhOptions
 {
+    public string Endpoint { get; set; } = "https://eu.api.ovh.com/1.0/";
+
     public required string ApplicationKey { get; set; }
 
     public required string ApplicationSecret { get; set; }

--- a/src/Acmebot.App/Providers/AzurePrivateDnsProvider.cs
+++ b/src/Acmebot.App/Providers/AzurePrivateDnsProvider.cs
@@ -38,7 +38,7 @@ public class AzurePrivateDnsProvider(AzurePrivateDnsOptions options, AzureEnviro
         // TXT レコードに値をセットする
         var txtRecordData = new PrivateDnsTxtRecordData
         {
-            TtlInSeconds = 3600
+            TtlInSeconds = 60
         };
 
         foreach (var value in values)

--- a/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
+++ b/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
@@ -77,18 +77,39 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
 
         private readonly HttpClient _httpClient;
 
-        public async Task<IReadOnlyList<Domain>> ListDomainsAsync(CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<Domain>> ListDomainsAsync(CancellationToken cancellationToken = default)
         {
-            var result = await _httpClient.GetFromJsonAsync<PaginationArray<Domain>>("managed", cancellationToken);
-
-            return result?.Data ?? [];
+            return GetAllPagesAsync<Domain>("managed", cancellationToken);
         }
 
-        public async Task<IReadOnlyList<Record>> ListRecordsAsync(long zoneId, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<Record>> ListRecordsAsync(long zoneId, CancellationToken cancellationToken = default)
         {
-            var entries = await _httpClient.GetFromJsonAsync<PaginationArray<Record>>($"managed/{zoneId}/records", cancellationToken);
+            return GetAllPagesAsync<Record>($"managed/{zoneId}/records", cancellationToken);
+        }
 
-            return entries?.Data ?? [];
+        private async Task<IReadOnlyList<T>> GetAllPagesAsync<T>(string path, CancellationToken cancellationToken)
+        {
+            var items = new List<T>();
+            var page = 0;
+
+            while (true)
+            {
+                var result = await _httpClient.GetFromJsonAsync<PaginationArray<T>>($"{path}?page={page}", cancellationToken);
+
+                if (result?.Data is { Length: > 0 })
+                {
+                    items.AddRange(result.Data);
+                }
+
+                if (result is null || page >= result.TotalPages - 1)
+                {
+                    break;
+                }
+
+                page++;
+            }
+
+            return items;
         }
 
         public async Task DeleteRecordAsync(long zoneId, long recordId, CancellationToken cancellationToken = default)

--- a/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
+++ b/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
@@ -36,13 +36,17 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
                 Value = value
             };
 
-            await _dnsMadeEasyClient.CreateRecordAsync(zone.Id, record, cancellationToken);
+            var zoneId = long.Parse(zone.Id);
+
+            await _dnsMadeEasyClient.CreateRecordAsync(zoneId, record, cancellationToken);
         }
     }
 
     public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
     {
-        var records = await _dnsMadeEasyClient.ListRecordsAsync(zone.Id, cancellationToken);
+        var zoneId = long.Parse(zone.Id);
+
+        var records = await _dnsMadeEasyClient.ListRecordsAsync(zoneId, cancellationToken);
 
         var recordsToDelete = records.Where(x => x.Name == relativeRecordName && x.Type == "TXT");
 
@@ -50,7 +54,7 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
         {
             try
             {
-                await _dnsMadeEasyClient.DeleteRecordAsync(zone.Id, record.Id, cancellationToken);
+                await _dnsMadeEasyClient.DeleteRecordAsync(zoneId, record.Id, cancellationToken);
             }
             catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
             {
@@ -80,21 +84,21 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
             return result?.Data ?? [];
         }
 
-        public async Task<IReadOnlyList<Record>> ListRecordsAsync(string zoneId, CancellationToken cancellationToken = default)
+        public async Task<IReadOnlyList<Record>> ListRecordsAsync(long zoneId, CancellationToken cancellationToken = default)
         {
             var entries = await _httpClient.GetFromJsonAsync<PaginationArray<Record>>($"managed/{zoneId}/records", cancellationToken);
 
             return entries?.Data ?? [];
         }
 
-        public async Task DeleteRecordAsync(string zoneId, string recordId, CancellationToken cancellationToken = default)
+        public async Task DeleteRecordAsync(long zoneId, long recordId, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.DeleteAsync($"managed/{zoneId}/records/{recordId}", cancellationToken);
 
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task CreateRecordAsync(string zoneId, RecordParam txtRecord, CancellationToken cancellationToken = default)
+        public async Task CreateRecordAsync(long zoneId, RecordParam txtRecord, CancellationToken cancellationToken = default)
         {
             var response = await _httpClient.PostAsJsonAsync($"managed/{zoneId}/records", txtRecord, cancellationToken);
 
@@ -168,6 +172,6 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
     internal class Record : RecordParam
     {
         [JsonPropertyName("id")]
-        public required string Id { get; set; }
+        public required long Id { get; set; }
     }
 }

--- a/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
+++ b/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
@@ -26,6 +26,8 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
 
     public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
+        var zoneId = long.Parse(zone.Id);
+
         foreach (var value in values)
         {
             var record = new RecordParam
@@ -35,8 +37,6 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
                 Ttl = 60,
                 Value = value
             };
-
-            var zoneId = long.Parse(zone.Id);
 
             await _dnsMadeEasyClient.CreateRecordAsync(zoneId, record, cancellationToken);
         }

--- a/src/Acmebot.App/Providers/GoDaddyProvider.cs
+++ b/src/Acmebot.App/Providers/GoDaddyProvider.cs
@@ -22,7 +22,7 @@ public class GoDaddyProvider(GoDaddyOptions options) : IDnsProvider
 
         await foreach (var domain in _goDaddyClient.ListDomainsAsync(cancellationToken))
         {
-            zones.Add(new DnsZone(this) { Id = domain.DomainId, Name = domain.Domain, NameServers = domain.NameServers ?? [] });
+            zones.Add(new DnsZone(this) { Id = domain.DomainId.ToString(), Name = domain.Domain, NameServers = domain.NameServers ?? [] });
         }
 
         return zones;
@@ -105,7 +105,7 @@ public class GoDaddyProvider(GoDaddyOptions options) : IDnsProvider
         public required string Domain { get; set; }
 
         [JsonPropertyName("domainId")]
-        public required string DomainId { get; set; }
+        public required long DomainId { get; set; }
 
         [JsonPropertyName("nameServers")]
         public string[]? NameServers { get; set; }

--- a/src/Acmebot.App/Providers/GoogleDnsProvider.cs
+++ b/src/Acmebot.App/Providers/GoogleDnsProvider.cs
@@ -43,7 +43,8 @@ public class GoogleDnsProvider(GoogleDnsOptions options) : IDnsProvider
 
         } while (!string.IsNullOrEmpty(response.NextPageToken));
 
-        return zones.Select(x => new DnsZone(this) { Id = x.Name, Name = x.DnsName.TrimEnd('.'), NameServers = x.NameServers?.ToArray() ?? [] })
+        return zones.Where(x => !string.Equals(x.Visibility, "private", StringComparison.OrdinalIgnoreCase))
+                    .Select(x => new DnsZone(this) { Id = x.Name, Name = x.DnsName.TrimEnd('.'), NameServers = x.NameServers?.ToArray() ?? [] })
                     .ToArray();
     }
 

--- a/src/Acmebot.App/Providers/IonosDnsProvider.cs
+++ b/src/Acmebot.App/Providers/IonosDnsProvider.cs
@@ -30,11 +30,13 @@ public class IonosDnsProvider(IonosDnsOptions options) : IDnsProvider
 
     public async Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)
     {
+        var recordName = $"{relativeRecordName}.{zone.Name}";
+
         foreach (var value in values)
         {
             var record = new RecordParam
             {
-                Name = relativeRecordName,
+                Name = recordName,
                 Type = "TXT",
                 Content = value,
                 Ttl = 60
@@ -46,7 +48,9 @@ public class IonosDnsProvider(IonosDnsOptions options) : IDnsProvider
 
     public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
     {
-        var records = await _ionosDnsClient.ListRecordsAsync(zone.Id, relativeRecordName, cancellationToken);
+        var recordName = $"{relativeRecordName}.{zone.Name}";
+
+        var records = await _ionosDnsClient.ListRecordsAsync(zone.Id, recordName, cancellationToken);
 
         foreach (var record in records)
         {

--- a/src/Acmebot.App/Providers/IonosDnsProvider.cs
+++ b/src/Acmebot.App/Providers/IonosDnsProvider.cs
@@ -71,7 +71,7 @@ public class IonosDnsProvider(IonosDnsOptions options) : IDnsProvider
             };
 
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("X-API-Key", apiKey);
+            _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("X-API-Key", apiKey);
         }
 
         private readonly HttpClient _httpClient;

--- a/src/Acmebot.App/Providers/OvhProvider.cs
+++ b/src/Acmebot.App/Providers/OvhProvider.cs
@@ -11,10 +11,9 @@ namespace Acmebot.App.Providers;
 
 public class OvhProvider(OvhOptions options) : IDnsProvider
 {
-    private const string OvhApiEndpoint = "https://eu.api.ovh.com/1.0/";
     private const int TxtRecordTtl = 60;
 
-    private readonly OvhClient _ovhClient = new(options.ApplicationKey, options.ApplicationSecret, options.ConsumerKey);
+    private readonly OvhClient _ovhClient = new(options.Endpoint, options.ApplicationKey, options.ApplicationSecret, options.ConsumerKey);
 
     public string Name => "OVH";
 
@@ -67,18 +66,20 @@ public class OvhProvider(OvhOptions options) : IDnsProvider
 
     private class OvhClient
     {
-        public OvhClient(string applicationKey, string applicationSecret, string consumerKey)
+        public OvhClient(string endpoint, string applicationKey, string applicationSecret, string consumerKey)
         {
             // DNS providers in this project own their API clients; this one is constructed once by the singleton provider.
             _httpClient = new HttpClient(new ApiKeyHandler(applicationKey, applicationSecret, consumerKey))
             {
-                BaseAddress = new Uri(OvhApiEndpoint)
+                BaseAddress = new Uri(NormalizeEndpoint(endpoint))
             };
 
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }
 
         private readonly HttpClient _httpClient;
+
+        private static string NormalizeEndpoint(string endpoint) => endpoint.EndsWith("/", StringComparison.Ordinal) ? endpoint : $"{endpoint}/";
 
         public async Task<IReadOnlyList<string>> ListZonesAsync(CancellationToken cancellationToken = default)
         {

--- a/src/Acmebot.App/Providers/Route53Provider.cs
+++ b/src/Acmebot.App/Providers/Route53Provider.cs
@@ -29,7 +29,9 @@ public class Route53Provider(Route53Options options) : IDnsProvider
 
         } while (response.IsTruncated ?? false);
 
-        return zones.Select(x => new DnsZone(this) { Id = x.Id, Name = x.Name.TrimEnd('.') }).ToArray();
+        return zones.Where(x => x.Config?.PrivateZone != true)
+                    .Select(x => new DnsZone(this) { Id = x.Id, Name = x.Name.TrimEnd('.') })
+                    .ToArray();
     }
 
     public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default)


### PR DESCRIPTION
This pull request includes several improvements and fixes to DNS provider integrations, with a focus on consistency in record handling, improved pagination support, and better configuration flexibility. The most significant changes are grouped below.

### DNS Provider Improvements

* Refactored DNS record name handling by introducing a new `GetRelativeRecordName` helper in `DnsChallengeActivities.cs` to ensure consistency across providers when extracting the relative record name. [[1]](diffhunk://#diff-3e4dde19aa5f408b974bc112c3e23cdc23f9de2dea53b2c1dc37714a8f2bfdecL152-R152) [[2]](diffhunk://#diff-3e4dde19aa5f408b974bc112c3e23cdc23f9de2dea53b2c1dc37714a8f2bfdecL213-R231)
* Updated the IONOS DNS provider to always use fully qualified record names when creating and deleting TXT records, ensuring correct DNS record management. [[1]](diffhunk://#diff-190a4ae01463ff2a82fb8aaffc6910a33e1f825aea58d69a6cd0e85409ac0a34R33-R39) [[2]](diffhunk://#diff-190a4ae01463ff2a82fb8aaffc6910a33e1f825aea58d69a6cd0e85409ac0a34L49-R53)
* Changed the Azure Private DNS provider to set TXT record TTL to 60 seconds (was 3600), improving DNS challenge responsiveness.

### Pagination and Data Handling

* Refactored the DNS Made Easy provider to support paginated API responses for listing domains and records, updated method signatures to use `long` for IDs, and improved type safety. [[1]](diffhunk://#diff-7a2da47667968afba3fb582ba81cc8e7d0b0a24f38686670bce51d4f84925988L39-R57) [[2]](diffhunk://#diff-7a2da47667968afba3fb582ba81cc8e7d0b0a24f38686670bce51d4f84925988L76-R122) [[3]](diffhunk://#diff-7a2da47667968afba3fb582ba81cc8e7d0b0a24f38686670bce51d4f84925988L171-R196)

### Provider Filtering and Data Consistency

* Updated Google DNS and Route53 providers to filter out private zones from the returned list, ensuring only public zones are used for DNS challenges. [[1]](diffhunk://#diff-21ef31d91b5005a7aa869fd8fb4c00491cc541dabd4c107c1cf39699eb4c49ddL46-R47) [[2]](diffhunk://#diff-dbd8554eaa27ddc9b55c3b7954a30290c67803bf2a6321cd6297c58aa8b05984L32-R34)
* Fixed GoDaddy provider to use string IDs for zones and updated the underlying model to use `long` for domain IDs for consistency. [[1]](diffhunk://#diff-2cc615950ad5c2a207207333d8a7b304529c6ea898dbbd8a85cee7343220b9b2L25-R25) [[2]](diffhunk://#diff-2cc615950ad5c2a207207333d8a7b304529c6ea898dbbd8a85cee7343220b9b2L108-R108)

### OVH Provider Configuration

* Added a configurable `Endpoint` property to `OvhOptions` and updated the OVH provider to use this endpoint, improving deployment flexibility and removing the hardcoded API endpoint. [[1]](diffhunk://#diff-2cc349d2372751bba3ab86b615d27c140f4214b01dfeb9c41e8b44e30ce8e478R5-R6) [[2]](diffhunk://#diff-60da9440e48f64187d824f0375307a1345d101467cc92d1f5437b0e33c8cd35bL14-R16) [[3]](diffhunk://#diff-60da9440e48f64187d824f0375307a1345d101467cc92d1f5437b0e33c8cd35bL70-R83)

### Minor Improvements

* Updated the IONOS DNS client to set the API key header using `TryAddWithoutValidation` for better compatibility.