### PR TITLE
Use response replay-nonce for subsequent requests

### DIFF
--- a/src/Acmebot.Acme/AcmeClient.cs
+++ b/src/Acmebot.Acme/AcmeClient.cs
@@ -633,6 +633,7 @@ public sealed class AcmeClient : IDisposable
 
             using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             var rawResponse = await ToRawResponseAsync(response, cancellationToken).ConfigureAwait(false);
+            _nonceStore.Add(rawResponse.ReplayNonce);
 
             if (response.IsSuccessStatusCode)
             {
@@ -758,11 +759,6 @@ public sealed class AcmeClient : IDisposable
     private async Task<AcmeRawResponse> ToRawResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken)
     {
         var replayNonce = TryGetSingleHeaderValue(response.Headers, "Replay-Nonce");
-
-        if (!string.IsNullOrWhiteSpace(replayNonce))
-        {
-            _nonceStore.Add(replayNonce);
-        }
 
         var body = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
 

--- a/tests/Acmebot.Acme.Tests/AcmeClientTests.cs
+++ b/tests/Acmebot.Acme.Tests/AcmeClientTests.cs
@@ -168,6 +168,80 @@ public sealed class AcmeClientTests
     }
 
     [Fact]
+    public async Task UpdateAccountAsync_UsesResponseNonceForNextChallengeRequest()
+    {
+        var directoryUrl = new Uri("https://example.com/acme/directory");
+        var challengeUrl = new Uri("https://example.com/acme/challenge/1");
+        using var signer = AcmeSigner.CreateP256();
+        using var handler = new RecordingHandler();
+        using var httpClient = new HttpClient(handler);
+        using var client = new AcmeClient(httpClient, directoryUrl);
+        var account = AcmeTestSupport.CreateAccountHandle(signer);
+
+        AcmeTestSupport.EnqueueDirectory(handler);
+        AcmeTestSupport.EnqueueNonce(handler, "bm9uY2Ux");
+        handler.Enqueue(_ => AcmeTestSupport.CreateJsonResponse(HttpStatusCode.OK, new
+        {
+            status = "valid",
+            contact = new[] { "mailto:new@example.com" }
+        }, replayNonce: "bm9uY2Uy"));
+        handler.Enqueue(_ => AcmeTestSupport.CreateJsonResponse(
+            HttpStatusCode.OK,
+            new { type = "dns-01", url = challengeUrl, status = "pending" },
+            replayNonce: "bm9uY2Uz"));
+
+        account = await client.UpdateAccountAsync(account, new AcmeUpdateAccountRequest { Contact = ["mailto:new@example.com"] }, TestContext.Current.CancellationToken);
+        await client.AnswerChallengeAsync(account, challengeUrl, TestContext.Current.CancellationToken);
+
+        var postRequests = handler.Requests.Where(x => x.Method == HttpMethod.Post).ToArray();
+        Assert.Equal(2, postRequests.Length);
+        Assert.Single(handler.Requests, x => x.Method == HttpMethod.Head);
+
+        using var accountProtectedHeader = postRequests[0].GetProtectedHeaderJson();
+        using var challengeProtectedHeader = postRequests[1].GetProtectedHeaderJson();
+        Assert.Equal("bm9uY2Ux", accountProtectedHeader.RootElement.GetProperty("nonce").GetString());
+        Assert.Equal("bm9uY2Uy", challengeProtectedHeader.RootElement.GetProperty("nonce").GetString());
+    }
+
+    [Fact]
+    public async Task UpdateAccountAsync_UsesResponseNonceForNextCertificateRequest()
+    {
+        var directoryUrl = new Uri("https://example.com/acme/directory");
+        var certificateUrl = new Uri("https://example.com/acme/cert/1");
+        using var signer = AcmeSigner.CreateP256();
+        using var certificate = AcmeTestSupport.CreateCertificate();
+        using var handler = new RecordingHandler();
+        using var httpClient = new HttpClient(handler);
+        using var client = new AcmeClient(httpClient, directoryUrl);
+        var account = AcmeTestSupport.CreateAccountHandle(signer);
+
+        AcmeTestSupport.EnqueueDirectory(handler);
+        AcmeTestSupport.EnqueueNonce(handler, "bm9uY2Ux");
+        handler.Enqueue(_ => AcmeTestSupport.CreateJsonResponse(HttpStatusCode.OK, new
+        {
+            status = "valid",
+            contact = new[] { "mailto:new@example.com" }
+        }, replayNonce: "bm9uY2Uy"));
+        handler.Enqueue(_ => AcmeTestSupport.CreateResponse(
+            HttpStatusCode.OK,
+            certificate.ExportCertificatePem(),
+            AcmeTestSupport.PemCertificateChainMediaType,
+            replayNonce: "bm9uY2Uz"));
+
+        account = await client.UpdateAccountAsync(account, new AcmeUpdateAccountRequest { Contact = ["mailto:new@example.com"] }, TestContext.Current.CancellationToken);
+        await client.DownloadCertificateAsync(account, certificateUrl, TestContext.Current.CancellationToken);
+
+        var postRequests = handler.Requests.Where(x => x.Method == HttpMethod.Post).ToArray();
+        Assert.Equal(2, postRequests.Length);
+        Assert.Single(handler.Requests, x => x.Method == HttpMethod.Head);
+
+        using var accountProtectedHeader = postRequests[0].GetProtectedHeaderJson();
+        using var certificateProtectedHeader = postRequests[1].GetProtectedHeaderJson();
+        Assert.Equal("bm9uY2Ux", accountProtectedHeader.RootElement.GetProperty("nonce").GetString());
+        Assert.Equal("bm9uY2Uy", certificateProtectedHeader.RootElement.GetProperty("nonce").GetString());
+    }
+
+    [Fact]
     public async Task DeactivateAccountAsync_SendsDeactivatedStatus()
     {
         var directoryUrl = new Uri("https://example.com/acme/directory");


### PR DESCRIPTION
Add the response Replay-Nonce to the nonce store immediately after reading the raw response in AcmeClient, and remove the redundant header-add in the raw response parsing path. Add tests (UpdateAccountAsync_UsesResponseNonceForNextChallengeRequest and UpdateAccountAsync_UsesResponseNonceForNextCertificateRequest) to assert that the nonce returned by one response is used as the nonce for the next POST request. This ensures proper nonce propagation between sequential ACME requests and prevents use of stale nonces.