### PR TITLE
[codex] Announce commercial support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,13 @@ Thank you for your support of our development. Interested in supporting the proj
 
 ## Commercial Support
 
-Commercial support for Acmebot is planned to be offered by Polymind Inc.
+Commercial support for Acmebot v5 is now available from Polymind Inc.
 
-Details of the support offerings are not yet finalized and will be announced separately.
-Acmebot remains fully open source and free to use under the Apache License 2.0.
+Commercial support is intended for organizations running Acmebot in production and can cover deployment planning, v4-to-v5 migration, Azure and DNS provider configuration, troubleshooting, and operational guidance.
 
-If you are interested in future commercial support, please reach out to [Polymind Inc.](https://github.com/polymind-inc)
+Acmebot remains fully open source and free to use under the Apache License 2.0. Community questions and bug reports continue to be handled through GitHub Discussions and Issues.
+
+To discuss commercial support, see the [Support guide](https://acmebot.dev/guide/support.html) or contact [Polymind Inc.](https://github.com/polymind-inc).
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ Thank you for your support of our development. Interested in supporting the proj
 
 Commercial support for Acmebot v5 is now available from Polymind Inc.
 
-Commercial support is intended for organizations running Acmebot in production and can cover deployment planning, v4-to-v5 migration, Azure and DNS provider configuration, troubleshooting, and operational guidance.
+Commercial support is optional and intended for organizations running Acmebot in production. It can cover deployment planning, v4-to-v5 migration, Azure and DNS provider configuration, troubleshooting, and operational guidance.
 
 Acmebot remains fully open source and free to use under the Apache License 2.0. Community questions and bug reports continue to be handled through GitHub Discussions and Issues.
 
-To discuss commercial support, see the [Support guide](https://acmebot.dev/guide/support.html) or contact [Polymind Inc.](https://github.com/polymind-inc).
+To discuss commercial support, visit the [Polymind Acmebot support page](https://polymind.jp/acmebot), email [support@polymind.jp](mailto:support@polymind.jp), or see the [Support guide](https://acmebot.dev/guide/support.html).
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Commercial support is optional and intended for organizations running Acmebot in
 
 Acmebot remains fully open source and free to use under the Apache License 2.0. Community questions and bug reports continue to be handled through GitHub Discussions and Issues.
 
-To discuss commercial support, visit the [Polymind Acmebot support page](https://polymind.jp/acmebot), email [support@polymind.jp](mailto:support@polymind.jp), or see the [Support guide](https://acmebot.dev/guide/support.html).
+To discuss commercial support, visit the [Polymind Acmebot support page](https://polymind.jp/acmebot) or see the [Support guide](https://acmebot.dev/guide/support.html).
 
 ## Community
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -20,4 +20,4 @@ Commercial support is optional and intended for organizations running Acmebot in
 
 Acmebot remains fully open source and free to use under the Apache License 2.0. Community support continues through GitHub Discussions and Issues.
 
-Use the [Polymind Acmebot support page](https://polymind.jp/acmebot) or email [support@polymind.jp](mailto:support@polymind.jp) for commercial inquiries, and see the [Support guide](docs/guide/support.md) for support options and FAQ.
+Use the [Polymind Acmebot support page](https://polymind.jp/acmebot) for commercial inquiries, and see the [Support guide](docs/guide/support.md) for support options and FAQ.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -14,4 +14,10 @@
 
 ## Commercial Support
 
-Commercial support is planned to be offered by Polymind Inc. See the project README for the current status.
+Commercial support for Acmebot v5 is available from [Polymind Inc.](https://github.com/polymind-inc).
+
+Commercial support is intended for organizations running Acmebot in production and can cover deployment planning, v4-to-v5 migration, Azure and DNS provider configuration, troubleshooting, and operational guidance.
+
+Acmebot remains fully open source and free to use under the Apache License 2.0. Community support continues through GitHub Discussions and Issues.
+
+See the [Support guide](docs/guide/support.md) for details.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -14,10 +14,10 @@
 
 ## Commercial Support
 
-Commercial support for Acmebot v5 is available from [Polymind Inc.](https://github.com/polymind-inc).
+Commercial support for Acmebot v5 is available from [Polymind Inc.](https://polymind.jp/acmebot).
 
-Commercial support is intended for organizations running Acmebot in production and can cover deployment planning, v4-to-v5 migration, Azure and DNS provider configuration, troubleshooting, and operational guidance.
+Commercial support is optional and intended for organizations running Acmebot in production. It can cover deployment planning, v4-to-v5 migration, Azure and DNS provider configuration, troubleshooting, and operational guidance.
 
 Acmebot remains fully open source and free to use under the Apache License 2.0. Community support continues through GitHub Discussions and Issues.
 
-See the [Support guide](docs/guide/support.md) for details.
+Use the [Polymind Acmebot support page](https://polymind.jp/acmebot) or email [support@polymind.jp](mailto:support@polymind.jp) for commercial inquiries, and see the [Support guide](docs/guide/support.md) for support options and FAQ.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -29,7 +29,8 @@ const guideSidebar = [
       { text: "Dashboard", link: "/guide/dashboard" },
       { text: "Operations", link: "/guide/operations" },
       { text: "Troubleshooting", link: "/guide/troubleshooting" },
-      { text: "FAQ", link: "/guide/faq" }
+      { text: "FAQ", link: "/guide/faq" },
+      { text: "Support", link: "/guide/support" }
     ]
   },
   {
@@ -65,6 +66,7 @@ export default defineConfig({
       { text: "Guide", link: "/guide/" },
       { text: "Reference", link: "/reference/configuration" },
       { text: "Deploy", link: "/guide/deployment" },
+      { text: "Support", link: "/guide/support" },
       { text: "GitHub", link: "https://github.com/polymind-inc/acmebot" }
     ],
     sidebar: {

--- a/docs/.vitepress/theme/HomePage.vue
+++ b/docs/.vitepress/theme/HomePage.vue
@@ -348,7 +348,7 @@ function scrollToSection(event: MouseEvent, selector: string) {
             <div class="footer-col">
               <h4>Support</h4>
               <a href="https://github.com/sponsors/shibayan">Sponsor</a>
-              <a href="https://github.com/polymind-inc">Commercial Support</a>
+              <a href="/guide/support.html">Commercial Support</a>
             </div>
           </div>
         </div>

--- a/docs/.vitepress/theme/HomePage.vue
+++ b/docs/.vitepress/theme/HomePage.vue
@@ -348,7 +348,7 @@ function scrollToSection(event: MouseEvent, selector: string) {
             <div class="footer-col">
               <h4>Support</h4>
               <a href="https://github.com/sponsors/shibayan">Sponsor</a>
-              <a href="/guide/support.html">Commercial Support</a>
+              <a href="https://polymind.jp/acmebot">Commercial Support</a>
             </div>
           </div>
         </div>

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -55,6 +55,7 @@ The dashboard is a same-origin web app served by the Function App. It calls the 
 | Connect renewed certificates to Azure services | [Azure Service Integration](./service-integration) |
 | Diagnose failed issuance, renewal, or service sync | [Troubleshooting](./troubleshooting) |
 | Answer common deployment and operations questions | [FAQ](./faq) |
+| Get community or commercial support | [Support](./support) |
 | Review every app setting | [Configuration Reference](../reference/configuration) |
 | Integrate with the HTTP endpoints | [HTTP API Reference](../reference/api) |
 

--- a/docs/guide/support.md
+++ b/docs/guide/support.md
@@ -31,7 +31,7 @@ Scope, response expectations, and terms are arranged directly with Polymind Inc.
 
 ## How It Works
 
-1. Submit an inquiry through the [Polymind Acmebot support page](https://polymind.jp/acmebot) or email [support@polymind.jp](mailto:support@polymind.jp).
+1. Submit an inquiry through the [Polymind Acmebot support page](https://polymind.jp/acmebot).
 2. Polymind reviews the environment, issue details, and support scope.
 3. If substantial investigation is required, Polymind proposes an appropriate support engagement.
 
@@ -40,7 +40,6 @@ Scope, response expectations, and terms are arranged directly with Polymind Inc.
 Please include enough context to understand the environment and failure mode:
 
 - Acmebot version.
-- Company name and contact email address.
 - Azure hosting plan.
 - DNS provider and certificate authority.
 - Target Azure service that consumes the certificate.

--- a/docs/guide/support.md
+++ b/docs/guide/support.md
@@ -1,6 +1,6 @@
 # Support
 
-Acmebot is an open source project released under the Apache License 2.0. Community support remains available through GitHub, and commercial support for Acmebot v5 is now available from Polymind Inc.
+Acmebot is an open source project released under the Apache License 2.0. Community support remains available through GitHub, and optional commercial support for Acmebot v5 is available from Polymind Inc.
 
 ## Community Support
 
@@ -14,7 +14,7 @@ Community support is best effort and does not include guaranteed response times.
 
 ## Commercial Support
 
-Commercial support for Acmebot v5 is available from [Polymind Inc.](https://github.com/polymind-inc) for organizations running Acmebot in production or planning a production rollout.
+Commercial support for Acmebot v5 is available from [Polymind Inc.](https://polymind.jp/acmebot) for organizations running Acmebot in production or planning a production rollout.
 
 Support engagements can cover:
 
@@ -24,16 +24,48 @@ Support engagements can cover:
 - DNS provider and ACME certificate authority configuration.
 - Troubleshooting issuance, renewal, and operational issues.
 - Operational guidance for monitoring, upgrades, and incident response.
+- Architecture guidance for production deployments.
+- DNS provider integration consulting.
 
 Scope, response expectations, and terms are arranged directly with Polymind Inc.
+
+## How It Works
+
+1. Submit an inquiry through the [Polymind Acmebot support page](https://polymind.jp/acmebot) or email [support@polymind.jp](mailto:support@polymind.jp).
+2. Polymind reviews the environment, issue details, and support scope.
+3. If substantial investigation is required, Polymind proposes an appropriate support engagement.
 
 ## Before Requesting Help
 
 Please include enough context to understand the environment and failure mode:
 
 - Acmebot version.
-- Azure region and hosting plan.
+- Company name and contact email address.
+- Azure hosting plan.
 - DNS provider and certificate authority.
 - Target Azure service that consumes the certificate.
-- Relevant error messages from the dashboard, operation status, or Application Insights.
+- Description of the issue and relevant error messages from the dashboard, operation status, or Application Insights.
 - Whether the issue happens during deployment, issuance, renewal, revocation, or downstream service sync.
+- Related GitHub issue URL, log snippets, or screenshot URLs when available.
+
+## FAQ
+
+### Is Acmebot still open source?
+
+Yes. Acmebot remains licensed under the Apache License 2.0.
+
+### Is commercial support required?
+
+No. Commercial support is entirely optional.
+
+### Do you provide SLA-backed support?
+
+Not by default. Engagements are handled individually.
+
+### Do you provide 24x7 support?
+
+Not by default.
+
+### Do you provide managed hosting?
+
+No.

--- a/docs/guide/support.md
+++ b/docs/guide/support.md
@@ -1,0 +1,39 @@
+# Support
+
+Acmebot is an open source project released under the Apache License 2.0. Community support remains available through GitHub, and commercial support for Acmebot v5 is now available from Polymind Inc.
+
+## Community Support
+
+Use the community channels when you have general questions, want to discuss usage patterns, or need to report reproducible bugs:
+
+- Usage questions and general discussion: [GitHub Discussions](https://github.com/polymind-inc/acmebot/discussions)
+- Bug reports: [GitHub Issues](https://github.com/polymind-inc/acmebot/issues)
+- Security issues: see the [Security Policy](https://github.com/polymind-inc/acmebot/blob/master/SECURITY.md)
+
+Community support is best effort and does not include guaranteed response times.
+
+## Commercial Support
+
+Commercial support for Acmebot v5 is available from [Polymind Inc.](https://github.com/polymind-inc) for organizations running Acmebot in production or planning a production rollout.
+
+Support engagements can cover:
+
+- Production deployment planning and review.
+- Migration from Acmebot v4 to v5.
+- Azure Functions, Key Vault, managed identity, and networking configuration.
+- DNS provider and ACME certificate authority configuration.
+- Troubleshooting issuance, renewal, and operational issues.
+- Operational guidance for monitoring, upgrades, and incident response.
+
+Scope, response expectations, and terms are arranged directly with Polymind Inc.
+
+## Before Requesting Help
+
+Please include enough context to understand the environment and failure mode:
+
+- Acmebot version.
+- Azure region and hosting plan.
+- DNS provider and certificate authority.
+- Target Azure service that consumes the certificate.
+- Relevant error messages from the dashboard, operation status, or Application Insights.
+- Whether the issue happens during deployment, issuance, renewal, revocation, or downstream service sync.


### PR DESCRIPTION
## Summary

- Announce that commercial support for Acmebot v5 is available from Polymind Inc. and link repository support surfaces to the existing Polymind Acmebot support page.
- Expand the support guide with commercial engagement types, inquiry flow, recommended context to include before first response, and FAQ for optional support, SLA-backed support, 24x7 support, and managed hosting.
- Keep community support channels separate while routing commercial support links to Polymind.

## Validation

- `git diff --check`
- `npm run build` from `docs/`

The VitePress build completed successfully. Rollup emitted existing dependency annotation warnings from `@vueuse/core`, but no build errors.