### PR TITLE
Update documentation and UI for ACME endpoints and terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,10 @@ Acmebot uses Azure Key Vault to provide secure and centralized management of ACM
 - Automated certificate renewal
 - Support for ACME v2 compliant Certification Authorities
   - [Let's Encrypt](https://letsencrypt.org/)
-  - [ZeroSSL](https://zerossl.com/features/acme/) (Requires EAB Credentials)
+  - [GlobalSign](https://www.globalsign.com/) (Requires EAB Credentials)
   - [Google Trust Services](https://pki.goog/) (Requires EAB Credentials)
   - [SSL.com](https://www.ssl.com/how-to/order-free-90-day-ssl-tls-certificates-with-acme/) (Requires EAB Credentials)
-  - [Entrust](https://www.entrust.com/) (Requires EAB Credentials)
-  - [GlobalSign](https://www.globalsign.com/) (Requires EAB Credentials)
+  - [ZeroSSL](https://zerossl.com/features/acme/) (Requires EAB Credentials)
 - Certificates can be used with many Azure services
   - Azure App Service (Web Apps / Functions / Containers)
   - Azure Container Apps (Include custom DNS suffix)

--- a/deploy/uiFormDefinition.json
+++ b/deploy/uiFormDefinition.json
@@ -256,13 +256,6 @@
                     "required": true
                   },
                   "visible": "[if(equals(steps('acmeStep').endpointSection.endpointType, 'custom'), true, false)]"
-                },
-                {
-                  "name": "caRequiresEab",
-                  "type": "Microsoft.Common.CheckBox",
-                  "label": "CA requires EAB",
-                  "defaultValue": "[and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90')))]",
-                  "visible": false
                 }
               ],
               "visible": true
@@ -310,7 +303,7 @@
                   "type": "Microsoft.Common.OptionsGroup",
                   "label": "Credential type",
                   "toolTip": "This credential type is fixed because the selected certificate authority requires external account binding.",
-                  "defaultValue": "eab",
+                  "defaultValue": "External Account Binding (EAB)",
                   "constraints": {
                     "allowedValues": [
                       {
@@ -320,7 +313,7 @@
                     ],
                     "required": true
                   },
-                  "visible": "[steps('acmeStep').endpointSection.caRequiresEab]"
+                  "visible": "[and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90')))]"
                 }
               ],
               "visible": true
@@ -385,7 +378,7 @@
                   "visible": true
                 }
               ],
-              "visible": "[or(steps('acmeStep').endpointSection.caRequiresEab, equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab'))]"
+              "visible": "[or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab'))]"
             }
           ]
         },
@@ -1384,10 +1377,10 @@
           "endpoint": "[if(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), steps('acmeStep').endpointSection.verifiedEndpoint, steps('acmeStep').endpointSection.customEndpoint)]",
           "contacts": "[steps('acmeStep').credentialSection.mailAddress]",
           "externalAccountBinding": {
-            "enabled": "[or(steps('acmeStep').endpointSection.caRequiresEab, equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab'))]",
-            "keyId": "[if(or(steps('acmeStep').endpointSection.caRequiresEab, equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.keyId, '')]",
-            "hmacKey": "[if(or(steps('acmeStep').endpointSection.caRequiresEab, equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.hmacKey, '')]",
-            "algorithm": "[if(or(steps('acmeStep').endpointSection.caRequiresEab, equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.algorithm, 'HS256')]"
+            "enabled": "[or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab'))]",
+            "keyId": "[if(or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.keyId, '')]",
+            "hmacKey": "[if(or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.hmacKey, '')]",
+            "algorithm": "[if(or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.algorithm, 'HS256')]"
           }
         },
         "dnsProvider": {

--- a/deploy/uiFormDefinition.json
+++ b/deploy/uiFormDefinition.json
@@ -256,6 +256,13 @@
                     "required": true
                   },
                   "visible": "[if(equals(steps('acmeStep').endpointSection.endpointType, 'custom'), true, false)]"
+                },
+                {
+                  "name": "caRequiresEab",
+                  "type": "Microsoft.Common.CheckBox",
+                  "label": "CA requires EAB",
+                  "defaultValue": "[and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90')))]",
+                  "visible": false
                 }
               ],
               "visible": true
@@ -303,7 +310,7 @@
                   "type": "Microsoft.Common.OptionsGroup",
                   "label": "Credential type",
                   "toolTip": "This credential type is fixed because the selected certificate authority requires external account binding.",
-                  "defaultValue": "External Account Binding (EAB)",
+                  "defaultValue": "eab",
                   "constraints": {
                     "allowedValues": [
                       {
@@ -313,7 +320,7 @@
                     ],
                     "required": true
                   },
-                  "visible": "[and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90')))]"
+                  "visible": "[steps('acmeStep').endpointSection.caRequiresEab]"
                 }
               ],
               "visible": true
@@ -378,7 +385,7 @@
                   "visible": true
                 }
               ],
-              "visible": "[or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab'))]"
+              "visible": "[or(steps('acmeStep').endpointSection.caRequiresEab, equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab'))]"
             }
           ]
         },
@@ -1377,10 +1384,10 @@
           "endpoint": "[if(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), steps('acmeStep').endpointSection.verifiedEndpoint, steps('acmeStep').endpointSection.customEndpoint)]",
           "contacts": "[steps('acmeStep').credentialSection.mailAddress]",
           "externalAccountBinding": {
-            "enabled": "[or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab'))]",
-            "keyId": "[if(or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.keyId, '')]",
-            "hmacKey": "[if(or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.hmacKey, '')]",
-            "algorithm": "[if(or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.algorithm, 'HS256')]"
+            "enabled": "[or(steps('acmeStep').endpointSection.caRequiresEab, equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab'))]",
+            "keyId": "[if(or(steps('acmeStep').endpointSection.caRequiresEab, equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.keyId, '')]",
+            "hmacKey": "[if(or(steps('acmeStep').endpointSection.caRequiresEab, equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.hmacKey, '')]",
+            "algorithm": "[if(or(steps('acmeStep').endpointSection.caRequiresEab, equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.algorithm, 'HS256')]"
           }
         },
         "dnsProvider": {

--- a/deploy/uiFormDefinition.json
+++ b/deploy/uiFormDefinition.json
@@ -212,32 +212,32 @@
                     "allowedValues": [
                       {
                         "label": "Let's Encrypt",
-                        "description": "Let's Encrypt ACME v2 production endpoint for publicly trusted certificates.",
+                        "description": "Let's Encrypt ACME endpoint for publicly trusted certificates.",
                         "value": "https://acme-v02.api.letsencrypt.org/directory"
                       },
                       {
                         "label": "GlobalSign",
-                        "description": "GlobalSign ACME endpoint for accounts enabled for certificate automation.",
+                        "description": "GlobalSign ACME endpoint for publicly trusted certificates.",
                         "value": "https://emea.acme.atlas.globalsign.com/directory"
                       },
                       {
                         "label": "Google Trust Services",
-                        "description": "Google Trust Services ACME endpoint for public TLS certificates.",
+                        "description": "Google Trust Services ACME endpoint for publicly trusted certificates.",
                         "value": "https://dv.acme-v02.api.pki.goog/directory"
                       },
                       {
                         "label": "SSL.com (ECC)",
-                        "description": "SSL.com ACME endpoint for DV certificates using ECC certificate keys.",
+                        "description": "SSL.com ACME endpoint for DV certificates using ECC keys.",
                         "value": "https://acme.ssl.com/sslcom-dv-ecc"
                       },
                       {
                         "label": "SSL.com (RSA)",
-                        "description": "SSL.com ACME endpoint for DV certificates using RSA certificate keys.",
+                        "description": "SSL.com ACME endpoint for DV certificates using RSA keys.",
                         "value": "https://acme.ssl.com/sslcom-dv-rsa"
                       },
                       {
                         "label": "ZeroSSL",
-                        "description": "ZeroSSL ACME endpoint for 90-day DV certificates. EAB credentials are required.",
+                        "description": "ZeroSSL ACME endpoint for 90-day DV certificates.",
                         "value": "https://acme.zerossl.com/v2/DV90"
                       }
                     ],
@@ -296,7 +296,24 @@
                     ],
                     "required": true
                   },
-                  "visible": true
+                  "visible": "[equals(steps('acmeStep').endpointSection.endpointType, 'custom')]"
+                },
+                {
+                  "name": "requiredCredentialType",
+                  "type": "Microsoft.Common.OptionsGroup",
+                  "label": "Credential type",
+                  "toolTip": "This credential type is fixed because the selected certificate authority requires external account binding.",
+                  "defaultValue": "External Account Binding (EAB)",
+                  "constraints": {
+                    "allowedValues": [
+                      {
+                        "label": "External Account Binding (EAB)",
+                        "value": "eab"
+                      }
+                    ],
+                    "required": true
+                  },
+                  "visible": "[and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90')))]"
                 }
               ],
               "visible": true
@@ -361,7 +378,7 @@
                   "visible": true
                 }
               ],
-              "visible": "[if(equals(steps('acmeStep').credentialSection.credentialType, 'eab'), true, false)]"
+              "visible": "[or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab'))]"
             }
           ]
         },
@@ -1360,10 +1377,10 @@
           "endpoint": "[if(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), steps('acmeStep').endpointSection.verifiedEndpoint, steps('acmeStep').endpointSection.customEndpoint)]",
           "contacts": "[steps('acmeStep').credentialSection.mailAddress]",
           "externalAccountBinding": {
-            "enabled": "[equals(steps('acmeStep').credentialSection.credentialType, 'eab')]",
-            "keyId": "[if(equals(steps('acmeStep').credentialSection.credentialType, 'eab'), steps('acmeStep').eabSection.keyId, '')]",
-            "hmacKey": "[if(equals(steps('acmeStep').credentialSection.credentialType, 'eab'), steps('acmeStep').eabSection.hmacKey, '')]",
-            "algorithm": "[if(equals(steps('acmeStep').credentialSection.credentialType, 'eab'), steps('acmeStep').eabSection.algorithm, 'HS256')]"
+            "enabled": "[or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab'))]",
+            "keyId": "[if(or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.keyId, '')]",
+            "hmacKey": "[if(or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.hmacKey, '')]",
+            "algorithm": "[if(or(and(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), or(equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://emea.acme.atlas.globalsign.com/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://dv.acme-v02.api.pki.goog/directory'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-ecc'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.ssl.com/sslcom-dv-rsa'), equals(coalesce(steps('acmeStep').endpointSection.verifiedEndpoint, ''), 'https://acme.zerossl.com/v2/DV90'))), equals(coalesce(steps('acmeStep').credentialSection.credentialType, ''), 'eab')), steps('acmeStep').eabSection.algorithm, 'HS256')]"
           }
         },
         "dnsProvider": {

--- a/deploy/uiFormDefinition.json
+++ b/deploy/uiFormDefinition.json
@@ -188,8 +188,8 @@
                   "constraints": {
                     "allowedValues": [
                       {
-                        "label": "Known endpoint (recommended)",
-                        "value": "known"
+                        "label": "Verified endpoint (recommended)",
+                        "value": "verified"
                       },
                       {
                         "label": "Custom",
@@ -201,9 +201,9 @@
                   "visible": true
                 },
                 {
-                  "name": "knownEndpoint",
+                  "name": "verifiedEndpoint",
                   "type": "Microsoft.Common.DropDown",
-                  "label": "Known ACME endpoint",
+                  "label": "Verified ACME endpoint",
                   "placeholder": "ACME endpoint",
                   "defaultValue": "",
                   "multiLine": true,
@@ -216,9 +216,9 @@
                         "value": "https://acme-v02.api.letsencrypt.org/directory"
                       },
                       {
-                        "label": "ZeroSSL",
-                        "description": "ZeroSSL ACME endpoint for 90-day DV certificates. EAB credentials are required.",
-                        "value": "https://acme.zerossl.com/v2/DV90"
+                        "label": "GlobalSign",
+                        "description": "GlobalSign ACME endpoint for accounts enabled for certificate automation.",
+                        "value": "https://emea.acme.atlas.globalsign.com/directory"
                       },
                       {
                         "label": "Google Trust Services",
@@ -226,29 +226,24 @@
                         "value": "https://dv.acme-v02.api.pki.goog/directory"
                       },
                       {
-                        "label": "SSL.com (RSA)",
-                        "description": "SSL.com ACME endpoint for DV certificates using RSA certificate keys.",
-                        "value": "https://acme.ssl.com/sslcom-dv-rsa"
-                      },
-                      {
                         "label": "SSL.com (ECC)",
                         "description": "SSL.com ACME endpoint for DV certificates using ECC certificate keys.",
                         "value": "https://acme.ssl.com/sslcom-dv-ecc"
                       },
                       {
-                        "label": "Entrust",
-                        "description": "Entrust ACME endpoint for accounts enabled for Entrust certificate automation.",
-                        "value": "https://acme.entrust.net/acme2/directory"
+                        "label": "SSL.com (RSA)",
+                        "description": "SSL.com ACME endpoint for DV certificates using RSA certificate keys.",
+                        "value": "https://acme.ssl.com/sslcom-dv-rsa"
                       },
                       {
-                        "label": "Global Sign",
-                        "description": "GlobalSign Atlas ACME endpoint for accounts enabled for certificate automation.",
-                        "value": "https://emea.acme.atlas.globalsign.com/directory"
+                        "label": "ZeroSSL",
+                        "description": "ZeroSSL ACME endpoint for 90-day DV certificates. EAB credentials are required.",
+                        "value": "https://acme.zerossl.com/v2/DV90"
                       }
                     ],
                     "required": true
                   },
-                  "visible": "[if(equals(steps('acmeStep').endpointSection.endpointType, 'known'), true, false)]"
+                  "visible": "[if(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), true, false)]"
                 },
                 {
                   "name": "customEndpoint",
@@ -1362,7 +1357,7 @@
           "logAnalyticsWorkspaceName": "[if(equals(steps('loggingStep').createNew, 'create'), if(equals(steps('basics').namingRule, 'custom'), steps('loggingStep').logAnalyticsWorkspaceName, concat('log-', steps('basics').appPrefix)), '')]"
         },
         "acme": {
-          "endpoint": "[if(equals(steps('acmeStep').endpointSection.endpointType, 'known'), steps('acmeStep').endpointSection.knownEndpoint, steps('acmeStep').endpointSection.customEndpoint)]",
+          "endpoint": "[if(equals(steps('acmeStep').endpointSection.endpointType, 'verified'), steps('acmeStep').endpointSection.verifiedEndpoint, steps('acmeStep').endpointSection.customEndpoint)]",
           "contacts": "[steps('acmeStep').credentialSection.mailAddress]",
           "externalAccountBinding": {
             "enabled": "[equals(steps('acmeStep').credentialSection.credentialType, 'eab')]",

--- a/docs/.vitepress/theme/HomePage.vue
+++ b/docs/.vitepress/theme/HomePage.vue
@@ -82,7 +82,7 @@ function scrollToSection(event: MouseEvent, selector: string) {
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z" /></svg>
             </div>
             <h3>Multiple CAs</h3>
-            <p>Support for Let's Encrypt, ZeroSSL, Google Trust Services, SSL.com, Entrust, and more ACME v2 CAs.</p>
+            <p>Support for Let's Encrypt, GlobalSign, Google Trust Services, SSL.com, ZeroSSL, and more ACME v2 CAs.</p>
           </div>
         </div>
       </div>
@@ -210,9 +210,9 @@ function scrollToSection(event: MouseEvent, selector: string) {
             <p>The most widely used free CA. No additional credentials required.</p>
           </div>
           <div class="ca-card">
-            <strong>ZeroSSL</strong>
+            <strong>GlobalSign</strong>
             <span class="ca-badge">EAB</span>
-            <p>Free SSL certificates with ACME support and REST API.</p>
+            <p>GlobalSign ACME support for automated certificate issuance.</p>
           </div>
           <div class="ca-card">
             <strong>Google Trust Services</strong>
@@ -225,9 +225,9 @@ function scrollToSection(event: MouseEvent, selector: string) {
             <p>Commercial CA offering free 90-day certificates via ACME.</p>
           </div>
           <div class="ca-card">
-            <strong>Entrust</strong>
+            <strong>ZeroSSL</strong>
             <span class="ca-badge">EAB</span>
-            <p>Enterprise-grade certificates with ACME automation support.</p>
+            <p>Free SSL certificates with ACME support and REST API.</p>
           </div>
         </div>
       </div>

--- a/docs/guide/certificate-authorities.md
+++ b/docs/guide/certificate-authorities.md
@@ -2,17 +2,16 @@
 
 Acmebot works with ACME v2 certificate authorities. Configure the ACME directory endpoint with `Acmebot__Endpoint`.
 
-## Known Endpoints
+## Verified Endpoints
 
 | CA | Endpoint | Notes |
 | --- | --- | --- |
-| Let's Encrypt | `https://acme-v02.api.letsencrypt.org/directory` | No EAB required. |
-| ZeroSSL | `https://acme.zerossl.com/v2/DV90` | EAB credentials are required. |
-| Google Trust Services | `https://dv.acme-v02.api.pki.goog/directory` | EAB may be required depending on your account setup. |
-| SSL.com RSA | `https://acme.ssl.com/sslcom-dv-rsa` | EAB credentials are typically required. |
-| SSL.com ECC | `https://acme.ssl.com/sslcom-dv-ecc` | Use when issuing ECC certificates through SSL.com. |
-| Entrust | `https://acme.entrust.net/acme2/directory` | Requires an Entrust ACME-enabled account. |
-| GlobalSign Atlas | `https://emea.acme.atlas.globalsign.com/directory` | Requires an Atlas ACME-enabled account. |
+| Let's Encrypt | `https://acme-v02.api.letsencrypt.org/directory` | No EAB required. See the [Let's Encrypt documentation](https://letsencrypt.org/docs/) to get started. |
+| GlobalSign | `https://emea.acme.atlas.globalsign.com/directory` | Requires a GlobalSign account with ACME enabled. See the [GlobalSign ACME documentation](https://docs.globalsign.com/solutions/services/clm/acme) for account setup. |
+| Google Trust Services | `https://dv.acme-v02.api.pki.goog/directory` | EAB credentials are required. See the [Google Public CA documentation](https://cloud.google.com/certificate-manager/docs/public-ca-tutorial) for account setup. |
+| SSL.com ECC | `https://acme.ssl.com/sslcom-dv-ecc` | Use when issuing ECC certificates through SSL.com. EAB credentials are typically required. |
+| SSL.com RSA | `https://acme.ssl.com/sslcom-dv-rsa` | EAB credentials are typically required. See the [SSL.com ACME guide](https://www.ssl.com/guide/ssl-tls-certificate-issuance-and-revocation-with-acme/) for credential setup. |
+| ZeroSSL | `https://acme.zerossl.com/v2/DV90` | EAB credentials are required. See the [ZeroSSL ACME documentation](https://zerossl.com/documentation/acme) for credential setup. |
 
 You can also enter a custom ACME directory endpoint in the deployment form.
 
@@ -47,11 +46,10 @@ Common EAB scenarios:
 | CA | EAB guidance |
 | --- | --- |
 | Let's Encrypt | Usually not required. |
-| ZeroSSL | Required for ACME account registration. |
-| Google Trust Services | May be required depending on account setup. |
+| GlobalSign | Required for an ACME-enabled GlobalSign account. |
+| Google Trust Services | Required for ACME account registration. |
 | SSL.com | Typically required. |
-| Entrust | Required for an ACME-enabled Entrust account. |
-| GlobalSign Atlas | Required for an ACME-enabled Atlas account. |
+| ZeroSSL | Required for ACME account registration. |
 
 ## Preferred Chain
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -13,17 +13,16 @@ This walkthrough deploys a first Acmebot v5 environment and issues a certificate
 
 ## 1. Choose an ACME Endpoint
 
-For a first test, use a staging endpoint if your certificate authority offers one. For production, the deployment form includes these known endpoints:
+For a first test, use a staging endpoint if your certificate authority offers one. For production, the deployment form includes these verified endpoints:
 
 | CA | Endpoint |
 | --- | --- |
 | Let's Encrypt | `https://acme-v02.api.letsencrypt.org/directory` |
-| ZeroSSL | `https://acme.zerossl.com/v2/DV90` |
+| GlobalSign | `https://emea.acme.atlas.globalsign.com/directory` |
 | Google Trust Services | `https://dv.acme-v02.api.pki.goog/directory` |
-| SSL.com RSA | `https://acme.ssl.com/sslcom-dv-rsa` |
 | SSL.com ECC | `https://acme.ssl.com/sslcom-dv-ecc` |
-| Entrust | `https://acme.entrust.net/acme2/directory` |
-| GlobalSign Atlas | `https://emea.acme.atlas.globalsign.com/directory` |
+| SSL.com RSA | `https://acme.ssl.com/sslcom-dv-rsa` |
+| ZeroSSL | `https://acme.zerossl.com/v2/DV90` |
 
 If your CA requires external account binding, select the EAB credential type during deployment. See [Certificate Authorities](./certificate-authorities) for details.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -24,7 +24,7 @@ For a first test, use a staging endpoint if your certificate authority offers on
 | SSL.com RSA | `https://acme.ssl.com/sslcom-dv-rsa` |
 | ZeroSSL | `https://acme.zerossl.com/v2/DV90` |
 
-If your CA requires external account binding, select the EAB credential type during deployment. See [Certificate Authorities](./certificate-authorities) for details.
+If a verified CA requires external account binding, the deployment form fixes the credential type to EAB. For custom endpoints, select EAB when your CA requires it. See [Certificate Authorities](./certificate-authorities) for details.
 
 ## 2. Deploy Acmebot
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -35,7 +35,7 @@ Acmebot validates with DNS-01 only. This supports wildcard certificates and work
 
 ### Certificate Authorities
 
-Acmebot works with any ACME v2 directory endpoint. The deployment form offers common endpoints such as Let's Encrypt, ZeroSSL, Google Trust Services, SSL.com, Entrust, and GlobalSign, and also accepts a custom ACME directory URL.
+Acmebot works with any ACME v2 directory endpoint. The deployment form offers common endpoints such as Let's Encrypt, GlobalSign, Google Trust Services, SSL.com, and ZeroSSL, and also accepts a custom ACME directory URL.
 
 ### Dashboard
 


### PR DESCRIPTION
## Summary

- Renames "Known Endpoints" to "Verified Endpoints" across docs and the Azure deployment form for clarity.
- Reorders and refreshes the curated CA/endpoint list (promoting GlobalSign; removing Entrust from default options).
- Updates the deployment form logic to surface EAB requirements for verified endpoints and conditionally pass EAB parameters.
- Fixes a `defaultValue` bug in the `requiredCredentialType` OptionsGroup where the label text was used instead of the option value, causing the EAB option to not be properly pre-selected.
- Centralizes the repeated "CA requires EAB" condition into a single hidden `caRequiresEab` computed field, eliminating the duplicated endpoint URL list across `visible` rules and output expressions.

## Related Issue

## What Changed

- Renamed "Known Endpoints" / `knownEndpoint` to "Verified Endpoints" / `verifiedEndpoint` throughout docs and `deploy/uiFormDefinition.json`.
- Updated `README.md`, `docs/guide/index.md`, `docs/guide/getting-started.md`, `docs/guide/certificate-authorities.md`, and `docs/.vitepress/theme/HomePage.vue` to reflect the new CA ordering (Let's Encrypt, GlobalSign, Google Trust Services, SSL.com ECC/RSA, ZeroSSL) and remove Entrust from the default list.
- Added EAB-aware UI logic in `uiFormDefinition.json`: a fixed `requiredCredentialType` field is shown for endpoints that mandate EAB, and EAB parameters are conditionally passed to the ARM template.
- Fixed `defaultValue` for the `requiredCredentialType` OptionsGroup from `"External Account Binding (EAB)"` (label text) to `"eab"` (option value) so the field is correctly pre-selected.
- Introduced a hidden `caRequiresEab` CheckBox field in `endpointSection` that holds the EAB endpoint-list expression in one place; all dependent `visible` conditions and `externalAccountBinding` output expressions now reference this single field.

## Validation

- [ ] `dotnet build -c Release ./Acmebot.slnx`
- [ ] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx`
- [ ] `az bicep build -f ./deploy/azuredeploy.bicep`
- [ ] Documentation updated if needed

## Notes

-