### PR TITLE
Enhance BlobContainerClient initialization with managed identity

### DIFF
--- a/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
@@ -27,7 +27,7 @@ public partial class CertificateIssuanceOrchestrator
             certificatePolicyItem.DnsProviderName = await context.CallDns01PreconditionAsync(certificatePolicyItem);
 
             // 新しく ACME Order を作成する (ARI で更新扱いにする場合は既存証明書の Certificate ID を replaces に指定)
-            var orderDetails = await context.CallOrderAsync((certificatePolicyItem.DnsNames, /*certificatePolicyItem.CertificateId*/ null));
+            var orderDetails = await context.CallOrderAsync((certificatePolicyItem.DnsNames, certificatePolicyItem.CertificateId));
 
             // 既に確認済みの場合は Challenge をスキップする
             if (orderDetails.Payload.Status != AcmeOrderStatuses.Ready)

--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -130,7 +130,7 @@ builder.Services.AddSingleton(provider =>
         AuthorityHost = environment.AuthorityHost
     });
 
-return new BlobContainerClient(new Uri(new Uri(blobServiceUri.TrimEnd('/') + "/"), acmeStateContainerName), credential);
+    return new BlobContainerClient(new Uri(new Uri(blobServiceUri.TrimEnd('/') + "/"), acmeStateContainerName), credential);
 });
 
 builder.Services.AddSingleton<BlobAcmeStateStore>();

--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -130,7 +130,7 @@ builder.Services.AddSingleton(provider =>
         AuthorityHost = environment.AuthorityHost
     });
 
-    return new BlobContainerClient(new Uri($"{blobServiceUri}/{acmeStateContainerName}"), credential);
+return new BlobContainerClient(new Uri(new Uri(blobServiceUri.TrimEnd('/') + "/"), acmeStateContainerName), credential);
 });
 
 builder.Services.AddSingleton<BlobAcmeStateStore>();

--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -97,10 +97,40 @@ builder.Services.AddSingleton(provider =>
 {
     const string acmeStateContainerName = "acmebot-state";
 
+    var environment = provider.GetRequiredService<AzureEnvironment>();
     var configuration = provider.GetRequiredService<IConfiguration>();
-    var connectionString = configuration["AzureWebJobsStorage"] ?? throw new InvalidOperationException("AzureWebJobsStorage is not configured.");
 
-    return new BlobContainerClient(connectionString, acmeStateContainerName);
+    var connectionString = configuration["AzureWebJobsStorage"];
+
+    if (!string.IsNullOrWhiteSpace(connectionString))
+    {
+        return new BlobContainerClient(connectionString, acmeStateContainerName);
+    }
+
+    var blobServiceUri = configuration["AzureWebJobsStorage__blobServiceUri"];
+
+    if (string.IsNullOrWhiteSpace(blobServiceUri))
+    {
+        var accountName = configuration["AzureWebJobsStorage__accountName"];
+
+        if (string.IsNullOrWhiteSpace(accountName))
+        {
+            throw new InvalidOperationException("AzureWebJobsStorage, AzureWebJobsStorage__blobServiceUri, or AzureWebJobsStorage__accountName is required.");
+        }
+
+        blobServiceUri = $"https://{accountName}.blob.core.windows.net";
+    }
+
+    var clientId = configuration["AzureWebJobsStorage__clientId"];
+
+    var managedIdentityId = string.IsNullOrWhiteSpace(clientId) ? ManagedIdentityId.SystemAssigned : ManagedIdentityId.FromUserAssignedClientId(clientId);
+
+    var credential = new ManagedIdentityCredential(new ManagedIdentityCredentialOptions(managedIdentityId)
+    {
+        AuthorityHost = environment.AuthorityHost
+    });
+
+    return new BlobContainerClient(new Uri($"{blobServiceUri}/{acmeStateContainerName}"), credential);
 });
 
 builder.Services.AddSingleton<BlobAcmeStateStore>();
@@ -181,6 +211,8 @@ builder.Services.AddSingleton<IEnumerable<IDnsProvider>>(provider =>
 });
 
 builder.Build().Run();
+
+return;
 
 static bool HasAzureFilesContentShare(IConfiguration configuration)
     => !string.IsNullOrEmpty(configuration["WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"]) || !string.IsNullOrEmpty(configuration["WEBSITE_CONTENTSHARE"]);


### PR DESCRIPTION
This pull request updates the initialization logic for the `BlobContainerClient` in `Program.cs` to support multiple authentication and configuration methods for Azure Blob Storage. The changes improve flexibility by allowing the application to connect using either a connection string or managed identity, and provide clearer error handling when required configuration is missing.

**Enhancements to Azure Blob Storage initialization:**

* Updated the logic to first check for `AzureWebJobsStorage` connection string, and if missing, to fall back to using `blobServiceUri` or `accountName` with managed identity authentication, improving support for different deployment environments.
* Added support for user-assigned or system-assigned managed identities by reading `clientId` from configuration and constructing the appropriate `ManagedIdentityCredential` with the correct authority host.
* Improved error handling by throwing a clear exception if none of the required configuration settings (`AzureWebJobsStorage`, `AzureWebJobsStorage__blobServiceUri`, or `AzureWebJobsStorage__accountName`) are provided.

**General code changes:**

* Added an explicit `return;` statement after `builder.Build().Run();` to prevent further code execution, clarifying the application flow.

Close #1103 