### PR TITLE
Migrate Function App settings and use zip deploy

### DIFF
--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -465,7 +465,7 @@ resource functionAppDeploy 'Microsoft.Web/sites/extensions@2025-03-01' = {
   #disable-next-line BCP187
   properties: {
     packageUri: appPackageUri
-    remoteBuild: false
+    type: 'zip'
   }
 }
 

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "11436136674992823003"
+      "templateHash": "12738268151428963457"
     }
   },
   "definitions": {
@@ -389,7 +389,7 @@
       "name": "[format('{0}/{1}', variables('functionAppName'), 'onedeploy')]",
       "properties": {
         "packageUri": "[parameters('appPackageUri')]",
-        "remoteBuild": false
+        "type": "zip"
       },
       "dependsOn": [
         "functionApp"

--- a/deploy/migrate/appsettings.bicep
+++ b/deploy/migrate/appsettings.bicep
@@ -5,6 +5,7 @@ targetScope = 'resourceGroup'
 param functionAppName string
 
 @description('Merged application settings to apply to the Function App.')
+@secure()
 param appSettings object
 
 resource functionApp 'Microsoft.Web/sites@2025-03-01' existing = {

--- a/deploy/migrate/appsettings.bicep
+++ b/deploy/migrate/appsettings.bicep
@@ -1,0 +1,18 @@
+targetScope = 'resourceGroup'
+
+@description('Name of the existing Acmebot Function App to update.')
+@minLength(1)
+param functionAppName string
+
+@description('Merged application settings to apply to the Function App.')
+param appSettings object
+
+resource functionApp 'Microsoft.Web/sites@2025-03-01' existing = {
+  name: functionAppName
+}
+
+resource functionAppAppSettings 'Microsoft.Web/sites/config@2025-03-01' = {
+  parent: functionApp
+  name: 'appsettings'
+  properties: appSettings
+}

--- a/deploy/migrate/azuredeploy.bicep
+++ b/deploy/migrate/azuredeploy.bicep
@@ -11,6 +11,18 @@ resource functionApp 'Microsoft.Web/sites@2025-03-01' existing = {
   name: functionAppName
 }
 
+var existingAppSettings = list('${functionApp.id}/config/appsettings', '2025-03-01').properties
+var preservedAppSettings = toObject(
+  filter(items(existingAppSettings), setting => setting.key != 'FUNCTIONS_INPROC_NET8_ENABLED'),
+  setting => setting.key,
+  setting => setting.value
+)
+var migratedAppSettings = union(preservedAppSettings, {
+  FUNCTIONS_EXTENSION_VERSION: '~4'
+  FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
+  WEBSITE_RUN_FROM_PACKAGE: '1'
+})
+
 resource functionAppRuntimeConfig 'Microsoft.Web/sites/config@2025-03-01' = {
   parent: functionApp
   name: 'web'
@@ -19,14 +31,11 @@ resource functionAppRuntimeConfig 'Microsoft.Web/sites/config@2025-03-01' = {
   }
 }
 
-resource functionAppAppSettings 'Microsoft.Web/sites/config@2025-03-01' = {
-  parent: functionApp
-  name: 'appsettings'
-  properties: union(list('${functionApp.id}/config/appsettings', '2025-03-01').properties, {
-    FUNCTIONS_EXTENSION_VERSION: '~4'
-    FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
-    WEBSITE_RUN_FROM_PACKAGE: '1'
-  })
+module functionAppAppSettings 'appsettings.bicep' = {
+  params: {
+    functionAppName: functionApp.name
+    appSettings: migratedAppSettings
+  }
 }
 
 resource functionAppDeploy 'Microsoft.Web/sites/extensions@2025-03-01' = {
@@ -35,7 +44,7 @@ resource functionAppDeploy 'Microsoft.Web/sites/extensions@2025-03-01' = {
   #disable-next-line BCP187
   properties: {
     packageUri: appPackageUri
-    remoteBuild: false
+    type: 'zip'
   }
   dependsOn: [
     functionAppAppSettings

--- a/deploy/migrate/azuredeploy.json
+++ b/deploy/migrate/azuredeploy.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
   "contentVersion": "1.0.0.0",
   "metadata": {
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "13231595133678368284"
+      "templateHash": "2442440675729594827"
     }
   },
   "parameters": {
@@ -20,8 +21,14 @@
   "variables": {
     "appPackageUri": "https://github.com/polymind-inc/acmebot/releases/latest/download/acmebot.zip"
   },
-  "resources": [
-    {
+  "resources": {
+    "functionApp": {
+      "existing": true,
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2025-03-01",
+      "name": "[parameters('functionAppName')]"
+    },
+    "functionAppRuntimeConfig": {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2025-03-01",
       "name": "[format('{0}/{1}', parameters('functionAppName'), 'web')]",
@@ -29,24 +36,71 @@
         "netFrameworkVersion": "v10.0"
       }
     },
-    {
-      "type": "Microsoft.Web/sites/config",
-      "apiVersion": "2025-03-01",
-      "name": "[format('{0}/{1}', parameters('functionAppName'), 'appsettings')]",
-      "properties": "[union(list(format('{0}/config/appsettings', resourceId('Microsoft.Web/sites', parameters('functionAppName'))), '2025-03-01').properties, createObject('FUNCTIONS_EXTENSION_VERSION', '~4', 'FUNCTIONS_WORKER_RUNTIME', 'dotnet-isolated', 'WEBSITE_RUN_FROM_PACKAGE', '1'))]"
-    },
-    {
+    "functionAppDeploy": {
       "type": "Microsoft.Web/sites/extensions",
       "apiVersion": "2025-03-01",
       "name": "[format('{0}/{1}', parameters('functionAppName'), 'onedeploy')]",
       "properties": {
         "packageUri": "[variables('appPackageUri')]",
-        "remoteBuild": false
+        "type": "zip"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/config', parameters('functionAppName'), 'appsettings')]",
-        "[resourceId('Microsoft.Web/sites/config', parameters('functionAppName'), 'web')]"
+        "functionAppAppSettings",
+        "functionAppRuntimeConfig"
       ]
+    },
+    "functionAppAppSettings": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('functionAppAppSettings-{0}', uniqueString('functionAppAppSettings', deployment().name))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "functionAppName": {
+            "value": "[parameters('functionAppName')]"
+          },
+          "appSettings": {
+            "value": "[union(toObject(filter(items(list(format('{0}/config/appsettings', resourceId('Microsoft.Web/sites', parameters('functionAppName'))), '2025-03-01').properties), lambda('setting', not(equals(lambdaVariables('setting').key, 'FUNCTIONS_INPROC_NET8_ENABLED')))), lambda('setting', lambdaVariables('setting').key), lambda('setting', lambdaVariables('setting').value)), createObject('FUNCTIONS_EXTENSION_VERSION', '~4', 'FUNCTIONS_WORKER_RUNTIME', 'dotnet-isolated', 'WEBSITE_RUN_FROM_PACKAGE', '1'))]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.43.8.12551",
+              "templateHash": "18096985042760134925"
+            }
+          },
+          "parameters": {
+            "functionAppName": {
+              "type": "string",
+              "minLength": 1,
+              "metadata": {
+                "description": "Name of the existing Acmebot Function App to update."
+              }
+            },
+            "appSettings": {
+              "type": "object",
+              "metadata": {
+                "description": "Merged application settings to apply to the Function App."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Web/sites/config",
+              "apiVersion": "2025-03-01",
+              "name": "[format('{0}/{1}', parameters('functionAppName'), 'appsettings')]",
+              "properties": "[parameters('appSettings')]"
+            }
+          ]
+        }
+      }
     }
-  ]
+  }
 }

--- a/deploy/migrate/azuredeploy.json
+++ b/deploy/migrate/azuredeploy.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "2442440675729594827"
+      "templateHash": "18020216459641093548"
     }
   },
   "parameters": {
@@ -73,7 +73,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.43.8.12551",
-              "templateHash": "18096985042760134925"
+              "templateHash": "16877996648624795941"
             }
           },
           "parameters": {
@@ -85,7 +85,7 @@
               }
             },
             "appSettings": {
-              "type": "object",
+              "type": "secureObject",
               "metadata": {
                 "description": "Merged application settings to apply to the Function App."
               }

--- a/deploy/update/azuredeploy.bicep
+++ b/deploy/update/azuredeploy.bicep
@@ -28,7 +28,7 @@ resource functionAppDeploy 'Microsoft.Web/sites/extensions@2025-03-01' = {
   #disable-next-line BCP187
   properties: {
     packageUri: appPackageUri
-    remoteBuild: false
+    type: 'zip'
   }
 }
 

--- a/deploy/update/azuredeploy.json
+++ b/deploy/update/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "499901938734517665"
+      "templateHash": "10678533054684801357"
     }
   },
   "parameters": {
@@ -37,7 +37,7 @@
       "name": "[format('{0}/{1}', parameters('functionAppName'), 'onedeploy')]",
       "properties": {
         "packageUri": "[variables('appPackageUri')]",
-        "remoteBuild": false
+        "type": "zip"
       }
     }
   ],


### PR DESCRIPTION
Add a reusable appsettings.bicep module and update migration template to preserve existing settings (except FUNCTIONS_INPROC_NET8_ENABLED) while applying FUNCTIONS_EXTENSION_VERSION=~4, FUNCTIONS_WORKER_RUNTIME=dotnet-isolated, and WEBSITE_RUN_FROM_PACKAGE=1. Replace deprecated remoteBuild property with type='zip' for one-step deployments across bicep and generated ARM templates, and update generated template metadata/hashes and deployment structure for the migrate flow.

Fixes #1089 