### PR TITLE
Prevent cancel while busy; simplify Revoke button

### DIFF
--- a/src/Acmebot.App/ClientApp/src/components/ConfirmRevokeDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/ConfirmRevokeDialog.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { AlertTriangle } from 'lucide-vue-next';
 import {
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -11,7 +10,7 @@ import {
   AlertDialogTitle,
 } from 'reka-ui';
 
-defineProps<{
+const props = defineProps<{
   open: boolean;
   certificateName: string;
   busy: boolean;
@@ -23,7 +22,7 @@ const emit = defineEmits<{
 }>();
 
 function handleOpenChange(open: boolean): void {
-  if (!open) {
+  if (!open && !props.busy) {
     emit('cancel');
   }
 }
@@ -61,16 +60,14 @@ function handleOpenChange(open: boolean): void {
               Cancel
             </button>
           </AlertDialogCancel>
-          <AlertDialogAction as-child>
-            <button
-              class="danger-button"
-              type="button"
-              :disabled="busy"
-              @click="emit('confirm')"
-            >
-              Revoke
-            </button>
-          </AlertDialogAction>
+          <button
+            class="danger-button"
+            type="button"
+            :disabled="busy"
+            @click="emit('confirm')"
+          >
+            Revoke
+          </button>
         </div>
       </AlertDialogContent>
     </AlertDialogPortal>


### PR DESCRIPTION
Stop emitting cancel when the dialog is closing if an operation is in progress by using props.busy in handleOpenChange. Replace AlertDialogAction/as-child wrapper with a plain button for the Revoke action and remove the unused import. Minor props handling change: assign defineProps to a props variable.

Fixes #1073