### PR TITLE
Migrate package deployment to GitHub Releases and update docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,15 +7,13 @@ on:
 env:
   DOTNET_VERSION: 10.0.x
   NODE_VERSION: 24.x
+  RELEASE_ASSET_NAME: acmebot.zip
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-    outputs:
-      version: ${{ steps.setup_version.outputs.version }}
-      major_version: ${{ steps.setup_version.outputs.major_version }}
+      contents: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -34,9 +32,8 @@ jobs:
     - name: Setup Version
       id: setup_version
       run: |
-        FULL_VERSION=${GITHUB_REF/refs\/tags\/v/}
-        echo "VERSION=${FULL_VERSION}" >> $GITHUB_OUTPUT
-        echo "MAJOR_VERSION=${FULL_VERSION%%.*}" >> $GITHUB_OUTPUT
+        FULL_VERSION=${GITHUB_REF_NAME#v}
+        echo "version=${FULL_VERSION}" >> "$GITHUB_OUTPUT"
 
     - name: Build Dashboard
       working-directory: ./src/Acmebot.App/ClientApp
@@ -51,35 +48,30 @@ jobs:
       run: dotnet publish -c Release --no-self-contained -o ./dist -p:Version=${{ steps.setup_version.outputs.version }} ./src/Acmebot.App
 
     - name: Archive artifacts
-      run: 7z a -mx=9 latest.zip ./dist/* ./dist/.[^.]*
+      run: 7z a -mx=9 ${{ env.RELEASE_ASSET_NAME }} ./dist/* ./dist/.[^.]*
 
     - name: Upload artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: dist
-        path: latest.zip
+        path: ${{ env.RELEASE_ASSET_NAME }}
 
-  deploy:
-    runs-on: ubuntu-latest
-    needs: publish
-    permissions:
-      contents: read
-      id-token: write
-    environment: production
-    steps:
-    - name: Azure Login
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
-      with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-    - name: Download artifacts
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: dist
-
-    - name: Upload to Blob
+    - name: Upload release asset and publish draft
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG_NAME: ${{ github.ref_name }}
       run: |
-        az storage blob upload --auth-mode login -f latest.zip --account-name stacmebotprod -c acmebot -n v${{ needs.publish.outputs.major_version }}/latest.zip --overwrite
-        az storage blob upload --auth-mode login -f latest.zip --account-name stacmebotprod -c acmebot -n v${{ needs.publish.outputs.major_version }}/${{ needs.publish.outputs.version }}.zip --overwrite
+        if ! gh release view "$TAG_NAME" > /dev/null 2>&1; then
+          echo "::error::Draft release $TAG_NAME does not exist. Create the tag and draft release manually before this workflow runs."
+          exit 1
+        fi
+
+        IS_DRAFT=$(gh release view "$TAG_NAME" --json isDraft --jq '.isDraft')
+
+        if [ "$IS_DRAFT" != "true" ]; then
+          echo "::error::Release $TAG_NAME is not a draft. Release assets must be uploaded before publishing immutable releases."
+          exit 1
+        fi
+
+        gh release upload "$TAG_NAME" "${{ env.RELEASE_ASSET_NAME }}" --clobber
+        gh release edit "$TAG_NAME" --draft=false

--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -41,7 +41,7 @@ param keyVaultSkuName string = 'standard'
 
 @description('Package URI deployed to the Function App.')
 #disable-next-line no-hardcoded-env-urls
-param appPackageUri string = 'https://stacmebotprod.blob.core.windows.net/acmebot/v5/latest.zip'
+param appPackageUri string = 'https://github.com/polymind-inc/acmebot/releases/latest/download/acmebot.zip'
 
 @description('Additional name/value pairs appended to the Function App app settings.')
 param additionalAppSettings appSettingType[] = []

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "16716232259059819569"
+      "templateHash": "11436136674992823003"
     }
   },
   "definitions": {
@@ -162,7 +162,7 @@
     },
     "appPackageUri": {
       "type": "string",
-      "defaultValue": "https://stacmebotprod.blob.core.windows.net/acmebot/v5/latest.zip",
+      "defaultValue": "https://github.com/polymind-inc/acmebot/releases/latest/download/acmebot.zip",
       "metadata": {
         "description": "Package URI deployed to the Function App."
       }

--- a/deploy/migrate/azuredeploy.bicep
+++ b/deploy/migrate/azuredeploy.bicep
@@ -5,7 +5,7 @@ targetScope = 'resourceGroup'
 param functionAppName string
 
 #disable-next-line no-hardcoded-env-urls
-var appPackageUri = 'https://stacmebotprod.blob.core.windows.net/acmebot/v5/latest.zip'
+var appPackageUri = 'https://github.com/polymind-inc/acmebot/releases/latest/download/acmebot.zip'
 
 resource functionApp 'Microsoft.Web/sites@2025-03-01' existing = {
   name: functionAppName

--- a/deploy/migrate/azuredeploy.json
+++ b/deploy/migrate/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "17574436574139873436"
+      "templateHash": "13231595133678368284"
     }
   },
   "parameters": {
@@ -18,7 +18,7 @@
     }
   },
   "variables": {
-    "appPackageUri": "https://stacmebotprod.blob.core.windows.net/acmebot/v5/latest.zip"
+    "appPackageUri": "https://github.com/polymind-inc/acmebot/releases/latest/download/acmebot.zip"
   },
   "resources": [
     {

--- a/deploy/update/azuredeploy.bicep
+++ b/deploy/update/azuredeploy.bicep
@@ -4,12 +4,6 @@ targetScope = 'resourceGroup'
 @minLength(1)
 param functionAppName string
 
-@description('Acmebot major version channel to deploy.')
-@allowed([
-  'v5'
-])
-param majorVersion string = 'v5'
-
 @description('Acmebot version to deploy. Use latest or a specific v5 version such as 5.0.0 or v5.0.0.')
 @minLength(1)
 param targetVersion string = 'latest'
@@ -39,6 +33,5 @@ resource functionAppDeploy 'Microsoft.Web/sites/extensions@2025-03-01' = {
 }
 
 output functionAppName string = functionApp.name
-output majorVersion string = majorVersion
 output targetVersion string = targetVersion
 output appPackageUri string = appPackageUri

--- a/deploy/update/azuredeploy.bicep
+++ b/deploy/update/azuredeploy.bicep
@@ -18,10 +18,11 @@ var versionIsLatest = toLower(targetVersion) == 'latest'
 var normalizedTargetVersion = startsWith(toLower(targetVersion), 'v')
   ? substring(targetVersion, 1, length(targetVersion) - 1)
   : targetVersion
-var packageFileName = versionIsLatest ? 'latest.zip' : '${normalizedTargetVersion}.zip'
 
 #disable-next-line no-hardcoded-env-urls
-var appPackageUri = 'https://stacmebotprod.blob.core.windows.net/acmebot/${majorVersion}/${packageFileName}'
+var appPackageUri = versionIsLatest
+  ? 'https://github.com/polymind-inc/acmebot/releases/latest/download/acmebot.zip'
+  : 'https://github.com/polymind-inc/acmebot/releases/download/v${normalizedTargetVersion}/acmebot.zip'
 
 resource functionApp 'Microsoft.Web/sites@2025-03-01' existing = {
   name: functionAppName

--- a/deploy/update/azuredeploy.json
+++ b/deploy/update/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "13891239680625672059"
+      "templateHash": "499901938734517665"
     }
   },
   "parameters": {
@@ -14,16 +14,6 @@
       "minLength": 1,
       "metadata": {
         "description": "Name of the existing Acmebot Function App to update."
-      }
-    },
-    "majorVersion": {
-      "type": "string",
-      "defaultValue": "v5",
-      "allowedValues": [
-        "v5"
-      ],
-      "metadata": {
-        "description": "Acmebot major version channel to deploy."
       }
     },
     "targetVersion": {
@@ -55,10 +45,6 @@
     "functionAppName": {
       "type": "string",
       "value": "[parameters('functionAppName')]"
-    },
-    "majorVersion": {
-      "type": "string",
-      "value": "[parameters('majorVersion')]"
     },
     "targetVersion": {
       "type": "string",

--- a/deploy/update/azuredeploy.json
+++ b/deploy/update/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "16749310730509452827"
+      "templateHash": "13891239680625672059"
     }
   },
   "parameters": {
@@ -38,8 +38,7 @@
   "variables": {
     "versionIsLatest": "[equals(toLower(parameters('targetVersion')), 'latest')]",
     "normalizedTargetVersion": "[if(startsWith(toLower(parameters('targetVersion')), 'v'), substring(parameters('targetVersion'), 1, sub(length(parameters('targetVersion')), 1)), parameters('targetVersion'))]",
-    "packageFileName": "[if(variables('versionIsLatest'), 'latest.zip', format('{0}.zip', variables('normalizedTargetVersion')))]",
-    "appPackageUri": "[format('https://stacmebotprod.blob.core.windows.net/acmebot/{0}/{1}', parameters('majorVersion'), variables('packageFileName'))]"
+    "appPackageUri": "[if(variables('versionIsLatest'), 'https://github.com/polymind-inc/acmebot/releases/latest/download/acmebot.zip', format('https://github.com/polymind-inc/acmebot/releases/download/v{0}/acmebot.zip', variables('normalizedTargetVersion')))]"
   },
   "resources": [
     {

--- a/deploy/update/uiFormDefinition.json
+++ b/deploy/update/uiFormDefinition.json
@@ -52,26 +52,6 @@
                   }
                 },
                 {
-                  "name": "majorVersion",
-                  "type": "Microsoft.Common.DropDown",
-                  "label": "Major version",
-                  "placeholder": "Major version",
-                  "defaultValue": {
-                    "value": "v5"
-                  },
-                  "toolTip": "Acmebot major version to deploy. Only v5 releases are currently supported.",
-                  "constraints": {
-                    "allowedValues": [
-                      {
-                        "label": "v5",
-                        "value": "v5"
-                      }
-                    ],
-                    "required": true
-                  },
-                  "visible": true
-                },
-                {
                   "name": "targetVersionType",
                   "type": "Microsoft.Common.OptionsGroup",
                   "label": "Target version",
@@ -131,7 +111,6 @@
       "location": "[steps('basics').targetSection.functionApp.location]",
       "parameters": {
         "functionAppName": "[steps('basics').targetSection.functionApp.name]",
-        "majorVersion": "[steps('basics').packageSection.majorVersion]",
         "targetVersion": "[if(equals(steps('basics').packageSection.targetVersionType, 'latest'), 'latest', steps('basics').packageSection.specificVersion)]"
       }
     }

--- a/deploy/update/uiFormDefinition.json
+++ b/deploy/update/uiFormDefinition.json
@@ -59,7 +59,7 @@
                   "defaultValue": {
                     "value": "v5"
                   },
-                  "toolTip": "Acmebot major version channel to deploy.",
+                  "toolTip": "Acmebot major version to deploy. Only v5 releases are currently supported.",
                   "constraints": {
                     "allowedValues": [
                       {
@@ -75,7 +75,7 @@
                   "name": "targetVersionType",
                   "type": "Microsoft.Common.OptionsGroup",
                   "label": "Target version",
-                  "toolTip": "Deploy the latest package for the selected major version or enter a specific release version.",
+                  "toolTip": "Deploy the latest GitHub Release asset or enter a specific release version.",
                   "defaultValue": "latest",
                   "constraints": {
                     "allowedValues": [
@@ -97,7 +97,7 @@
                   "type": "Microsoft.Common.InfoBox",
                   "options": {
                     "style": "Warning",
-                    "text": "The specified package version must already be published. Deployment fails if the package cannot be found."
+                    "text": "The specified GitHub Release must already include the acmebot.zip asset. Deployment fails if the asset cannot be found."
                   },
                   "visible": "[if(equals(steps('basics').packageSection.targetVersionType, 'specific'), true, false)]"
                 },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,5 +1,48 @@
 import { defineConfig } from "vitepress";
 
+const guideSidebar = [
+  {
+    text: "Start",
+    items: [
+      { text: "Overview", link: "/guide/" },
+      { text: "Getting Started", link: "/guide/getting-started" }
+    ]
+  },
+  {
+    text: "Deploy",
+    items: [
+      { text: "Deployment", link: "/guide/deployment" },
+      { text: "Migrating from v4 to v5", link: "/guide/migration-v5" }
+    ]
+  },
+  {
+    text: "Configure",
+    items: [
+      { text: "DNS Providers", link: "/guide/dns-providers" },
+      { text: "Certificate Authorities", link: "/guide/certificate-authorities" },
+      { text: "Azure Service Integration", link: "/guide/service-integration" }
+    ]
+  },
+  {
+    text: "Operate",
+    items: [
+      { text: "Dashboard", link: "/guide/dashboard" },
+      { text: "Operations", link: "/guide/operations" },
+      { text: "Troubleshooting", link: "/guide/troubleshooting" },
+      { text: "FAQ", link: "/guide/faq" }
+    ]
+  },
+  {
+    text: "Reference",
+    items: [
+      { text: "Configuration", link: "/reference/configuration" },
+      { text: "Architecture", link: "/reference/architecture" },
+      { text: "HTTP API", link: "/reference/api" },
+      { text: "Security", link: "/reference/security" }
+    ]
+  }
+];
+
 export default defineConfig({
   lang: "en-US",
   title: "Acmebot",
@@ -25,58 +68,8 @@ export default defineConfig({
       { text: "GitHub", link: "https://github.com/polymind-inc/acmebot" }
     ],
     sidebar: {
-      "/guide/": [
-        {
-          text: "Guide",
-          items: [
-            { text: "Overview", link: "/guide/" },
-            { text: "Getting Started", link: "/guide/getting-started" },
-            { text: "Deployment", link: "/guide/deployment" },
-            { text: "Dashboard", link: "/guide/dashboard" },
-            { text: "DNS Providers", link: "/guide/dns-providers" },
-            { text: "Certificate Authorities", link: "/guide/certificate-authorities" },
-            { text: "Operations", link: "/guide/operations" },
-            { text: "Azure Service Integration", link: "/guide/service-integration" },
-            { text: "Troubleshooting", link: "/guide/troubleshooting" },
-            { text: "FAQ", link: "/guide/faq" }
-          ]
-        },
-        {
-          text: "Reference",
-          items: [
-            { text: "Configuration", link: "/reference/configuration" },
-            { text: "Architecture", link: "/reference/architecture" },
-            { text: "HTTP API", link: "/reference/api" },
-            { text: "Security", link: "/reference/security" }
-          ]
-        }
-      ],
-      "/reference/": [
-        {
-          text: "Guide",
-          items: [
-            { text: "Overview", link: "/guide/" },
-            { text: "Getting Started", link: "/guide/getting-started" },
-            { text: "Deployment", link: "/guide/deployment" },
-            { text: "Dashboard", link: "/guide/dashboard" },
-            { text: "DNS Providers", link: "/guide/dns-providers" },
-            { text: "Certificate Authorities", link: "/guide/certificate-authorities" },
-            { text: "Operations", link: "/guide/operations" },
-            { text: "Azure Service Integration", link: "/guide/service-integration" },
-            { text: "Troubleshooting", link: "/guide/troubleshooting" },
-            { text: "FAQ", link: "/guide/faq" }
-          ]
-        },
-        {
-          text: "Reference",
-          items: [
-            { text: "Configuration", link: "/reference/configuration" },
-            { text: "Architecture", link: "/reference/architecture" },
-            { text: "HTTP API", link: "/reference/api" },
-            { text: "Security", link: "/reference/security" }
-          ]
-        }
-      ]
+      "/guide/": guideSidebar,
+      "/reference/": guideSidebar
     },
     socialLinks: [
       { icon: "github", link: "https://github.com/polymind-inc/acmebot" }

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -101,7 +101,9 @@ Use the update template to redeploy the application package while preserving exi
 
 [Update an existing deployment](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fupdate%2Fazuredeploy.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fupdate%2FuiFormDefinition.json)
 
-The update flow asks for the existing Function App and package version. It does not recreate Key Vault, Storage, or monitoring resources.
+The update flow asks for the existing Function App and package version. It deploys the `acmebot.zip` asset attached to GitHub Releases and does not recreate Key Vault, Storage, or monitoring resources.
+
+For Acmebot v4 deployments, use the migration flow instead of the update flow. See [Migrating from v4 to v5](./migration-v5).
 
 ## Terraform
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -47,6 +47,7 @@ The dashboard is a same-origin web app served by the Function App. It calls `/ap
 | --- | --- |
 | Deploy a new environment | [Getting Started](./getting-started) |
 | Understand portal template inputs | [Deployment](./deployment) |
+| Migrate an existing v4 deployment | [Migrating from v4 to v5](./migration-v5) |
 | Issue, renew, or revoke a certificate | [Dashboard](./dashboard) |
 | Configure Azure DNS, Cloudflare, Route 53, or another DNS provider | [DNS Providers](./dns-providers) |
 | Use EAB or a non-Let's Encrypt CA | [Certificate Authorities](./certificate-authorities) |

--- a/docs/guide/migration-v5.md
+++ b/docs/guide/migration-v5.md
@@ -44,7 +44,7 @@ az functionapp config appsettings list \
 
 ## Automatic Migration
 
-The automatic migration uses the ARM template in `deploy/migrate`. The template asks for the existing Function App, preserves current app settings, switches `WEBSITE_RUN_FROM_PACKAGE` to `1`, applies the v5 worker and .NET site runtime settings, and deploys the latest v5 package.
+The automatic migration uses the ARM template in `deploy/migrate`. The template asks for the existing Function App, preserves current app settings, switches `WEBSITE_RUN_FROM_PACKAGE` to `1`, applies the v5 worker and .NET site runtime settings, and deploys the latest package from GitHub Releases.
 
 <div class="deploy-buttons">
   <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fmigrate%2Fazuredeploy.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fmigrate%2FuiFormDefinition.json">Azure Public</a>

--- a/docs/guide/migration-v5.md
+++ b/docs/guide/migration-v5.md
@@ -1,0 +1,158 @@
+# Migrating from v4 to v5
+
+Acmebot v5 moves the app from the .NET in-process worker to the .NET isolated worker. Existing certificates, Key Vault, DNS provider settings, managed identity, and monitoring resources can stay in place.
+
+Use the automatic migration unless you need to make the same changes manually through your own deployment pipeline.
+
+## What the Migration Changes
+
+The in-place migration updates only the existing Function App worker setting, .NET site runtime, Run From Package mode, and application package.
+
+| Area | Typical v4 value | v5 value |
+| --- | --- | --- |
+| Function worker | `FUNCTIONS_WORKER_RUNTIME=dotnet` | `FUNCTIONS_WORKER_RUNTIME=dotnet-isolated` |
+| .NET site runtime | `netFrameworkVersion=v8.0` | `netFrameworkVersion=v10.0` |
+| Run From Package | `WEBSITE_RUN_FROM_PACKAGE=https://stacmebotprod.blob.core.windows.net/keyvault-acmebot/v4/latest.zip` | `WEBSITE_RUN_FROM_PACKAGE=1` |
+| Package deployment | Package URL stored in app settings | GitHub Release asset deployed by ARM OneDeploy or ZIP deploy |
+
+v5 does not store the package URL in `WEBSITE_RUN_FROM_PACKAGE`. The v5 GitHub Release asset URL is used only as the deployment source for the ARM template or `az webapp deploy`.
+
+The migration preserves the existing app settings. Do not remove `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING` or `WEBSITE_CONTENTSHARE` during an in-place migration; when those settings exist, v5 continues to use the existing Azure Files content share for ACME account state.
+
+The migration template does not recreate the Function App, App Service plan, Storage account, Key Vault, Application Insights, or Log Analytics workspace. To move to the new v5 default architecture on Flex Consumption, deploy a new v5 environment instead of using the in-place migration.
+
+## Before You Start
+
+Plan a short maintenance window. The Function App restarts during migration, and certificate operations in progress should be allowed to finish before you start.
+
+Before changing the app:
+
+1. Confirm the existing v4 deployment is healthy.
+2. Record the Function App name and resource group.
+3. Export the current app settings and store the file securely because it may include DNS provider credentials.
+4. Confirm the Function App managed identity still has Key Vault and DNS provider permissions.
+5. Keep the dashboard authentication configuration in place.
+
+You can export the current app settings with Azure CLI:
+
+```bash
+az functionapp config appsettings list \
+  --resource-group <resource-group> \
+  --name <function-app-name> \
+  --output json > acmebot-v4-appsettings.json
+```
+
+## Automatic Migration
+
+The automatic migration uses the ARM template in `deploy/migrate`. The template asks for the existing Function App, preserves current app settings, switches `WEBSITE_RUN_FROM_PACKAGE` to `1`, applies the v5 worker and .NET site runtime settings, and deploys the latest v5 package.
+
+<div class="deploy-buttons">
+  <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fmigrate%2Fazuredeploy.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fmigrate%2FuiFormDefinition.json">Azure Public</a>
+  <a class="secondary" href="https://portal.azure.cn/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fmigrate%2Fazuredeploy.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fmigrate%2FuiFormDefinition.json">Azure China</a>
+  <a class="secondary" href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fmigrate%2Fazuredeploy.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fpolymind-inc%2Facmebot%2Fmaster%2Fdeploy%2Fmigrate%2FuiFormDefinition.json">Azure Government</a>
+</div>
+
+### Portal Steps
+
+1. Open the migration template for your Azure cloud.
+2. Select the subscription that contains the existing Function App.
+3. Select the existing Acmebot v4 Function App.
+4. Review and create the deployment.
+5. Wait for the deployment to complete.
+6. Restart the Function App if the portal does not show the app as restarted.
+
+### Azure CLI
+
+Run the template deployment against the resource group that contains the existing Function App:
+
+```bash
+az deployment group create \
+  --resource-group <resource-group> \
+  --template-uri https://raw.githubusercontent.com/polymind-inc/acmebot/master/deploy/migrate/azuredeploy.json \
+  --parameters functionAppName=<function-app-name>
+```
+
+## Manual Migration
+
+Manual migration is useful when you need to apply the same changes through an internal deployment process.
+
+1. Stop the Function App.
+2. Preserve all existing Acmebot, DNS provider, Key Vault, Storage, Application Insights, authentication, and webhook settings.
+3. Set the Function App runtime app settings. This replaces the v4 URL-based Run From Package setting with `WEBSITE_RUN_FROM_PACKAGE=1`:
+
+```bash
+az functionapp config appsettings set \
+  --resource-group <resource-group> \
+  --name <function-app-name> \
+  --settings FUNCTIONS_WORKER_RUNTIME=dotnet-isolated WEBSITE_RUN_FROM_PACKAGE=1
+```
+
+4. Set the .NET site runtime:
+
+```bash
+az functionapp config set \
+  --resource-group <resource-group> \
+  --name <function-app-name> \
+  --net-framework-version v10.0
+```
+
+5. Deploy the v5 package from the GitHub Release asset. The URL is used only as the deployment source and is not stored in `WEBSITE_RUN_FROM_PACKAGE`:
+
+```bash
+az webapp deploy \
+  --resource-group <resource-group> \
+  --name <function-app-name> \
+  --src-url https://github.com/polymind-inc/acmebot/releases/latest/download/acmebot.zip \
+  --type zip \
+  --async true
+```
+
+6. Start or restart the Function App.
+
+```bash
+az functionapp restart \
+  --resource-group <resource-group> \
+  --name <function-app-name>
+```
+
+When adding new Acmebot app settings after migration, prefer the double-underscore form used by the v5 documentation, such as `Acmebot__Endpoint`. Existing `Acmebot:` settings can remain in an in-place migration.
+
+## Verify the Migration
+
+After the Function App starts:
+
+1. Open the dashboard and confirm the footer shows an Acmebot v5 version.
+2. Confirm existing certificates appear in the dashboard.
+3. Confirm existing certificates issued by v4 are shown as Acmebot-managed certificates.
+4. Load DNS zones from the dashboard.
+5. Renew a low-risk certificate or issue a test certificate from a staging ACME endpoint.
+6. Check Application Insights for startup errors, configuration validation failures, and DNS or Key Vault authorization failures.
+
+## Roll Back
+
+If the migrated app does not start and you need to return to v4, restore the app settings snapshot. To roll back manually while keeping the non-URL Run From Package mode, reapply the v4 runtime values and deploy the v4 package from the release you are rolling back to:
+
+```bash
+az functionapp config appsettings set \
+  --resource-group <resource-group> \
+  --name <function-app-name> \
+  --settings FUNCTIONS_WORKER_RUNTIME=dotnet FUNCTIONS_INPROC_NET8_ENABLED=1 WEBSITE_RUN_FROM_PACKAGE=1
+
+az functionapp config set \
+  --resource-group <resource-group> \
+  --name <function-app-name> \
+  --net-framework-version v8.0
+
+az webapp deploy \
+  --resource-group <resource-group> \
+  --name <function-app-name> \
+  --src-url <v4-package-url> \
+  --type zip \
+  --async true
+
+az functionapp restart \
+  --resource-group <resource-group> \
+  --name <function-app-name>
+```
+
+Review Application Insights and the Function App log stream before trying the migration again.


### PR DESCRIPTION
This pull request makes significant improvements to the deployment, release, and documentation process for Acmebot. The main focus is migrating release asset hosting from Azure Blob Storage to GitHub Releases, simplifying deployment parameters, and updating documentation and UI to reflect these changes.

**Deployment and Release Process Modernization:**

* Migrated release asset hosting from Azure Blob Storage to GitHub Releases by updating all deployment templates (`.bicep` and `.json` files) to reference the `acmebot.zip` asset from GitHub Releases instead of the Azure blob URL. This affects both new deployments and updates. [[1]](diffhunk://#diff-f2ceaf2ff50b426e1177815f493418fa465b9944cea97319670e46a214d63328L44-R44) [[2]](diffhunk://#diff-150fe65cc616fccb2fd239782a3b8f1fded84c00083e6901e2f09311e3b6288bL165-R165) [[3]](diffhunk://#diff-5225101bd2ee7a09c4747b6ae10ea1fba20958a704ed16f39770331f8d6efaecL8-R8) [[4]](diffhunk://#diff-2bef72043e63ef933c4e8b40013932d150edd7622b574d3c8a3eebd5ce2802a1L21-R21) [[5]](diffhunk://#diff-6fc2ed304f6316907c4f267fb71c5bd47837d7b6cb8456a9058123c7dd44ef8aL21-R19) [[6]](diffhunk://#diff-3f8d2fa920e19fd352c287dff93736d74e8ce0bab33dc958471b40c693c0e6dbL41-R31)
* Simplified the update deployment process by removing the `majorVersion` parameter and channel concept, making version selection rely solely on the target version and the corresponding GitHub Release asset. [[1]](diffhunk://#diff-6fc2ed304f6316907c4f267fb71c5bd47837d7b6cb8456a9058123c7dd44ef8aL7-L12) [[2]](diffhunk://#diff-3f8d2fa920e19fd352c287dff93736d74e8ce0bab33dc958471b40c693c0e6dbL19-L28) [[3]](diffhunk://#diff-3f8d2fa920e19fd352c287dff93736d74e8ce0bab33dc958471b40c693c0e6dbL60-L63) [[4]](diffhunk://#diff-63b7823fe9b46834a9b764f674b713d9dd7abbd1cdc0f62932c9098ac1344addL54-R58) [[5]](diffhunk://#diff-63b7823fe9b46834a9b764f674b713d9dd7abbd1cdc0f62932c9098ac1344addL134)

**GitHub Actions Workflow Enhancements:**

* Updated the `publish.yml` workflow to:
  - Set the release asset name to `acmebot.zip`
  - Grant write permissions for release uploads
  - Archive and upload the release asset as `acmebot.zip`
  - Remove the Azure Blob upload and deploy jobs, replacing them with logic to upload the asset to a GitHub Release and publish the release when ready (manual draft release required). [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R10-R16) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L37-R36) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L54-R77)

**Documentation and UI Updates:**

* Updated documentation and deployment UI to instruct users about the new release asset location, clarify that the update flow uses GitHub Releases, and add guidance for v4 to v5 migrations. [[1]](diffhunk://#diff-44e6ff52727b134ce19559fdf93877483b7473135fa5432f7cf34e04722b2a15L104-R106) [[2]](diffhunk://#diff-a9f09e5fd39208124b216a0cac772b60ab660bf177b9ecd1ab87f18006cecdbcR50)
* Improved the VitePress documentation sidebar structure for better navigation and added a dedicated migration guide link. [[1]](diffhunk://#diff-3def678deb1b1d5a53948eb8491817dde4dc881e032e785fc61cc93d334eefcdL3-L65) [[2]](diffhunk://#diff-3def678deb1b1d5a53948eb8491817dde4dc881e032e785fc61cc93d334eefcdL79-R72)

**Other Technical Cleanups:**

* Updated template hashes in generated deployment files to reflect changes. [[1]](diffhunk://#diff-150fe65cc616fccb2fd239782a3b8f1fded84c00083e6901e2f09311e3b6288bL9-R9) [[2]](diffhunk://#diff-2bef72043e63ef933c4e8b40013932d150edd7622b574d3c8a3eebd5ce2802a1L8-R8) [[3]](diffhunk://#diff-3f8d2fa920e19fd352c287dff93736d74e8ce0bab33dc958471b40c693c0e6dbL8-R8)

These changes streamline the release process, reduce Azure dependency, and make deployments more robust and easier to manage.