### PR TITLE
Use ServiceAccountCredential in GoogleDnsProvider

### DIFF
--- a/src/Acmebot.App/Providers/GoogleDnsProvider.cs
+++ b/src/Acmebot.App/Providers/GoogleDnsProvider.cs
@@ -5,21 +5,24 @@ using Acmebot.App.Options;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Dns.v1.Data;
-using Google.Apis.Json;
 using Google.Apis.Services;
 
 namespace Acmebot.App.Providers;
 
-public class GoogleDnsProvider(GoogleDnsOptions options) : IDnsProvider
+public class GoogleDnsProvider : IDnsProvider
 {
-    private readonly DnsService _dnsService = new(new BaseClientService.Initializer
+    public GoogleDnsProvider(GoogleDnsOptions options)
     {
-        HttpClientInitializer = CredentialFactory.FromJson<GoogleCredential>(Encoding.UTF8.GetString(Convert.FromBase64String(options.KeyFile64)))
-                                                 .CreateScoped(DnsService.Scope.NdevClouddnsReadwrite)
-    });
+        _credential = CredentialFactory.FromJson<ServiceAccountCredential>(Encoding.UTF8.GetString(Convert.FromBase64String(options.KeyFile64)));
 
-    private readonly JsonCredentialParameters _credsParameters =
-        NewtonsoftJsonSerializer.Instance.Deserialize<JsonCredentialParameters>(Encoding.UTF8.GetString(Convert.FromBase64String(options.KeyFile64)));
+        _dnsService = new DnsService(new BaseClientService.Initializer
+        {
+            HttpClientInitializer = _credential
+        });
+    }
+
+    private readonly ServiceAccountCredential _credential;
+    private readonly DnsService _dnsService;
 
     public string Name => "Google Cloud DNS";
 
@@ -33,7 +36,7 @@ public class GoogleDnsProvider(GoogleDnsOptions options) : IDnsProvider
 
         do
         {
-            var request = _dnsService.ManagedZones.List(_credsParameters.ProjectId);
+            var request = _dnsService.ManagedZones.List(_credential.ProjectId);
 
             request.PageToken = response?.NextPageToken;
 
@@ -66,14 +69,14 @@ public class GoogleDnsProvider(GoogleDnsOptions options) : IDnsProvider
             ]
         };
 
-        return _dnsService.Changes.Create(change, _credsParameters.ProjectId, zone.Id).ExecuteAsync(cancellationToken);
+        return _dnsService.Changes.Create(change, _credential.ProjectId, zone.Id).ExecuteAsync(cancellationToken);
     }
 
     public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
     {
         var recordName = $"{relativeRecordName}.{zone.Name}.";
 
-        var request = _dnsService.ResourceRecordSets.List(_credsParameters.ProjectId, zone.Id);
+        var request = _dnsService.ResourceRecordSets.List(_credential.ProjectId, zone.Id);
 
         request.Name = recordName;
         request.Type = "TXT";
@@ -87,6 +90,6 @@ public class GoogleDnsProvider(GoogleDnsOptions options) : IDnsProvider
 
         var change = new Change { Deletions = txtRecords.Rrsets };
 
-        await _dnsService.Changes.Create(change, _credsParameters.ProjectId, zone.Id).ExecuteAsync(cancellationToken);
+        await _dnsService.Changes.Create(change, _credential.ProjectId, zone.Id).ExecuteAsync(cancellationToken);
     }
 }

--- a/src/Acmebot.App/Providers/GoogleDnsProvider.cs
+++ b/src/Acmebot.App/Providers/GoogleDnsProvider.cs
@@ -13,7 +13,10 @@ public class GoogleDnsProvider : IDnsProvider
 {
     public GoogleDnsProvider(GoogleDnsOptions options)
     {
-        _credential = CredentialFactory.FromJson<ServiceAccountCredential>(Encoding.UTF8.GetString(Convert.FromBase64String(options.KeyFile64)));
+        var serviceAccount = CredentialFactory.FromJson<ServiceAccountCredential>(Encoding.UTF8.GetString(Convert.FromBase64String(options.KeyFile64)));
+
+        _projectId = serviceAccount.ProjectId;
+        _credential = serviceAccount.ToGoogleCredential().CreateScoped(DnsService.Scope.NdevClouddnsReadwrite);
 
         _dnsService = new DnsService(new BaseClientService.Initializer
         {
@@ -21,7 +24,8 @@ public class GoogleDnsProvider : IDnsProvider
         });
     }
 
-    private readonly ServiceAccountCredential _credential;
+    private readonly string _projectId;
+    private readonly GoogleCredential _credential;
     private readonly DnsService _dnsService;
 
     public string Name => "Google Cloud DNS";
@@ -36,7 +40,7 @@ public class GoogleDnsProvider : IDnsProvider
 
         do
         {
-            var request = _dnsService.ManagedZones.List(_credential.ProjectId);
+            var request = _dnsService.ManagedZones.List(_projectId);
 
             request.PageToken = response?.NextPageToken;
 
@@ -69,14 +73,14 @@ public class GoogleDnsProvider : IDnsProvider
             ]
         };
 
-        return _dnsService.Changes.Create(change, _credential.ProjectId, zone.Id).ExecuteAsync(cancellationToken);
+        return _dnsService.Changes.Create(change, _projectId, zone.Id).ExecuteAsync(cancellationToken);
     }
 
     public async Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default)
     {
         var recordName = $"{relativeRecordName}.{zone.Name}.";
 
-        var request = _dnsService.ResourceRecordSets.List(_credential.ProjectId, zone.Id);
+        var request = _dnsService.ResourceRecordSets.List(_projectId, zone.Id);
 
         request.Name = recordName;
         request.Type = "TXT";
@@ -90,6 +94,6 @@ public class GoogleDnsProvider : IDnsProvider
 
         var change = new Change { Deletions = txtRecords.Rrsets };
 
-        await _dnsService.Changes.Create(change, _credential.ProjectId, zone.Id).ExecuteAsync(cancellationToken);
+        await _dnsService.Changes.Create(change, _projectId, zone.Id).ExecuteAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
Refactor GoogleDnsProvider initialization to use a ServiceAccountCredential and instance DnsService instead of inline initializer and deserialized JsonCredentialParameters. The change adds a constructor, stores readonly _credential and _dnsService fields, removes the dependency on Google.Apis.Json/Newtonsoft deserialization, and updates all API calls to use _credential.ProjectId. This simplifies credential handling and centralizes DNS service initialization.

Fixes #1080 