### PR TITLE
Support disabled certificate state

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -2,7 +2,7 @@
 
 ## How does automatic renewal work?
 
-The `RenewCertificates` timer runs daily. When ACME renewal information is available for a managed certificate, Acmebot renews after the CA reports that the renewal window has opened. Otherwise, it renews when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent (default 30):
+The `RenewCertificates` timer runs daily for enabled managed certificates. When ACME renewal information is available, Acmebot renews after the CA reports that the renewal window has opened. Otherwise, it renews when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent (default 30):
 
 ```text
 Acmebot__RenewBeforeExpiry=30
@@ -20,7 +20,7 @@ Yes. Acmebot stores the certificate in Key Vault, and any number of services can
 
 ## How do I remove a certificate from Acmebot management?
 
-Delete it from Key Vault. If it must also be revoked at the certificate authority, revoke it from the dashboard or HTTP API before deleting it.
+Delete it from Key Vault. If it must also be revoked at the certificate authority, revoke it from the dashboard or HTTP API before deleting it. Revocation also disables the current Key Vault certificate version.
 
 ## How do I reinstall or upgrade Acmebot without losing certificates?
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -98,6 +98,7 @@ Returns an array of certificate objects.
     "keySize": 2048,
     "reuseKey": false,
     "isExpired": false,
+    "enabled": true,
     "isIssuedByAcmebot": true,
     "isSameEndpoint": true,
     "acmeEndpoint": "acme-v02.api.letsencrypt.org",
@@ -143,7 +144,7 @@ POST /api/certificates/wildcard-example-com/revoke
 Accept: application/json
 ```
 
-Revocation waits for the ACME revoke operation to complete and returns `200 OK` on success.
+Revocation waits for the ACME revoke operation to complete, disables the current Key Vault certificate version, and returns `200 OK` on success.
 
 ## Errors
 

--- a/src/Acmebot.App/ClientApp/src/App.vue
+++ b/src/Acmebot.App/ClientApp/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue';
-import { Activity, AlertTriangle, BadgeCheck, CircleSlash, ExternalLink, Info, Shield, ShieldAlert, ShieldCheck, X } from 'lucide-vue-next';
+import { Activity, AlertTriangle, BadgeCheck, CircleSlash, ExternalLink, Info, PowerOff, Shield, ShieldAlert, ShieldCheck, X } from 'lucide-vue-next';
 
 import { formatApiError, getCertificates, getDnsZones, issueCertificate, renewCertificate, revokeCertificate } from '@/api/acmebotApi';
 import { getLatestRelease } from '@/api/releases';
@@ -51,7 +51,7 @@ const summary = computed(() => {
       counts[status.kind] += 1;
       return counts;
     },
-    { valid: 0, warning: 0, expired: 0 },
+    { valid: 0, warning: 0, expired: 0, disabled: 0 },
   );
 
   return {
@@ -67,6 +67,7 @@ const summaryItems = computed(() => [
   { label: 'Managed', value: summary.value.managed, tone: 'good', icon: ShieldCheck },
   { label: 'Expiring soon', value: summary.value.warning, tone: 'warning', icon: ShieldAlert },
   { label: 'Expired', value: summary.value.expired, tone: 'danger', icon: AlertTriangle },
+  { label: 'Disabled', value: summary.value.disabled, tone: 'disabled', icon: PowerOff },
   { label: 'Other CA', value: summary.value.otherCa, tone: 'neutral', icon: BadgeCheck },
   { label: 'Unmanaged', value: summary.value.unmanaged, tone: 'neutral', icon: CircleSlash },
 ]);

--- a/src/Acmebot.App/ClientApp/src/api/mockData.ts
+++ b/src/Acmebot.App/ClientApp/src/api/mockData.ts
@@ -23,6 +23,7 @@ let mockCertificates: CertificateItem[] = [
     keySize: 2048,
     reuseKey: false,
     isExpired: false,
+    enabled: true,
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
@@ -41,6 +42,7 @@ let mockCertificates: CertificateItem[] = [
     keySize: 2048,
     reuseKey: false,
     isExpired: false,
+    enabled: false,
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
@@ -59,6 +61,7 @@ let mockCertificates: CertificateItem[] = [
     keySize: 2048,
     reuseKey: false,
     isExpired: false,
+    enabled: true,
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
@@ -76,6 +79,7 @@ let mockCertificates: CertificateItem[] = [
     keyCurveName: 'P-256',
     reuseKey: true,
     isExpired: false,
+    enabled: true,
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
@@ -93,6 +97,7 @@ let mockCertificates: CertificateItem[] = [
     keyCurveName: 'P-256',
     reuseKey: false,
     isExpired: false,
+    enabled: true,
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
@@ -110,6 +115,7 @@ let mockCertificates: CertificateItem[] = [
     keySize: 3072,
     reuseKey: false,
     isExpired: true,
+    enabled: true,
     isIssuedByAcmebot: true,
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
@@ -127,6 +133,7 @@ let mockCertificates: CertificateItem[] = [
     keySize: 2048,
     reuseKey: false,
     isExpired: false,
+    enabled: true,
     isIssuedByAcmebot: true,
     isSameEndpoint: false,
     acmeEndpoint: 'https://acme.zerossl.com/v2/DV90',
@@ -144,6 +151,7 @@ let mockCertificates: CertificateItem[] = [
     keySize: 4096,
     reuseKey: null,
     isExpired: false,
+    enabled: true,
     isIssuedByAcmebot: false,
     isSameEndpoint: false,
     acmeEndpoint: null,
@@ -195,6 +203,7 @@ export async function mockIssueCertificate(policy: CertificatePolicyItem): Promi
       keyCurveName: policy.keyCurveName,
       reuseKey: policy.reuseKey,
       isExpired: false,
+      enabled: true,
       isIssuedByAcmebot: true,
       isSameEndpoint: true,
       acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
@@ -213,6 +222,7 @@ export async function mockRenewCertificate(certificateName: string): Promise<voi
           createdOn: new Date().toISOString(),
           expiresOn: dateFromNow(90),
           isExpired: false,
+          enabled: true,
         }
       : certificate,
   );
@@ -220,7 +230,7 @@ export async function mockRenewCertificate(certificateName: string): Promise<voi
 
 export async function mockRevokeCertificate(certificateName: string): Promise<void> {
   await delay(650);
-  mockCertificates = mockCertificates.filter((certificate) => certificate.name !== certificateName);
+  mockCertificates = mockCertificates.map((certificate) => (certificate.name === certificateName ? { ...certificate, enabled: false } : certificate));
 }
 
 function delay(milliseconds: number): Promise<void> {

--- a/src/Acmebot.App/ClientApp/src/api/types.ts
+++ b/src/Acmebot.App/ClientApp/src/api/types.ts
@@ -1,7 +1,7 @@
 export type KeyType = 'RSA' | 'EC';
 export type KeyCurveName = 'P-256' | 'P-384' | 'P-521' | 'P-256K';
 export type CertificateCategory = 'managed' | 'other-ca' | 'unmanaged';
-export type CertificateStatusKind = 'valid' | 'warning' | 'expired';
+export type CertificateStatusKind = 'valid' | 'warning' | 'expired' | 'disabled';
 
 export interface CertificateItem {
   id: string;
@@ -16,6 +16,7 @@ export interface CertificateItem {
   keyCurveName?: KeyCurveName | string | null;
   reuseKey?: boolean | null;
   isExpired: boolean;
+  enabled: boolean;
   isIssuedByAcmebot: boolean;
   isSameEndpoint: boolean;
   acmeEndpoint?: string | null;

--- a/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
+++ b/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
@@ -172,6 +172,7 @@ const zoneGroups = computed<ZoneGroup[]>(() => {
           valid: statusKind === 'valid' ? 1 : 0,
           warning: statusKind === 'warning' ? 1 : 0,
           expired: statusKind === 'expired' ? 1 : 0,
+          disabled: statusKind === 'disabled' ? 1 : 0,
         },
       });
     } else {
@@ -312,6 +313,7 @@ function toggleAllZoneGroups(): void {
           <option value="valid">Valid</option>
           <option value="warning">Expiring soon</option>
           <option value="expired">Expired</option>
+          <option value="disabled">Disabled</option>
         </select>
       </label>
       <label class="select-field">
@@ -473,6 +475,10 @@ function toggleAllZoneGroups(): void {
                         v-if="group.statusCounts.expired > 0"
                         class="zone-stat zone-stat--expired"
                       >{{ group.statusCounts.expired }} expired</span>
+                      <span
+                        v-if="group.statusCounts.disabled > 0"
+                        class="zone-stat zone-stat--disabled"
+                      >{{ group.statusCounts.disabled }} disabled</span>
                     </div>
                   </div>
                 </td>
@@ -482,14 +488,20 @@ function toggleAllZoneGroups(): void {
                   v-for="row in group.rows"
                   :key="row.original.id"
                   class="certificate-row"
-                  :class="{ 'is-selected': selectedCertificate?.id === row.original.id }"
+                  :class="{ 'is-selected': selectedCertificate?.id === row.original.id, 'is-disabled': !row.original.enabled }"
                 >
                   <td data-label="Name">
                     <div class="certificate-name">
                       {{ row.original.name }}
                     </div>
                     <div
-                      v-if="isShortLived(row.original)"
+                      v-if="!row.original.enabled"
+                      class="inline-note inline-note--disabled"
+                    >
+                      Disabled
+                    </div>
+                    <div
+                      v-if="row.original.enabled && isShortLived(row.original)"
                       class="inline-note"
                     >
                       Short-lived

--- a/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
+++ b/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
@@ -259,7 +259,7 @@ const customTagsCopyText = computed(() => customTags.value.map(([key, value]) =>
             <span>Renew</span>
           </button>
           <button
-            v-if="certificate.isIssuedByAcmebot && certificate.isSameEndpoint && !certificate.isExpired"
+            v-if="certificate.enabled && certificate.isIssuedByAcmebot && certificate.isSameEndpoint && !certificate.isExpired"
             class="danger-button"
             type="button"
             :disabled="busy"

--- a/src/Acmebot.App/ClientApp/src/styles/app.css
+++ b/src/Acmebot.App/ClientApp/src/styles/app.css
@@ -183,7 +183,7 @@ p {
 
 .summary-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 12px;
   margin-bottom: 18px;
 }
@@ -213,6 +213,10 @@ p {
 
 .summary-item--danger svg {
   color: var(--color-danger);
+}
+
+.summary-item--disabled svg {
+  color: var(--color-muted);
 }
 
 .summary-item__value {
@@ -580,8 +584,22 @@ button:disabled {
   border-color: #f2b8c5;
 }
 
+.zone-stat--disabled {
+  color: var(--color-muted);
+  background: var(--color-neutral-soft);
+  border-color: var(--color-border);
+}
+
 .certificate-table tbody tr.certificate-row.is-selected {
   background: #f4f8fb;
+}
+
+.certificate-table tbody tr.certificate-row.is-disabled {
+  background: var(--color-surface-subtle);
+}
+
+.certificate-table tbody tr.certificate-row.is-disabled .certificate-name {
+  color: var(--color-muted);
 }
 
 .certificate-table .cell-subtext {
@@ -602,6 +620,11 @@ button:disabled {
   background: var(--color-neutral-soft);
   font-size: 0.72rem;
   font-weight: 700;
+}
+
+.inline-note--disabled {
+  color: var(--color-muted);
+  border: 1px solid var(--color-border);
 }
 
 .dns-list {
@@ -694,6 +717,15 @@ button:disabled {
   background: var(--color-danger);
 }
 
+.status-badge--disabled {
+  color: var(--color-muted);
+  background: var(--color-neutral-soft);
+}
+
+.status-badge--disabled .status-badge__dot {
+  background: var(--color-muted);
+}
+
 .row-action,
 .icon-only-button,
 .copy-button {
@@ -740,6 +772,11 @@ button:disabled {
   inset: 0;
   border: 0;
   background: rgba(15, 23, 42, 0.42);
+}
+
+.modal-scrim {
+  position: fixed;
+  z-index: 70;
 }
 
 .drawer {
@@ -1259,6 +1296,7 @@ button:disabled {
   top: 50%;
   left: 50%;
   z-index: 80;
+  pointer-events: auto;
   width: min(440px, calc(100vw - 32px));
   padding: 18px;
   display: grid;

--- a/src/Acmebot.App/ClientApp/src/utils/certificates.ts
+++ b/src/Acmebot.App/ClientApp/src/utils/certificates.ts
@@ -57,6 +57,10 @@ export function getCertificateStatus(certificate: CertificateItem): CertificateS
   const remainingDays = Math.round(diff / 86_400_000);
   const remainingHours = Math.round(diff / 3_600_000);
 
+  if (!certificate.enabled) {
+    return { kind: 'disabled', label: 'Disabled', remainingDays };
+  }
+
   if (diff <= 0 || certificate.isExpired) {
     return { kind: 'expired', label: 'Expired', remainingDays };
   }

--- a/src/Acmebot.App/Extensions/CertificateExtensions.cs
+++ b/src/Acmebot.App/Extensions/CertificateExtensions.cs
@@ -46,6 +46,7 @@ internal static class CertificateExtensions
             KeyCurveName = certificate.Policy.KeyCurveName?.ToString(),
             ReuseKey = certificate.Policy.ReuseKey,
             IsExpired = DateTimeOffset.UtcNow > certificate.Properties.ExpiresOn.GetValueOrDefault(DateTimeOffset.MaxValue),
+            Enabled = certificate.Properties.Enabled != false,
             AcmeEndpoint = !string.IsNullOrEmpty(metadata?.Endpoint) ? NormalizeEndpoint(metadata.Endpoint) : "",
             DnsAlias = metadata?.DnsAlias ?? "",
             Tags = certificate.Properties.Tags.GetCustomCertificateTags()

--- a/src/Acmebot.App/Functions/Orchestration/CertificateActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateActivities.cs
@@ -31,6 +31,11 @@ public class CertificateActivities(
 
         await foreach (var properties in certificateProperties)
         {
+            if (properties.Enabled == false)
+            {
+                continue;
+            }
+
             if (!properties.IsIssuedByAcmebot() || !properties.IsSameEndpoint(_options.Endpoint))
             {
                 continue;
@@ -97,6 +102,10 @@ public class CertificateActivities(
         using var acmeContext = await acmeClientFactory.CreateClientAsync();
 
         await acmeContext.Client.RevokeCertificateAsync(acmeContext.Account, response.Value.Cer);
+
+        response.Value.Properties.Enabled = false;
+
+        await certificateClient.UpdateCertificatePropertiesAsync(response.Value.Properties);
     }
 
     private static bool ShouldRenewByLifetimePercentage(CertificateProperties properties, DateTimeOffset now, int renewBeforeExpiryPercentage)

--- a/src/Acmebot.App/Models/CertificateItem.cs
+++ b/src/Acmebot.App/Models/CertificateItem.cs
@@ -40,6 +40,9 @@ public class CertificateItem
     [JsonPropertyName("isExpired")]
     public bool IsExpired { get; set; }
 
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+
     [JsonPropertyName("isIssuedByAcmebot")]
     public bool IsIssuedByAcmebot { get; set; }
 


### PR DESCRIPTION
Add explicit enabled/disabled handling for certificates across API, backend and frontend.\n\n- API/docs: include `enabled` field and note that revoke disables the Key Vault certificate version.\n- Backend: add Enabled to CertificateItem, map certificate.Properties.Enabled, skip disabled certificates in orchestration, and set Enabled=false when revoking.\n- Frontend: add `enabled` to types and mock data, update UI (summary, table, details drawer) to show/filter disabled certificates and prevent revoke on disabled items, and adjust styles.\n- Mock API: mockRevokeCertificate now marks certificates as disabled instead of removing them.

Close #1100
Close #967