### PR TITLE
[codex] Add Azure DNS managed identity overrides

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -41,7 +41,7 @@ The Function App can use either:
 - A system-assigned managed identity, which is simplest for a single deployment.
 - A user-assigned managed identity, useful when you want a stable identity across redeployments or multiple apps.
 
-When using a user-assigned identity, Acmebot sets `Acmebot__ManagedIdentityClientId` so Azure SDK clients choose that identity.
+When using a user-assigned identity, Acmebot sets `Acmebot__ManagedIdentityClientId` as the app-wide identity.
 
 ### Key Vault
 
@@ -117,7 +117,7 @@ Use Terraform when you need repeatable deployments, custom network or authentica
 
 - Use a staging ACME endpoint for the first validation when possible.
 - Scope DNS provider credentials to the smallest practical set of zones.
-- Use a user-assigned identity if you need stable identity across app recreation.
+- Use a user-assigned identity if you need stable app-wide identity across app recreation.
 - Confirm Key Vault RBAC and DNS RBAC after deployment.
 - Enable dashboard authentication before using the app.
 - Configure webhook notifications if certificate operations should alert an operations channel.

--- a/docs/guide/dns-providers.md
+++ b/docs/guide/dns-providers.md
@@ -67,14 +67,16 @@ Acmebot__Akamai__AccessToken=<access-token>
 
 ## Azure DNS
 
-Azure DNS uses the Function App managed identity.
+Azure DNS uses the app-wide managed identity by default. For manual app setting configuration, set `ManagedIdentityClientId` to override it.
 
 | Option | Description |
 | --- | --- |
 | `SubscriptionId` | Azure subscription ID that contains the public DNS zones Acmebot manages. This can differ from the Function App subscription. |
+| `ManagedIdentityClientId` | Optional client ID of a user-assigned managed identity assigned to the Function App for Azure DNS. Leave empty to use the app-wide managed identity. |
 
 ```text
 Acmebot__AzureDns__SubscriptionId=<subscription-id>
+Acmebot__AzureDns__ManagedIdentityClientId=<user-assigned-client-id>
 ```
 
 Assign the identity a role that can list DNS zones and manage TXT records, such as `DNS Zone Contributor`, on the DNS zone or a tightly scoped resource group.
@@ -83,14 +85,16 @@ If the DNS zone is in a different subscription than the Function App, set `Subsc
 
 ## Azure Private DNS
 
-Azure Private DNS also uses the Function App managed identity.
+Azure Private DNS also uses the app-wide managed identity by default. For manual app setting configuration, set `ManagedIdentityClientId` to override it.
 
 | Option | Description |
 | --- | --- |
 | `SubscriptionId` | Azure subscription ID that contains the private DNS zones Acmebot manages. |
+| `ManagedIdentityClientId` | Optional client ID of a user-assigned managed identity assigned to the Function App for Azure Private DNS. Leave empty to use the app-wide managed identity. |
 
 ```text
 Acmebot__AzurePrivateDns__SubscriptionId=<subscription-id>
+Acmebot__AzurePrivateDns__ManagedIdentityClientId=<user-assigned-client-id>
 ```
 
 Assign `Private DNS Zone Contributor` on the private DNS zone or a tightly scoped resource group.
@@ -356,7 +360,7 @@ Acmebot__TransIp__CustomerName=<customer-name>
 Acmebot__TransIp__PrivateKeyName=<key-name>
 ```
 
-The Function App managed identity must be allowed to use the Key Vault key for signing.
+The app-wide managed identity must be allowed to use the Key Vault key for signing.
 
 ## UnitedDomains
 

--- a/docs/guide/migration-v5.md
+++ b/docs/guide/migration-v5.md
@@ -30,7 +30,7 @@ Before changing the app:
 1. Confirm the existing v4 deployment is healthy.
 2. Record the Function App name and resource group.
 3. Export the current app settings and store the file securely because it may include DNS provider credentials.
-4. Confirm the Function App managed identity still has Key Vault and DNS provider permissions.
+4. Confirm the configured managed identities still have Key Vault and DNS provider permissions.
 5. Keep the dashboard authentication configuration in place.
 
 You can export the current app settings with Azure CLI:

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -41,6 +41,7 @@ What to verify:
 - `dnsAlias` has the required CNAME or delegation in place.
 - A TXT record appears at `_acme-challenge.<name>` while the operation is running.
 - `Acmebot__UseSystemNameServer=true` is used only when the validation design requires the platform resolver.
+- For Azure DNS or Azure Private DNS, the selected identity has zone permissions. Provider-specific managed identity client IDs override `Acmebot__ManagedIdentityClientId`; when they are empty, verify the app-wide identity has DNS permissions.
 
 See [DNS Providers](./dns-providers) for provider-specific settings and propagation behavior.
 
@@ -51,7 +52,7 @@ Typical causes:
 - The Function App identity does not have certificate management permissions.
 - The vault permission model changed between Azure RBAC and access policies.
 - `Acmebot__VaultBaseUrl` points to the wrong vault.
-- A user-assigned managed identity is configured but `Acmebot__ManagedIdentityClientId` is missing or incorrect.
+- A user-assigned managed identity should be used for Key Vault but `Acmebot__ManagedIdentityClientId` is missing or incorrect.
 
 What to verify:
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -55,8 +55,8 @@ Acmebot uses `IAcmeStateStore` for ACME account state.
 
 | Environment | Store |
 | --- | --- |
-| Azure without Azure Files content share | Blob storage container `acmebot-state`. |
-| Local development or Azure Files content share deployments | File system under `%HOME%/data/.acmebot/<endpoint-host>/`. |
+| Without Azure Files content share | Blob storage container `acmebot-state`. |
+| With Azure Files content share | File system under `%HOME%/data/.acmebot/<endpoint-host>/`. |
 
 The v5 template creates the `acmebot-state` container.
 
@@ -64,13 +64,14 @@ The v5 template creates the `acmebot-state` container.
 
 Azure resource access uses `DefaultAzureCredential`.
 
-In Azure, this normally resolves to the Function App managed identity. If `Acmebot__ManagedIdentityClientId` is set, Azure SDK clients use that user-assigned managed identity.
+In Azure, this normally resolves to the Function App system-assigned managed identity. `Acmebot__ManagedIdentityClientId` selects the app-wide user-assigned managed identity for Key Vault certificate operations, Key Vault keys, and Azure DNS providers that do not override it.
 
-The same identity is used for:
+Azure DNS providers can select their own user-assigned managed identity through provider-specific settings:
 
-- Key Vault certificate operations.
-- Azure DNS and Azure Private DNS provider operations.
-- TransIP request signing with Key Vault keys.
+- `Acmebot__AzureDns__ManagedIdentityClientId`
+- `Acmebot__AzurePrivateDns__ManagedIdentityClientId`
+
+When a provider-specific client ID is empty, that provider uses the app-wide managed identity from `Acmebot__ManagedIdentityClientId`. If the app-wide client ID is also empty, Azure SDK clients use the system-assigned managed identity. TransIP request signing uses the Key Vault identity because its private key is stored in Key Vault.
 
 ## Key Vault Metadata
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -26,7 +26,7 @@ Acmebot__Endpoint=https://acme-v02.api.letsencrypt.org/directory
 | `Acmebot__PreferredProfile` | Empty | Preferred ACME profile when the CA advertises profiles. |
 | `Acmebot__RenewBeforeExpiry` | `30` | Number of days before certificate expiry when scheduled renewal should run. Valid range is 0 to 365. |
 | `Acmebot__UseSystemNameServer` | `false` | Use the system DNS resolver instead of Google Public DNS for challenge verification. |
-| `Acmebot__ManagedIdentityClientId` | Empty | Client ID for a user-assigned managed identity. |
+| `Acmebot__ManagedIdentityClientId` | Empty | Client ID for the app-wide user-assigned managed identity used for Key Vault certificate operations, Key Vault keys, and Azure DNS providers that do not override it. When empty, Acmebot uses the system-assigned managed identity. The user-assigned identity must be assigned to the Function App. |
 
 ## Azure Environments
 
@@ -67,17 +67,19 @@ Provider credentials are secrets. Use scoped provider tokens where possible, and
 
 | Setting | Description |
 | --- | --- |
-| `Acmebot__AzureDns__SubscriptionId` | Azure subscription ID containing the public DNS zones Acmebot manages. The Function App managed identity must have zone read and TXT record write/delete access in this subscription. |
+| `Acmebot__AzureDns__SubscriptionId` | Azure subscription ID containing the public DNS zones Acmebot manages. The selected identity must have zone read and TXT record write/delete access in this subscription. |
+| `Acmebot__AzureDns__ManagedIdentityClientId` | Optional client ID for a user-assigned managed identity used for Azure DNS. When empty, Acmebot uses the app-wide managed identity from `Acmebot__ManagedIdentityClientId`, or the system-assigned managed identity if the app-wide client ID is empty. The user-assigned identity must be assigned to the Function App. |
 
-Azure DNS uses the Function App managed identity.
+Azure DNS uses the app-wide managed identity by default and this setting overrides it.
 
 ### Azure Private DNS
 
 | Setting | Description |
 | --- | --- |
-| `Acmebot__AzurePrivateDns__SubscriptionId` | Azure subscription ID containing the private DNS zones Acmebot manages. The Function App managed identity must have private zone read and TXT record write/delete access in this subscription. |
+| `Acmebot__AzurePrivateDns__SubscriptionId` | Azure subscription ID containing the private DNS zones Acmebot manages. The selected identity must have private zone read and TXT record write/delete access in this subscription. |
+| `Acmebot__AzurePrivateDns__ManagedIdentityClientId` | Optional client ID for a user-assigned managed identity used for Azure Private DNS. When empty, Acmebot uses the app-wide managed identity from `Acmebot__ManagedIdentityClientId`, or the system-assigned managed identity if the app-wide client ID is empty. The user-assigned identity must be assigned to the Function App. |
 
-Azure Private DNS uses the Function App managed identity.
+Azure Private DNS uses the app-wide managed identity by default and this setting overrides it.
 
 ### Cloudflare
 
@@ -208,6 +210,7 @@ Acmebot__Contacts=mailto:admin@example.com
 Acmebot__VaultBaseUrl=https://my-vault.vault.azure.net/
 Acmebot__Environment=AzureCloud
 Acmebot__AzureDns__SubscriptionId=00000000-0000-0000-0000-000000000000
+Acmebot__AzureDns__ManagedIdentityClientId=
 Acmebot__RenewBeforeExpiry=30
 Acmebot__Webhook=https://example.com/webhook
 ```

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -37,7 +37,7 @@ Listing certificates and DNS zones still requires authentication.
 
 ## Managed Identity
 
-Use managed identity for Azure resource access. The Function App identity is used for Key Vault and Azure DNS operations.
+Use managed identity for Azure resource access. By default, Acmebot uses the app-wide managed identity. Azure DNS and Azure Private DNS can override it with provider-specific user-assigned managed identity client IDs. If no client ID is configured, Azure SDK clients use the Function App system-assigned managed identity.
 
 Recommended scopes:
 

--- a/src/Acmebot.App/Options/AzureDnsOptions.cs
+++ b/src/Acmebot.App/Options/AzureDnsOptions.cs
@@ -2,5 +2,7 @@
 
 public class AzureDnsOptions
 {
+    public string? ManagedIdentityClientId { get; set; }
+
     public required string SubscriptionId { get; set; }
 }

--- a/src/Acmebot.App/Options/AzurePrivateDnsOptions.cs
+++ b/src/Acmebot.App/Options/AzurePrivateDnsOptions.cs
@@ -2,5 +2,7 @@
 
 public class AzurePrivateDnsOptions
 {
+    public string? ManagedIdentityClientId { get; set; }
+
     public required string SubscriptionId { get; set; }
 }

--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -27,8 +27,6 @@ using Microsoft.Extensions.Options;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
-const string AcmeStateContainerName = "acmebot-state";
-
 var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication()
@@ -96,10 +94,12 @@ builder.Services.AddSingleton(provider =>
 
 builder.Services.AddSingleton(provider =>
 {
+    const string acmeStateContainerName = "acmebot-state";
+
     var configuration = provider.GetRequiredService<IConfiguration>();
     var connectionString = configuration["AzureWebJobsStorage"] ?? throw new InvalidOperationException("AzureWebJobsStorage is not configured.");
 
-    return new BlobContainerClient(connectionString, AcmeStateContainerName);
+    return new BlobContainerClient(connectionString, acmeStateContainerName);
 });
 
 builder.Services.AddSingleton<BlobAcmeStateStore>();
@@ -108,9 +108,7 @@ builder.Services.AddSingleton<IAcmeStateStore>(provider =>
 {
     var configuration = provider.GetRequiredService<IConfiguration>();
 
-    return HasAzureFilesContentShare(configuration) || !IsRunningOnAzure(configuration)
-        ? provider.GetRequiredService<FileSystemAcmeStateStore>()
-        : provider.GetRequiredService<BlobAcmeStateStore>();
+    return HasAzureFilesContentShare(configuration) ? provider.GetRequiredService<FileSystemAcmeStateStore>() : provider.GetRequiredService<BlobAcmeStateStore>();
 });
 builder.Services.AddSingleton<AcmeClientFactory>();
 
@@ -145,14 +143,20 @@ builder.Services.AddSingleton<IWebhookPayloadBuilder>(provider =>
 builder.Services.AddSingleton<IEnumerable<IDnsProvider>>(provider =>
 {
     var options = provider.GetRequiredService<IOptions<AcmebotOptions>>().Value;
-    var environment = provider.GetRequiredService<AzureEnvironment>();
     var credential = provider.GetRequiredService<TokenCredential>();
+    var environment = provider.GetRequiredService<AzureEnvironment>();
 
     var dnsProviders = new List<IDnsProvider>();
 
     dnsProviders.TryAdd(options.Akamai, o => new AkamaiEdgeDnsProvider(o));
-    dnsProviders.TryAdd(options.AzureDns, o => new AzureDnsProvider(o, environment, credential));
-    dnsProviders.TryAdd(options.AzurePrivateDns, o => new AzurePrivateDnsProvider(o, environment, credential));
+    dnsProviders.TryAdd(options.AzureDns, o => new AzureDnsProvider(
+        o,
+        environment,
+        ResolveCredential(environment, credential, o.ManagedIdentityClientId)));
+    dnsProviders.TryAdd(options.AzurePrivateDns, o => new AzurePrivateDnsProvider(
+        o,
+        environment,
+        ResolveCredential(environment, credential, o.ManagedIdentityClientId)));
     dnsProviders.TryAdd(options.Cloudflare, o => new CloudflareProvider(o));
     dnsProviders.TryAdd(options.CustomDns, o => new CustomDnsProvider(o));
     dnsProviders.TryAdd(options.DnsMadeEasy, o => new DnsMadeEasyProvider(o));
@@ -181,6 +185,16 @@ static bool HasAzureFilesContentShare(IConfiguration configuration)
     => !string.IsNullOrEmpty(configuration["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"])
        || !string.IsNullOrEmpty(configuration["WEBSITE_CONTENTSHARE"]);
 
-static bool IsRunningOnAzure(IConfiguration configuration)
-    => !string.IsNullOrEmpty(configuration["WEBSITE_SITE_NAME"])
-       || !string.IsNullOrEmpty(configuration["WEBSITE_INSTANCE_ID"]);
+static TokenCredential ResolveCredential(AzureEnvironment environment, TokenCredential defaultCredential, string? managedIdentityClientId)
+{
+    if (string.IsNullOrEmpty(managedIdentityClientId))
+    {
+        return defaultCredential;
+    }
+
+    return new DefaultAzureCredential(new DefaultAzureCredentialOptions
+    {
+        AuthorityHost = environment.AuthorityHost,
+        ManagedIdentityClientId = managedIdentityClientId
+    });
+}


### PR DESCRIPTION
## Summary

- Add optional provider-specific managed identity client IDs for Azure DNS and Azure Private DNS.
- Resolve Azure DNS credentials from provider-specific settings before falling back to the app-wide managed identity.
- Update documentation to describe app-wide and provider-specific identity behavior, and remove the local-development state storage wording.

## Validation

- `dotnet test Acmebot.slnx`
- `dotnet build Acmebot.slnx`
- `npm run build` in `docs`
- `git diff --cached --check`
