### PR TITLE
Fix ZeroSSL account creation error caused by null kid in outer JWS

### DIFF
--- a/src/Acmebot.Acme/AcmeClient.cs
+++ b/src/Acmebot.Acme/AcmeClient.cs
@@ -18,10 +18,7 @@ public sealed class AcmeClient : IDisposable
     private const string JoseMediaType = "application/jose+json";
     private const string PemCertificateChainMediaType = "application/pem-certificate-chain";
 
-    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
-    {
-        TypeInfoResolver = AcmeJsonSerializerContext.Default
-    };
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = AcmeJsonSerializerContext.Default.Options;
 
     private readonly HttpClient _httpClient;
     private readonly Uri _directoryUrl;

--- a/src/Acmebot.Acme/AcmeClient.cs
+++ b/src/Acmebot.Acme/AcmeClient.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 using Acmebot.Acme.Internal;
 using Acmebot.Acme.Models;
@@ -18,7 +19,11 @@ public sealed class AcmeClient : IDisposable
     private const string JoseMediaType = "application/jose+json";
     private const string PemCertificateChainMediaType = "application/pem-certificate-chain";
 
-    private static readonly JsonSerializerOptions s_jsonSerializerOptions = AcmeJsonSerializerContext.Default.Options;
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
+    {
+        TypeInfoResolver = AcmeJsonSerializerContext.Default,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
 
     private readonly HttpClient _httpClient;
     private readonly Uri _directoryUrl;

--- a/src/Acmebot.Acme/AcmeClient.cs
+++ b/src/Acmebot.Acme/AcmeClient.cs
@@ -6,7 +6,6 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 using Acmebot.Acme.Internal;
 using Acmebot.Acme.Models;
@@ -19,11 +18,7 @@ public sealed class AcmeClient : IDisposable
     private const string JoseMediaType = "application/jose+json";
     private const string PemCertificateChainMediaType = "application/pem-certificate-chain";
 
-    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
-    {
-        TypeInfoResolver = AcmeJsonSerializerContext.Default,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-    };
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = AcmeJsonSerializerContext.Default.Options;
 
     private readonly HttpClient _httpClient;
     private readonly Uri _directoryUrl;

--- a/tests/Acmebot.Acme.Tests/AcmeClientTests.cs
+++ b/tests/Acmebot.Acme.Tests/AcmeClientTests.cs
@@ -71,6 +71,7 @@ public sealed class AcmeClientTests
 
         var accountRequest = Assert.Single(handler.Requests, x => x.Method == HttpMethod.Post);
         using var payload = accountRequest.GetPayloadJson();
+        using var protectedHeader = accountRequest.GetProtectedHeaderJson();
         var contact = payload.RootElement.GetProperty("contact");
 
         Assert.Equal("mailto:admin@example.com", Assert.Single(contact.EnumerateArray()).GetString());
@@ -80,6 +81,10 @@ public sealed class AcmeClientTests
         Assert.False(string.IsNullOrWhiteSpace(externalAccountBinding.GetProperty("protected").GetString()));
         Assert.False(string.IsNullOrWhiteSpace(externalAccountBinding.GetProperty("payload").GetString()));
         Assert.False(string.IsNullOrWhiteSpace(externalAccountBinding.GetProperty("signature").GetString()));
+
+        // Outer JWS protected header must have jwk but NOT kid (RFC 8555 §7.3.4)
+        Assert.True(protectedHeader.RootElement.TryGetProperty("jwk", out _), "Outer JWS must contain jwk for new account creation");
+        Assert.False(protectedHeader.RootElement.TryGetProperty("kid", out _), "Outer JWS must not contain kid for new account creation");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Creating new account requests to ZeroSSL failing with the error "A JSON Web Key and Key ID cannot both be specified".
- The JWS "protected" header is being sent containing both "jwk" and "kid", despite "kid" being `null`. This is contrary to [RFC 8555 §6.2](https://datatracker.ietf.org/doc/html/rfc8555#section-6.2), which clearly states that "[t]he "jwk" and "kid" fields are mutually exclusive.  Servers MUST reject requests that contain both."
- `AcmeClient` is building its own `JsonSerializeOptions`, which omits the `DefaultIgnoreCondition = WhenWritingNull` setting resulting in `null` properties are serialized. Adding this setting resolves the problem.

## What Changed

- `AcmeClient.cs`: add `DefaultIgnoreCondition = WhenWritingNull` setting to `JsonSerializerOptions`.
- `AcmeClientTests.cs`: assert the outer JWS protected header for account creation contains "jwk" and does
  not contain "kid".

## Validation

- [x] `dotnet build -c Release ./Acmebot.slnx`
- [x] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx`
- [x] `az bicep build -f ./deploy/azuredeploy.bicep`
- [x] Documentation updated if needed
