### PR TITLE
Fix group names in dependabot configuration for clarity

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      dependencies:
+      nuget:
         patterns:
           - "*"
     ignore:
@@ -23,7 +23,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      dependencies:
+      client-app:
         patterns:
           - "*"
     ignore:
@@ -36,7 +36,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      dependencies:
+      docs:
         patterns:
           - "*"
     ignore:
@@ -49,6 +49,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      dependencies:
+      github-actions:
         patterns:
           - "*"


### PR DESCRIPTION
This pull request updates the dependency group names in the `.github/dependabot.yml` configuration to be more descriptive and specific for different types of dependencies. This helps clarify which dependencies are being managed and grouped together for updates.

Dependency group renaming:

* Renamed the generic `dependencies` group to more specific groups: `nuget`, `client-app`, `docs`, and `github-actions`, each with its own pattern. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L13-R13) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L26-R26) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L39-R39) [[4]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L52-R52)