### PR TITLE
Add Acmebot CLI project and docs

### DIFF
--- a/Acmebot.slnx
+++ b/Acmebot.slnx
@@ -2,11 +2,13 @@
   <Folder Name="/src/">
     <Project Path="src/Acmebot.Acme/Acmebot.Acme.csproj" />
     <Project Path="src/Acmebot.App/Acmebot.App.csproj" />
+    <Project Path="src/Acmebot.Cli/Acmebot.Cli.csproj" />
   </Folder>
   <Folder Name="/samples/">
     <Project Path="samples/Acmebot.Acme.Sample/Acmebot.Acme.Sample.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Acmebot.Acme.Tests/Acmebot.Acme.Tests.csproj" />
+    <Project Path="tests/Acmebot.Cli.Tests/Acmebot.Cli.Tests.csproj" />
   </Folder>
 </Solution>

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -67,6 +67,7 @@ Typical symptoms:
 
 - The dashboard or an API call returns `401`.
 - A signed-in caller can list data but cannot issue or revoke certificates.
+- Azure CLI token acquisition fails with `AADSTS65001` or `consent_required`.
 
 What to verify:
 
@@ -74,8 +75,11 @@ What to verify:
 - Requests reach the app with an authenticated principal.
 - Microsoft Entra ID uses the intended tenant and application registration.
 - When `Acmebot__RequireAppRoles=true`, the token contains `Acmebot.IssueCertificate` or `Acmebot.RevokeCertificate`.
+- For Azure CLI-backed automation, the application registration used by App Service Authentication exposes a `user_impersonation` scope and pre-authorizes the Microsoft Azure CLI client ID `04b07795-8ddb-461a-bbee-02f9e1bf7b46`.
 
 The HTTP triggers use anonymous trigger authorization so App Service Authentication can populate the user identity before application code runs. A Functions host key alone does not satisfy the authenticated-user requirement for the v5 dashboard and API. See [Security](../reference/security) for the authorization model.
+
+If `az account get-access-token` fails before the HTTP request is sent, fix Microsoft Entra consent first. In the Acmebot application registration, go to **Expose an API** > **Authorized client applications**, add `04b07795-8ddb-461a-bbee-02f9e1bf7b46`, and select `user_impersonation`. If App Service Authentication is configured to allow only specific client applications, add the same client ID to that allow list as well.
 
 ## Renewal Does Not Run
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -17,6 +17,24 @@ The Function triggers use anonymous trigger authorization internally, but the ap
 
 When app role enforcement is enabled, issue and renew operations require `Acmebot.IssueCertificate`, and revoke operations require `Acmebot.RevokeCertificate`.
 
+## CLI
+
+The `Acmebot.Cli` project provides an automation-friendly wrapper around the same HTTP API. It uses Microsoft Entra ID bearer tokens through `Azure.Identity`; by default it follows `DefaultAzureCredential`, so local `az login`, managed identity, and service principal environment variables all work without adding API-specific authentication code.
+
+```bash
+acmebot --endpoint https://my-acmebot.azurewebsites.net certificate list
+acmebot --endpoint https://my-acmebot.azurewebsites.net dns-zone list
+acmebot --endpoint https://my-acmebot.azurewebsites.net certificate issue --dns-name "*.example.com" --dns-provider "Azure DNS"
+acmebot --endpoint https://my-acmebot.azurewebsites.net certificate renew wildcard-example-com
+acmebot --endpoint https://my-acmebot.azurewebsites.net certificate revoke wildcard-example-com
+```
+
+For JSON output, pass `--json` or `--format json`. For service principal authentication, use standard Azure Identity environment variables (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and either `AZURE_CLIENT_SECRET` or `AZURE_CLIENT_CERTIFICATE_PATH`) or the matching CLI options.
+
+If the protected API uses a custom application ID URI, pass `--audience <application-id-uri>`. When neither is provided, the CLI requests a token for the Acmebot endpoint origin. The CLI derives the Microsoft Entra token scope internally by appending `/.default`; do not pass `user_impersonation` or `.default` in the `--audience` value.
+
+When using `az login` or Azure CLI-backed credentials against a Microsoft Entra application ID URI such as `api://<application-client-id>`, the application registration used by App Service Authentication must allow the Microsoft Azure CLI public client. In the application registration, open **Expose an API**, add an authorized client application with client ID `04b07795-8ddb-461a-bbee-02f9e1bf7b46`, and select the `user_impersonation` scope. Without this pre-authorization or equivalent tenant consent, Microsoft Entra ID can return `AADSTS65001` / `consent_required` before Acmebot receives the request.
+
 ## Endpoints
 
 | Method | Path | Purpose |

--- a/src/Acmebot.Cli/Acmebot.Cli.csproj
+++ b/src/Acmebot.Cli/Acmebot.Cli.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>acmebot</AssemblyName>
+    <RootNamespace>Acmebot.Cli</RootNamespace>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>acmebot</ToolCommandName>
+    <PackageId>Acmebot.Cli</PackageId>
+    <Title>Acmebot CLI</Title>
+    <Description>Command-line client for Acmebot HTTP API automation.</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>acme;azure;key-vault;certificates;cli</PackageTags>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/Acmebot.Cli/AcmebotApiClient.cs
+++ b/src/Acmebot.Cli/AcmebotApiClient.cs
@@ -64,8 +64,6 @@ internal sealed class AcmebotApiClient(HttpClient httpClient, Uri endpoint, Toke
         {
             while (true)
             {
-                await Task.Delay(pollInterval, linkedTokenSource.Token);
-
                 using var request = new HttpRequestMessage(HttpMethod.Get, operationLocation);
                 using var response = await SendAsync(request, linkedTokenSource.Token);
 
@@ -77,6 +75,7 @@ internal sealed class AcmebotApiClient(HttpClient httpClient, Uri endpoint, Toke
                 if (response.StatusCode == HttpStatusCode.Accepted)
                 {
                     await progress.WriteLineAsync("Operation is still running...");
+                    await Task.Delay(pollInterval, linkedTokenSource.Token);
                     continue;
                 }
 

--- a/src/Acmebot.Cli/AcmebotApiClient.cs
+++ b/src/Acmebot.Cli/AcmebotApiClient.cs
@@ -1,0 +1,204 @@
+﻿using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using Azure.Core;
+
+namespace Acmebot.Cli;
+
+internal sealed class AcmebotApiClient(HttpClient httpClient, Uri endpoint, TokenCredential credential, string[] scopes) : IDisposable
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false
+    };
+
+    private readonly HttpClient _httpClient = httpClient;
+    private readonly Uri _endpoint = endpoint;
+    private readonly TokenCredential _credential = credential;
+    private readonly string[] _scopes = scopes;
+    private AccessToken? _accessToken;
+
+    public async Task<IReadOnlyList<CertificateItem>> GetCertificatesAsync(CancellationToken cancellationToken)
+    {
+        return await GetJsonAsync<IReadOnlyList<CertificateItem>>("api/certificates", cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<DnsZoneGroup>> GetDnsZonesAsync(CancellationToken cancellationToken)
+    {
+        return await GetJsonAsync<IReadOnlyList<DnsZoneGroup>>("api/dns-zones", cancellationToken);
+    }
+
+    public async Task<Uri> IssueCertificateAsync(CertificatePolicyItem policy, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, BuildUri("api/certificates"))
+        {
+            Content = JsonContent.Create(policy, options: s_jsonOptions)
+        };
+
+        return await StartOperationAsync(request, cancellationToken);
+    }
+
+    public async Task<Uri> RenewCertificateAsync(string certificateName, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, BuildUri($"api/certificates/{Uri.EscapeDataString(certificateName)}/renew"));
+
+        return await StartOperationAsync(request, cancellationToken);
+    }
+
+    public async Task RevokeCertificateAsync(string certificateName, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, BuildUri($"api/certificates/{Uri.EscapeDataString(certificateName)}/revoke"));
+        using var response = await SendAsync(request, cancellationToken);
+
+        await EnsureSuccessAsync(response, cancellationToken);
+    }
+
+    public async Task WaitForOperationAsync(Uri operationLocation, TimeSpan pollInterval, TimeSpan timeout, TextWriter progress, CancellationToken cancellationToken)
+    {
+        using var timeoutTokenSource = new CancellationTokenSource(timeout);
+        using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutTokenSource.Token);
+
+        try
+        {
+            while (true)
+            {
+                await Task.Delay(pollInterval, linkedTokenSource.Token);
+
+                using var request = new HttpRequestMessage(HttpMethod.Get, operationLocation);
+                using var response = await SendAsync(request, linkedTokenSource.Token);
+
+                if (response.StatusCode == HttpStatusCode.OK)
+                {
+                    return;
+                }
+
+                if (response.StatusCode == HttpStatusCode.Accepted)
+                {
+                    await progress.WriteLineAsync("Operation is still running...");
+                    continue;
+                }
+
+                await EnsureSuccessAsync(response, linkedTokenSource.Token);
+            }
+        }
+        catch (OperationCanceledException) when (timeoutTokenSource.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException($"Operation did not complete within {timeout.TotalSeconds:N0} seconds.");
+        }
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+
+    private async Task<T> GetJsonAsync<T>(string path, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, BuildUri(path));
+        using var response = await SendAsync(request, cancellationToken);
+
+        await EnsureSuccessAsync(response, cancellationToken);
+
+        var value = await response.Content.ReadFromJsonAsync<T>(s_jsonOptions, cancellationToken);
+
+        return value ?? throw new AcmebotApiException(response.StatusCode, "The API returned an empty response.");
+    }
+
+    private async Task<Uri> StartOperationAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        using var response = await SendAsync(request, cancellationToken);
+
+        await EnsureSuccessAsync(response, cancellationToken);
+
+        if (response.Headers.Location is null)
+        {
+            throw new AcmebotApiException(response.StatusCode, "The operation response did not include a Location header.");
+        }
+
+        return BuildLocationUri(response.Headers.Location);
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await GetAccessTokenAsync(cancellationToken));
+
+        return await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+    }
+
+    private async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken)
+    {
+        if (_accessToken is { ExpiresOn: var expiresOn, Token: var token } && expiresOn > DateTimeOffset.UtcNow.AddMinutes(5))
+        {
+            return token;
+        }
+
+        var accessToken = await _credential.GetTokenAsync(new TokenRequestContext(_scopes), cancellationToken);
+        _accessToken = accessToken;
+
+        return accessToken.Token;
+    }
+
+    private async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        var text = response.Content is null ? null : await response.Content.ReadAsStringAsync(cancellationToken);
+        ProblemDetails? problemDetails = null;
+
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            try
+            {
+                problemDetails = JsonSerializer.Deserialize<ProblemDetails>(text, s_jsonOptions);
+            }
+            catch (JsonException)
+            {
+                // Fall back to the raw response text below.
+            }
+        }
+
+        var message = GetProblemMessage(response.StatusCode, problemDetails, text);
+
+        throw new AcmebotApiException(response.StatusCode, message, problemDetails);
+    }
+
+    private static string GetProblemMessage(HttpStatusCode statusCode, ProblemDetails? problemDetails, string? rawText)
+    {
+        if (problemDetails?.Errors is { Count: > 0 })
+        {
+            return string.Join(Environment.NewLine, problemDetails.Errors.SelectMany(error => error.Value));
+        }
+
+        return problemDetails?.Detail
+            ?? problemDetails?.Output
+            ?? problemDetails?.Title
+            ?? rawText
+            ?? $"HTTP {(int)statusCode} {statusCode}";
+    }
+
+    private Uri BuildUri(string path)
+    {
+        return new Uri(_endpoint, path);
+    }
+
+    private Uri BuildLocationUri(Uri location)
+    {
+        if (location.IsAbsoluteUri)
+        {
+            return location;
+        }
+
+        if (location.OriginalString.StartsWith("/", StringComparison.Ordinal))
+        {
+            return new Uri(new Uri(_endpoint.GetLeftPart(UriPartial.Authority)), location.OriginalString.TrimStart('/'));
+        }
+
+        return new Uri(_endpoint, location);
+    }
+}

--- a/src/Acmebot.Cli/AcmebotApiException.cs
+++ b/src/Acmebot.Cli/AcmebotApiException.cs
@@ -1,0 +1,10 @@
+﻿using System.Net;
+
+namespace Acmebot.Cli;
+
+internal sealed class AcmebotApiException(HttpStatusCode statusCode, string message, ProblemDetails? problemDetails = null) : Exception(message)
+{
+    public HttpStatusCode StatusCode { get; } = statusCode;
+
+    public ProblemDetails? ProblemDetails { get; } = problemDetails;
+}

--- a/src/Acmebot.Cli/CertificatePolicyFactory.cs
+++ b/src/Acmebot.Cli/CertificatePolicyFactory.cs
@@ -1,0 +1,144 @@
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Acmebot.Cli;
+
+internal static partial class CertificatePolicyFactory
+{
+    private static readonly HashSet<int> s_rsaKeySizes = [2048, 3072, 4096];
+    private static readonly HashSet<string> s_ecKeyCurves = ["P-256", "P-384", "P-521", "P-256K"];
+
+    public static CertificatePolicyItem Create(CommandLine commandLine)
+    {
+        var dnsNames = commandLine.GetOptions("dns-name")
+            .Select(dnsName => dnsName.Trim())
+            .Where(dnsName => dnsName.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (dnsNames.Length == 0)
+        {
+            throw new CliException("At least one '--dns-name' value is required.");
+        }
+
+        var certificateName = commandLine.GetOption("name");
+
+        if (certificateName is not null && !CertificateNameRegex().IsMatch(certificateName))
+        {
+            throw new CliException("Option '--name' must contain only letters, numbers, and hyphens.");
+        }
+
+        var keyType = commandLine.GetOption("key-type")?.ToUpperInvariant() ?? "RSA";
+        var keyCurveName = commandLine.GetOption("key-curve");
+        int? keySize = null;
+
+        if (string.Equals(keyType, "RSA", StringComparison.Ordinal))
+        {
+            if (!string.IsNullOrWhiteSpace(keyCurveName))
+            {
+                throw new CliException("Option '--key-curve' can only be used when '--key-type EC' is specified.");
+            }
+
+            keySize = ParseOptionalInt(commandLine.GetOption("key-size")) ?? 2048;
+
+            if (!s_rsaKeySizes.Contains(keySize.Value))
+            {
+                throw new CliException("Option '--key-size' must be 2048, 3072, or 4096.");
+            }
+        }
+        else if (string.Equals(keyType, "EC", StringComparison.Ordinal))
+        {
+            if (commandLine.HasOption("key-size"))
+            {
+                throw new CliException("Option '--key-size' can only be used when '--key-type RSA' is specified.");
+            }
+
+            keyCurveName ??= "P-256";
+
+            if (!s_ecKeyCurves.Contains(keyCurveName))
+            {
+                throw new CliException("Option '--key-curve' must be P-256, P-384, P-521, or P-256K.");
+            }
+        }
+        else
+        {
+            throw new CliException("Option '--key-type' must be 'RSA' or 'EC'.");
+        }
+
+        return new CertificatePolicyItem
+        {
+            CertificateName = certificateName,
+            DnsNames = dnsNames,
+            DnsProviderName = NormalizeOptionalValue(commandLine.GetOption("dns-provider")),
+            KeyType = keyType,
+            KeySize = keySize,
+            KeyCurveName = keyCurveName,
+            ReuseKey = commandLine.HasOption("reuse-key") ? commandLine.GetFlag("reuse-key") : null,
+            DnsAlias = NormalizeOptionalValue(commandLine.GetOption("dns-alias")),
+            Tags = ParseTags(commandLine.GetOptions("tag"))
+        };
+    }
+
+    private static Dictionary<string, string>? ParseTags(IReadOnlyList<string> tagValues)
+    {
+        if (tagValues.Count == 0)
+        {
+            return null;
+        }
+
+        var tags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var tagValue in tagValues)
+        {
+            var separatorIndex = tagValue.IndexOf('=');
+
+            if (separatorIndex <= 0)
+            {
+                throw new CliException("Option '--tag' must use the form 'name=value'.");
+            }
+
+            var name = tagValue[..separatorIndex].Trim();
+            var value = tagValue[(separatorIndex + 1)..];
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new CliException("Tag name cannot be empty.");
+            }
+
+            if (!tags.TryAdd(name, value))
+            {
+                throw new CliException($"Duplicate tag '{name}'.");
+            }
+
+            if (string.Equals(name, "Acmebot", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new CliException("The 'Acmebot' tag is reserved for internal metadata.");
+            }
+        }
+
+        return tags;
+    }
+
+    private static int? ParseOptionalInt(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var result))
+        {
+            throw new CliException("Option '--key-size' must be a number.");
+        }
+
+        return result;
+    }
+
+    private static string? NormalizeOptionalValue(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    [GeneratedRegex("^[0-9a-zA-Z-]+$")]
+    private static partial Regex CertificateNameRegex();
+}

--- a/src/Acmebot.Cli/CertificatePolicyFactory.cs
+++ b/src/Acmebot.Cli/CertificatePolicyFactory.cs
@@ -6,7 +6,13 @@ namespace Acmebot.Cli;
 internal static partial class CertificatePolicyFactory
 {
     private static readonly HashSet<int> s_rsaKeySizes = [2048, 3072, 4096];
-    private static readonly HashSet<string> s_ecKeyCurves = ["P-256", "P-384", "P-521", "P-256K"];
+    private static readonly Dictionary<string, string> s_ecKeyCurves = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["P-256"] = "P-256",
+        ["P-384"] = "P-384",
+        ["P-521"] = "P-521",
+        ["P-256K"] = "P-256K"
+    };
 
     public static CertificatePolicyItem Create(CommandLine commandLine)
     {
@@ -29,7 +35,7 @@ internal static partial class CertificatePolicyFactory
         }
 
         var keyType = commandLine.GetOption("key-type")?.ToUpperInvariant() ?? "RSA";
-        var keyCurveName = commandLine.GetOption("key-curve");
+        var keyCurveName = NormalizeOptionalValue(commandLine.GetOption("key-curve"));
         int? keySize = null;
 
         if (string.Equals(keyType, "RSA", StringComparison.Ordinal))
@@ -53,9 +59,9 @@ internal static partial class CertificatePolicyFactory
                 throw new CliException("Option '--key-size' can only be used when '--key-type RSA' is specified.");
             }
 
-            keyCurveName ??= "P-256";
+            keyCurveName = NormalizeEcKeyCurve(keyCurveName) ?? "P-256";
 
-            if (!s_ecKeyCurves.Contains(keyCurveName))
+            if (!s_ecKeyCurves.ContainsKey(keyCurveName))
             {
                 throw new CliException("Option '--key-curve' must be P-256, P-384, P-521, or P-256K.");
             }
@@ -137,6 +143,13 @@ internal static partial class CertificatePolicyFactory
     private static string? NormalizeOptionalValue(string? value)
     {
         return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static string? NormalizeEcKeyCurve(string? value)
+    {
+        return value is not null && s_ecKeyCurves.TryGetValue(value, out var canonicalName)
+            ? canonicalName
+            : value;
     }
 
     [GeneratedRegex("^[0-9a-zA-Z-]+$")]

--- a/src/Acmebot.Cli/CliApplication.cs
+++ b/src/Acmebot.Cli/CliApplication.cs
@@ -1,0 +1,309 @@
+﻿using Azure.Identity;
+
+namespace Acmebot.Cli;
+
+internal static class CliApplication
+{
+    public static async Task<int> RunAsync(string[] args, TextWriter output, TextWriter error, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var commandLine = CommandLine.Parse(args);
+
+            if (commandLine.GetFlag("help") || commandLine.Arguments.Count == 0)
+            {
+                await HelpText.WriteAsync(output);
+                return ExitCodes.Success;
+            }
+
+            ValidateKnownOptions(commandLine);
+
+            var options = CliOptions.Create(commandLine);
+
+            using var client = new AcmebotApiClient(new HttpClient(), options.Endpoint, options.CredentialOptions.CreateCredential(), options.TokenScopes);
+
+            return await RunCommandAsync(commandLine, options, client, output, error, cancellationToken);
+        }
+        catch (CliException ex)
+        {
+            await error.WriteLineAsync(ex.Message);
+            await error.WriteLineAsync();
+            await HelpText.WriteUsageHintAsync(error);
+
+            return ExitCodes.Usage;
+        }
+        catch (AuthenticationFailedException ex)
+        {
+            await error.WriteLineAsync($"Authentication failed: {ex.Message}");
+
+            return ExitCodes.AuthenticationError;
+        }
+        catch (AcmebotApiException ex)
+        {
+            await error.WriteLineAsync($"API request failed: {(int)ex.StatusCode} {ex.StatusCode}");
+            await error.WriteLineAsync(ex.Message);
+
+            return ExitCodes.ApiError;
+        }
+        catch (HttpRequestException ex)
+        {
+            await error.WriteLineAsync($"HTTP request failed: {ex.Message}");
+
+            return ExitCodes.NetworkError;
+        }
+        catch (TimeoutException ex)
+        {
+            await error.WriteLineAsync(ex.Message);
+
+            return ExitCodes.ApiError;
+        }
+        catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            await error.WriteLineAsync("Canceled.");
+
+            return ExitCodes.Canceled;
+        }
+    }
+
+    private static async Task<int> RunCommandAsync(
+        CommandLine commandLine,
+        CliOptions options,
+        AcmebotApiClient client,
+        TextWriter output,
+        TextWriter error,
+        CancellationToken cancellationToken)
+    {
+        var command = commandLine.Arguments[0].ToLowerInvariant();
+
+        return command switch
+        {
+            "certificate" => await RunCertificateCommandAsync(commandLine, options, client, output, error, cancellationToken),
+            "dns-zone" => await RunDnsZoneCommandAsync(commandLine, options, client, output, cancellationToken),
+            "operation" => await RunOperationCommandAsync(commandLine, options, client, output, error, cancellationToken),
+            _ => throw new CliException($"Unknown command '{commandLine.Arguments[0]}'.")
+        };
+    }
+
+    private static async Task<int> RunCertificateCommandAsync(
+        CommandLine commandLine,
+        CliOptions options,
+        AcmebotApiClient client,
+        TextWriter output,
+        TextWriter error,
+        CancellationToken cancellationToken)
+    {
+        if (commandLine.Arguments.Count < 2)
+        {
+            throw new CliException("Missing certificate subcommand.");
+        }
+
+        return commandLine.Arguments[1].ToLowerInvariant() switch
+        {
+            "list" => await ListCertificatesAsync(commandLine, 2, options, client, output, cancellationToken),
+            "issue" => await IssueCertificateAsync(commandLine, 2, options, client, output, error, cancellationToken),
+            "renew" => await RenewCertificateAsync(commandLine, 2, options, client, output, error, cancellationToken),
+            "revoke" => await RevokeCertificateAsync(commandLine, 2, options, client, output, cancellationToken),
+            _ => throw new CliException($"Unknown certificate subcommand '{commandLine.Arguments[1]}'.")
+        };
+    }
+
+    private static async Task<int> RunDnsZoneCommandAsync(
+        CommandLine commandLine,
+        CliOptions options,
+        AcmebotApiClient client,
+        TextWriter output,
+        CancellationToken cancellationToken)
+    {
+        if (commandLine.Arguments.Count < 2)
+        {
+            throw new CliException("Missing DNS zone subcommand.");
+        }
+
+        return commandLine.Arguments[1].ToLowerInvariant() switch
+        {
+            "list" => await ListDnsZonesAsync(commandLine, 2, options, client, output, cancellationToken),
+            _ => throw new CliException($"Unknown DNS zone subcommand '{commandLine.Arguments[1]}'.")
+        };
+    }
+
+    private static async Task<int> RunOperationCommandAsync(
+        CommandLine commandLine,
+        CliOptions options,
+        AcmebotApiClient client,
+        TextWriter output,
+        TextWriter error,
+        CancellationToken cancellationToken)
+    {
+        if (commandLine.Arguments.Count < 2)
+        {
+            throw new CliException("Missing operation subcommand.");
+        }
+
+        if (!string.Equals(commandLine.Arguments[1], "wait", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new CliException($"Unknown operation subcommand '{commandLine.Arguments[1]}'.");
+        }
+
+        var operationLocation = GetSingleArgument(commandLine, 2, "operation location");
+
+        await client.WaitForOperationAsync(BuildOperationLocation(options.Endpoint, operationLocation), options.PollInterval, options.Timeout, error, cancellationToken);
+        await OutputFormatter.WriteOperationResultAsync(output, BuildOperationLocation(options.Endpoint, operationLocation), completed: true, options.OutputFormat, cancellationToken);
+
+        return ExitCodes.Success;
+    }
+
+    private static async Task<int> ListCertificatesAsync(
+        CommandLine commandLine,
+        int commandOffset,
+        CliOptions options,
+        AcmebotApiClient client,
+        TextWriter output,
+        CancellationToken cancellationToken)
+    {
+        EnsureNoExtraArguments(commandLine, commandOffset);
+
+        var certificates = await client.GetCertificatesAsync(cancellationToken);
+
+        await OutputFormatter.WriteCertificatesAsync(output, certificates, options.OutputFormat, cancellationToken);
+
+        return ExitCodes.Success;
+    }
+
+    private static async Task<int> ListDnsZonesAsync(
+        CommandLine commandLine,
+        int commandOffset,
+        CliOptions options,
+        AcmebotApiClient client,
+        TextWriter output,
+        CancellationToken cancellationToken)
+    {
+        EnsureNoExtraArguments(commandLine, commandOffset);
+
+        var dnsZones = await client.GetDnsZonesAsync(cancellationToken);
+
+        await OutputFormatter.WriteDnsZonesAsync(output, dnsZones, options.OutputFormat, cancellationToken);
+
+        return ExitCodes.Success;
+    }
+
+    private static async Task<int> IssueCertificateAsync(
+        CommandLine commandLine,
+        int commandOffset,
+        CliOptions options,
+        AcmebotApiClient client,
+        TextWriter output,
+        TextWriter error,
+        CancellationToken cancellationToken)
+    {
+        EnsureNoExtraArguments(commandLine, commandOffset);
+
+        var policy = CertificatePolicyFactory.Create(commandLine);
+        var operationLocation = await client.IssueCertificateAsync(policy, cancellationToken);
+        var wait = ShouldWait(commandLine);
+
+        if (wait)
+        {
+            await client.WaitForOperationAsync(operationLocation, options.PollInterval, options.Timeout, error, cancellationToken);
+        }
+
+        await OutputFormatter.WriteOperationResultAsync(output, operationLocation, wait, options.OutputFormat, cancellationToken);
+
+        return ExitCodes.Success;
+    }
+
+    private static async Task<int> RenewCertificateAsync(
+        CommandLine commandLine,
+        int commandOffset,
+        CliOptions options,
+        AcmebotApiClient client,
+        TextWriter output,
+        TextWriter error,
+        CancellationToken cancellationToken)
+    {
+        var certificateName = GetSingleArgument(commandLine, commandOffset, "certificate name");
+        var operationLocation = await client.RenewCertificateAsync(certificateName, cancellationToken);
+        var wait = ShouldWait(commandLine);
+
+        if (wait)
+        {
+            await client.WaitForOperationAsync(operationLocation, options.PollInterval, options.Timeout, error, cancellationToken);
+        }
+
+        await OutputFormatter.WriteOperationResultAsync(output, operationLocation, wait, options.OutputFormat, cancellationToken);
+
+        return ExitCodes.Success;
+    }
+
+    private static async Task<int> RevokeCertificateAsync(
+        CommandLine commandLine,
+        int commandOffset,
+        CliOptions options,
+        AcmebotApiClient client,
+        TextWriter output,
+        CancellationToken cancellationToken)
+    {
+        var certificateName = GetSingleArgument(commandLine, commandOffset, "certificate name");
+
+        await client.RevokeCertificateAsync(certificateName, cancellationToken);
+        await OutputFormatter.WriteCertificateCommandResultAsync(output, certificateName, "revoked", options.OutputFormat, cancellationToken);
+
+        return ExitCodes.Success;
+    }
+
+    private static bool ShouldWait(CommandLine commandLine)
+    {
+        return !commandLine.GetFlag("no-wait");
+    }
+
+    private static string GetSingleArgument(CommandLine commandLine, int commandOffset, string name)
+    {
+        var remaining = commandLine.Arguments.Skip(commandOffset).ToArray();
+
+        return remaining.Length switch
+        {
+            0 => throw new CliException($"Missing {name}."),
+            1 => remaining[0],
+            _ => throw new CliException($"Unexpected argument '{remaining[1]}'.")
+        };
+    }
+
+    private static void EnsureNoExtraArguments(CommandLine commandLine, int commandOffset)
+    {
+        if (commandLine.Arguments.Count > commandOffset)
+        {
+            throw new CliException($"Unexpected argument '{commandLine.Arguments[commandOffset]}'.");
+        }
+    }
+
+    private static void ValidateKnownOptions(CommandLine commandLine)
+    {
+        var unknownOptions = commandLine.OptionNames
+            .Where(option => !CliOptionNames.KnownOptions.Contains(option))
+            .ToArray();
+
+        if (unknownOptions.Length > 0)
+        {
+            throw new CliException($"Unknown option '--{unknownOptions[0]}'.");
+        }
+    }
+
+    private static Uri BuildOperationLocation(Uri endpoint, string operationLocation)
+    {
+        if (Uri.TryCreate(operationLocation, UriKind.Absolute, out var absoluteUri))
+        {
+            return absoluteUri;
+        }
+
+        if (operationLocation.StartsWith("/", StringComparison.Ordinal))
+        {
+            return new Uri(new Uri(endpoint.GetLeftPart(UriPartial.Authority)), operationLocation.TrimStart('/'));
+        }
+
+        if (!operationLocation.Contains('/', StringComparison.Ordinal))
+        {
+            return new Uri(endpoint, $"api/operations/{Uri.EscapeDataString(operationLocation)}");
+        }
+
+        return new Uri(endpoint, operationLocation);
+    }
+}

--- a/src/Acmebot.Cli/CliException.cs
+++ b/src/Acmebot.Cli/CliException.cs
@@ -1,0 +1,3 @@
+﻿namespace Acmebot.Cli;
+
+internal sealed class CliException(string message) : Exception(message);

--- a/src/Acmebot.Cli/CliOptionNames.cs
+++ b/src/Acmebot.Cli/CliOptionNames.cs
@@ -1,0 +1,35 @@
+﻿namespace Acmebot.Cli;
+
+internal static class CliOptionNames
+{
+    public static readonly HashSet<string> OptionsWithValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "endpoint",
+        "audience",
+        "tenant-id",
+        "client-id",
+        "client-secret",
+        "client-certificate-path",
+        "client-certificate-password",
+        "managed-identity-client-id",
+        "format",
+        "poll-interval",
+        "timeout",
+        "name",
+        "dns-name",
+        "dns-provider",
+        "key-type",
+        "key-size",
+        "key-curve",
+        "dns-alias",
+        "tag"
+    };
+
+    public static readonly HashSet<string> KnownOptions = new(OptionsWithValues, StringComparer.OrdinalIgnoreCase)
+    {
+        "json",
+        "reuse-key",
+        "no-wait",
+        "help"
+    };
+}

--- a/src/Acmebot.Cli/CliOptions.cs
+++ b/src/Acmebot.Cli/CliOptions.cs
@@ -1,0 +1,110 @@
+﻿using System.Globalization;
+
+namespace Acmebot.Cli;
+
+internal sealed record CliOptions(
+    Uri Endpoint,
+    string[] TokenScopes,
+    CredentialOptions CredentialOptions,
+    OutputFormat OutputFormat,
+    TimeSpan PollInterval,
+    TimeSpan Timeout)
+{
+    public static CliOptions Create(CommandLine commandLine)
+    {
+        var endpointValue = GetOptionOrEnvironment(commandLine, "endpoint", "ACMEBOT_ENDPOINT");
+
+        if (string.IsNullOrWhiteSpace(endpointValue))
+        {
+            throw new CliException("Missing required option '--endpoint'. You can also set ACMEBOT_ENDPOINT.");
+        }
+
+        if (!Uri.TryCreate(endpointValue, UriKind.Absolute, out var endpoint))
+        {
+            throw new CliException("Option '--endpoint' must be an absolute URL.");
+        }
+
+        var credentialOptions = CredentialOptions.Create(commandLine);
+        var tokenScopes = GetTokenScopes(commandLine, endpoint);
+        var outputFormat = GetOutputFormat(commandLine);
+
+        return new CliOptions(
+            NormalizeEndpoint(endpoint),
+            tokenScopes,
+            credentialOptions,
+            outputFormat,
+            GetDuration(commandLine, "poll-interval", TimeSpan.FromSeconds(5)),
+            GetDuration(commandLine, "timeout", TimeSpan.FromMinutes(30)));
+    }
+
+    private static Uri NormalizeEndpoint(Uri endpoint)
+    {
+        return new Uri(endpoint.AbsoluteUri.TrimEnd('/') + "/");
+    }
+
+    private static string[] GetTokenScopes(CommandLine commandLine, Uri endpoint)
+    {
+        var audience = commandLine.GetOption("audience")
+            ?? Environment.GetEnvironmentVariable("ACMEBOT_AUDIENCE")
+            ?? endpoint.GetLeftPart(UriPartial.Authority);
+
+        if (audience.EndsWith("/.default", StringComparison.Ordinal) || audience.EndsWith("/user_impersonation", StringComparison.Ordinal))
+        {
+            throw new CliException("Option '--audience' must be an application ID URI or endpoint origin, not a token scope.");
+        }
+
+        return [ToDefaultScope(audience)];
+    }
+
+    private static string ToDefaultScope(string audience)
+    {
+        return audience.TrimEnd('/') + "/.default";
+    }
+
+    private static OutputFormat GetOutputFormat(CommandLine commandLine)
+    {
+        if (commandLine.GetFlag("json"))
+        {
+            return OutputFormat.Json;
+        }
+
+        var value = commandLine.GetOption("format")
+            ?? Environment.GetEnvironmentVariable("ACMEBOT_FORMAT")
+            ?? "table";
+
+        return value.ToLowerInvariant() switch
+        {
+            "json" => OutputFormat.Json,
+            "table" => OutputFormat.Table,
+            _ => throw new CliException("Option '--format' must be 'table' or 'json'.")
+        };
+    }
+
+    private static TimeSpan GetDuration(CommandLine commandLine, string optionName, TimeSpan defaultValue)
+    {
+        var value = commandLine.GetOption(optionName);
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return defaultValue;
+        }
+
+        if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var seconds) || seconds <= 0)
+        {
+            throw new CliException($"Option '--{optionName}' must be a positive number of seconds.");
+        }
+
+        return TimeSpan.FromSeconds(seconds);
+    }
+
+    private static string? GetOptionOrEnvironment(CommandLine commandLine, string optionName, string environmentName)
+    {
+        return commandLine.GetOption(optionName) ?? Environment.GetEnvironmentVariable(environmentName);
+    }
+}
+
+internal enum OutputFormat
+{
+    Table,
+    Json
+}

--- a/src/Acmebot.Cli/CommandLine.cs
+++ b/src/Acmebot.Cli/CommandLine.cs
@@ -1,0 +1,127 @@
+﻿namespace Acmebot.Cli;
+
+internal sealed class CommandLine
+{
+    private readonly Dictionary<string, List<string?>> _options;
+
+    private CommandLine(IReadOnlyList<string> arguments, Dictionary<string, List<string?>> options)
+    {
+        Arguments = arguments;
+        _options = options;
+    }
+
+    public IReadOnlyList<string> Arguments { get; }
+
+    public IEnumerable<string> OptionNames => _options.Keys;
+
+    public static CommandLine Parse(string[] args)
+    {
+        var arguments = new List<string>();
+        var options = new Dictionary<string, List<string?>>(StringComparer.OrdinalIgnoreCase);
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var arg = args[index];
+
+            if (arg == "--")
+            {
+                arguments.AddRange(args.Skip(index + 1));
+                break;
+            }
+
+            if (arg == "-h")
+            {
+                AddOption(options, "help", null);
+                continue;
+            }
+
+            if (!arg.StartsWith("--", StringComparison.Ordinal))
+            {
+                arguments.Add(arg);
+                continue;
+            }
+
+            var optionText = arg[2..];
+            var separatorIndex = optionText.IndexOf('=');
+            string name;
+            string? value;
+
+            if (separatorIndex >= 0)
+            {
+                name = optionText[..separatorIndex];
+                value = optionText[(separatorIndex + 1)..];
+            }
+            else
+            {
+                name = optionText;
+                value = null;
+
+                if (CliOptionNames.OptionsWithValues.Contains(name))
+                {
+                    if (index + 1 >= args.Length || args[index + 1].StartsWith("-", StringComparison.Ordinal))
+                    {
+                        throw new CliException($"Option '--{name}' requires a value.");
+                    }
+
+                    value = args[++index];
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new CliException("Option name cannot be empty.");
+            }
+
+            AddOption(options, name, value);
+        }
+
+        return new CommandLine(arguments, options);
+    }
+
+    public bool HasOption(string name) => _options.ContainsKey(name);
+
+    public string? GetOption(string name)
+    {
+        return _options.TryGetValue(name, out var values) ? values.LastOrDefault() : null;
+    }
+
+    public IReadOnlyList<string> GetOptions(string name)
+    {
+        return _options.TryGetValue(name, out var values)
+            ? values.Where(value => value is not null).Cast<string>().ToArray()
+            : [];
+    }
+
+    public bool GetFlag(string name)
+    {
+        if (!_options.TryGetValue(name, out var values))
+        {
+            return false;
+        }
+
+        var value = values.LastOrDefault();
+
+        if (value is null)
+        {
+            return true;
+        }
+
+        if (bool.TryParse(value, out var result))
+        {
+            return result;
+        }
+
+        throw new CliException($"Option '--{name}' expects true or false when a value is provided.");
+    }
+
+    private static void AddOption(Dictionary<string, List<string?>> options, string name, string? value)
+    {
+        if (!options.TryGetValue(name, out var values))
+        {
+            values = [];
+            options.Add(name, values);
+        }
+
+        values.Add(value);
+    }
+}

--- a/src/Acmebot.Cli/CredentialOptions.cs
+++ b/src/Acmebot.Cli/CredentialOptions.cs
@@ -1,0 +1,94 @@
+﻿using Azure.Core;
+using Azure.Identity;
+
+namespace Acmebot.Cli;
+
+internal sealed record CredentialOptions(
+    string? TenantId,
+    string? ClientId,
+    string? ClientSecret,
+    string? ClientCertificatePath,
+    string? ClientCertificatePassword,
+    string? ManagedIdentityClientId)
+{
+    public static CredentialOptions Create(CommandLine commandLine)
+    {
+        var tenantId = commandLine.GetOption("tenant-id") ?? Environment.GetEnvironmentVariable("AZURE_TENANT_ID");
+        var clientId = commandLine.GetOption("client-id") ?? Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
+        var clientSecret = commandLine.GetOption("client-secret");
+        var clientCertificatePath = commandLine.GetOption("client-certificate-path");
+        var clientCertificatePassword = commandLine.GetOption("client-certificate-password");
+
+        if (!string.IsNullOrWhiteSpace(clientSecret) && !string.IsNullOrWhiteSpace(clientCertificatePath))
+        {
+            throw new CliException("Specify either '--client-secret' or '--client-certificate-path', not both.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(clientCertificatePassword) && string.IsNullOrWhiteSpace(clientCertificatePath))
+        {
+            throw new CliException("Option '--client-certificate-password' requires '--client-certificate-path'.");
+        }
+
+        return new CredentialOptions(
+            tenantId,
+            clientId,
+            clientSecret,
+            clientCertificatePath,
+            clientCertificatePassword,
+            commandLine.GetOption("managed-identity-client-id") ?? Environment.GetEnvironmentVariable("ACMEBOT_MANAGED_IDENTITY_CLIENT_ID"));
+    }
+
+    public TokenCredential CreateCredential()
+    {
+        if (!string.IsNullOrWhiteSpace(ClientSecret))
+        {
+            return new ClientSecretCredential(RequireTenantId(), RequireClientId(), ClientSecret);
+        }
+
+        if (!string.IsNullOrWhiteSpace(ClientCertificatePath))
+        {
+            if (!string.IsNullOrEmpty(ClientCertificatePassword))
+            {
+                var certificate = System.Security.Cryptography.X509Certificates.X509CertificateLoader.LoadPkcs12FromFile(ClientCertificatePath, ClientCertificatePassword);
+
+                return new ClientCertificateCredential(RequireTenantId(), RequireClientId(), certificate);
+            }
+
+            return new ClientCertificateCredential(RequireTenantId(), RequireClientId(), ClientCertificatePath);
+        }
+
+        var options = new DefaultAzureCredentialOptions();
+
+        if (!string.IsNullOrWhiteSpace(TenantId))
+        {
+            options.TenantId = TenantId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(ManagedIdentityClientId))
+        {
+            options.ManagedIdentityClientId = ManagedIdentityClientId;
+        }
+
+        return new DefaultAzureCredential(options);
+    }
+
+    private string RequireTenantId()
+    {
+        if (string.IsNullOrWhiteSpace(TenantId))
+        {
+            throw new CliException("Options '--tenant-id' and '--client-id' are required for explicit service principal authentication.");
+        }
+
+        return TenantId;
+    }
+
+    private string RequireClientId()
+    {
+        if (string.IsNullOrWhiteSpace(ClientId))
+        {
+            throw new CliException("Options '--tenant-id' and '--client-id' are required for explicit service principal authentication.");
+        }
+
+        return ClientId;
+    }
+}

--- a/src/Acmebot.Cli/CredentialOptions.cs
+++ b/src/Acmebot.Cli/CredentialOptions.cs
@@ -17,16 +17,35 @@ internal sealed record CredentialOptions(
         var clientId = commandLine.GetOption("client-id") ?? Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
         var clientSecret = commandLine.GetOption("client-secret");
         var clientCertificatePath = commandLine.GetOption("client-certificate-path");
-        var clientCertificatePassword = commandLine.GetOption("client-certificate-password");
+        var clientCertificatePasswordOption = commandLine.GetOption("client-certificate-password");
+        var clientCertificatePassword = clientCertificatePasswordOption
+            ?? Environment.GetEnvironmentVariable("AZURE_CLIENT_CERTIFICATE_PASSWORD");
 
         if (!string.IsNullOrWhiteSpace(clientSecret) && !string.IsNullOrWhiteSpace(clientCertificatePath))
         {
             throw new CliException("Specify either '--client-secret' or '--client-certificate-path', not both.");
         }
 
-        if (!string.IsNullOrWhiteSpace(clientCertificatePassword) && string.IsNullOrWhiteSpace(clientCertificatePath))
+        if (string.IsNullOrWhiteSpace(clientSecret) && string.IsNullOrWhiteSpace(clientCertificatePath))
+        {
+            clientSecret = Environment.GetEnvironmentVariable("AZURE_CLIENT_SECRET");
+
+            if (string.IsNullOrWhiteSpace(clientSecret))
+            {
+                clientCertificatePath = Environment.GetEnvironmentVariable("AZURE_CLIENT_CERTIFICATE_PATH");
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(clientCertificatePassword) &&
+            string.IsNullOrWhiteSpace(clientCertificatePath) &&
+            (!string.IsNullOrWhiteSpace(clientCertificatePasswordOption) || string.IsNullOrWhiteSpace(clientSecret)))
         {
             throw new CliException("Option '--client-certificate-password' requires '--client-certificate-path'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(clientCertificatePath))
+        {
+            clientCertificatePassword = null;
         }
 
         return new CredentialOptions(

--- a/src/Acmebot.Cli/ExitCodes.cs
+++ b/src/Acmebot.Cli/ExitCodes.cs
@@ -1,0 +1,11 @@
+﻿namespace Acmebot.Cli;
+
+internal static class ExitCodes
+{
+    public const int Success = 0;
+    public const int Usage = 2;
+    public const int ApiError = 3;
+    public const int AuthenticationError = 4;
+    public const int NetworkError = 5;
+    public const int Canceled = 130;
+}

--- a/src/Acmebot.Cli/HelpText.cs
+++ b/src/Acmebot.Cli/HelpText.cs
@@ -1,0 +1,48 @@
+﻿namespace Acmebot.Cli;
+
+internal static class HelpText
+{
+    public static async Task WriteAsync(TextWriter writer)
+    {
+        await writer.WriteLineAsync("Acmebot CLI");
+        await writer.WriteLineAsync();
+        await writer.WriteLineAsync("Usage:");
+        await writer.WriteLineAsync("  acmebot --endpoint <url> certificate list [options]");
+        await writer.WriteLineAsync("  acmebot --endpoint <url> certificate issue --dns-name <name> [options]");
+        await writer.WriteLineAsync("  acmebot --endpoint <url> certificate renew <certificate-name> [options]");
+        await writer.WriteLineAsync("  acmebot --endpoint <url> certificate revoke <certificate-name> [options]");
+        await writer.WriteLineAsync("  acmebot --endpoint <url> dns-zone list [options]");
+        await writer.WriteLineAsync("  acmebot --endpoint <url> operation wait <operation-location> [options]");
+        await writer.WriteLineAsync();
+        await writer.WriteLineAsync("Global options:");
+        await writer.WriteLineAsync("  --endpoint <url>                       Acmebot application URL. Env: ACMEBOT_ENDPOINT");
+        await writer.WriteLineAsync("  --audience <audience>                  Microsoft Entra application ID URI. Default: endpoint origin.");
+        await writer.WriteLineAsync("  --tenant-id <id>                       Microsoft Entra tenant ID.");
+        await writer.WriteLineAsync("  --client-id <id>                       Service principal client ID.");
+        await writer.WriteLineAsync("  --client-secret <secret>               Service principal client secret.");
+        await writer.WriteLineAsync("  --client-certificate-path <path>       Service principal certificate path.");
+        await writer.WriteLineAsync("  --client-certificate-password <value>  PFX certificate password.");
+        await writer.WriteLineAsync("  --managed-identity-client-id <id>      User-assigned managed identity client ID.");
+        await writer.WriteLineAsync("  --format <table|json>                  Output format. Default: table.");
+        await writer.WriteLineAsync("  --json                                 Shortcut for --format json.");
+        await writer.WriteLineAsync("  --poll-interval <seconds>              Operation polling interval. Default: 5.");
+        await writer.WriteLineAsync("  --timeout <seconds>                    Operation wait timeout. Default: 1800.");
+        await writer.WriteLineAsync();
+        await writer.WriteLineAsync("Certificate issue options:");
+        await writer.WriteLineAsync("  --name <value>                         Key Vault certificate name.");
+        await writer.WriteLineAsync("  --dns-name <value>                     DNS name. Repeatable.");
+        await writer.WriteLineAsync("  --dns-provider <value>                 DNS provider display name.");
+        await writer.WriteLineAsync("  --key-type <RSA|EC>                    Key type. Default: RSA.");
+        await writer.WriteLineAsync("  --key-size <2048|3072|4096>            RSA key size. Default: 2048.");
+        await writer.WriteLineAsync("  --key-curve <P-256|P-384|P-521|P-256K> EC key curve. Default: P-256.");
+        await writer.WriteLineAsync("  --reuse-key                            Reuse the Key Vault certificate key.");
+        await writer.WriteLineAsync("  --dns-alias <value>                    DNS-01 validation alias.");
+        await writer.WriteLineAsync("  --tag <name=value>                     Certificate tag. Repeatable.");
+        await writer.WriteLineAsync("  --no-wait                              Return after the operation is accepted.");
+    }
+
+    public static async Task WriteUsageHintAsync(TextWriter writer)
+    {
+        await writer.WriteLineAsync("Run 'acmebot --help' for usage.");
+    }
+}

--- a/src/Acmebot.Cli/Models.cs
+++ b/src/Acmebot.Cli/Models.cs
@@ -1,0 +1,121 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Acmebot.Cli;
+
+internal sealed class CertificatePolicyItem
+{
+    [JsonPropertyName("certificateName")]
+    public string? CertificateName { get; set; }
+
+    [JsonPropertyName("dnsNames")]
+    public required string[] DnsNames { get; set; }
+
+    [JsonPropertyName("dnsProviderName")]
+    public string? DnsProviderName { get; set; }
+
+    [JsonPropertyName("keyType")]
+    public required string KeyType { get; set; }
+
+    [JsonPropertyName("keySize")]
+    public int? KeySize { get; set; }
+
+    [JsonPropertyName("keyCurveName")]
+    public string? KeyCurveName { get; set; }
+
+    [JsonPropertyName("reuseKey")]
+    public bool? ReuseKey { get; set; }
+
+    [JsonPropertyName("dnsAlias")]
+    public string? DnsAlias { get; set; }
+
+    [JsonPropertyName("tags")]
+    public IDictionary<string, string>? Tags { get; set; }
+}
+
+internal sealed class CertificateItem
+{
+    [JsonPropertyName("id")]
+    public required Uri Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonPropertyName("dnsNames")]
+    public required IReadOnlyList<string> DnsNames { get; set; }
+
+    [JsonPropertyName("dnsProviderName")]
+    public string? DnsProviderName { get; set; }
+
+    [JsonPropertyName("createdOn")]
+    public DateTimeOffset CreatedOn { get; set; }
+
+    [JsonPropertyName("expiresOn")]
+    public DateTimeOffset ExpiresOn { get; set; }
+
+    [JsonPropertyName("x509Thumbprint")]
+    public string? X509Thumbprint { get; set; }
+
+    [JsonPropertyName("keyType")]
+    public string? KeyType { get; set; }
+
+    [JsonPropertyName("keySize")]
+    public int? KeySize { get; set; }
+
+    [JsonPropertyName("keyCurveName")]
+    public string? KeyCurveName { get; set; }
+
+    [JsonPropertyName("reuseKey")]
+    public bool? ReuseKey { get; set; }
+
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+
+    [JsonPropertyName("isIssuedByAcmebot")]
+    public bool IsIssuedByAcmebot { get; set; }
+
+    [JsonPropertyName("isSameEndpoint")]
+    public bool IsSameEndpoint { get; set; }
+
+    [JsonPropertyName("acmeEndpoint")]
+    public string? AcmeEndpoint { get; set; }
+
+    [JsonPropertyName("dnsAlias")]
+    public string? DnsAlias { get; set; }
+
+    [JsonPropertyName("tags")]
+    public IReadOnlyDictionary<string, string>? Tags { get; set; }
+}
+
+internal sealed class DnsZoneItem
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+}
+
+internal sealed class DnsZoneGroup
+{
+    [JsonPropertyName("dnsProviderName")]
+    public required string DnsProviderName { get; set; }
+
+    [JsonPropertyName("dnsZones")]
+    public IReadOnlyList<DnsZoneItem>? DnsZones { get; set; }
+}
+
+internal sealed class ProblemDetails
+{
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    [JsonPropertyName("detail")]
+    public string? Detail { get; set; }
+
+    [JsonPropertyName("output")]
+    public string? Output { get; set; }
+
+    [JsonPropertyName("errors")]
+    public Dictionary<string, string[]>? Errors { get; set; }
+}
+
+internal sealed record OperationResult(string Status, Uri OperationLocation);
+
+internal sealed record CertificateCommandResult(string Status, string CertificateName);

--- a/src/Acmebot.Cli/OutputFormatter.cs
+++ b/src/Acmebot.Cli/OutputFormatter.cs
@@ -1,0 +1,133 @@
+﻿using System.Text.Json;
+
+namespace Acmebot.Cli;
+
+internal static class OutputFormatter
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    public static async Task WriteJsonAsync(TextWriter writer, object value, CancellationToken cancellationToken)
+    {
+        var json = JsonSerializer.Serialize(value, s_jsonOptions);
+
+        await writer.WriteLineAsync(json.AsMemory(), cancellationToken);
+    }
+
+    public static async Task WriteCertificatesAsync(TextWriter writer, IReadOnlyList<CertificateItem> certificates, OutputFormat format, CancellationToken cancellationToken)
+    {
+        if (format == OutputFormat.Json)
+        {
+            await WriteJsonAsync(writer, certificates, cancellationToken);
+            return;
+        }
+
+        if (certificates.Count == 0)
+        {
+            await writer.WriteLineAsync("No certificates found.");
+            return;
+        }
+
+        var rows = certificates
+            .OrderBy(certificate => certificate.ExpiresOn)
+            .Select(certificate => new[]
+            {
+                certificate.Name,
+                certificate.ExpiresOn.ToString("u"),
+                certificate.Enabled ? "enabled" : "disabled",
+                certificate.DnsProviderName ?? "",
+                string.Join(", ", certificate.DnsNames)
+            })
+            .ToArray();
+
+        await WriteTableAsync(writer, ["Name", "Expires", "State", "DNS Provider", "DNS Names"], rows);
+    }
+
+    public static async Task WriteDnsZonesAsync(TextWriter writer, IReadOnlyList<DnsZoneGroup> groups, OutputFormat format, CancellationToken cancellationToken)
+    {
+        if (format == OutputFormat.Json)
+        {
+            await WriteJsonAsync(writer, groups, cancellationToken);
+            return;
+        }
+
+        var rows = groups
+            .SelectMany(group => (group.DnsZones ?? []).Select(zone => new[] { group.DnsProviderName, zone.Name }))
+            .OrderBy(row => row[0], StringComparer.OrdinalIgnoreCase)
+            .ThenBy(row => row[1], StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (rows.Length == 0)
+        {
+            await writer.WriteLineAsync("No DNS zones found.");
+            return;
+        }
+
+        await WriteTableAsync(writer, ["DNS Provider", "Zone"], rows);
+    }
+
+    public static async Task WriteOperationResultAsync(TextWriter writer, Uri location, bool completed, OutputFormat format, CancellationToken cancellationToken)
+    {
+        var result = new OperationResult(completed ? "completed" : "accepted", location);
+
+        if (format == OutputFormat.Json)
+        {
+            await WriteJsonAsync(writer, result, cancellationToken);
+            return;
+        }
+
+        await writer.WriteLineAsync(completed ? "Operation completed." : "Operation accepted.");
+        await writer.WriteLineAsync($"Location: {location}");
+    }
+
+    public static async Task WriteCertificateCommandResultAsync(TextWriter writer, string certificateName, string status, OutputFormat format, CancellationToken cancellationToken)
+    {
+        var result = new CertificateCommandResult(status, certificateName);
+
+        if (format == OutputFormat.Json)
+        {
+            await WriteJsonAsync(writer, result, cancellationToken);
+            return;
+        }
+
+        await writer.WriteLineAsync($"Certificate '{certificateName}' {status}.");
+    }
+
+    private static async Task WriteTableAsync(TextWriter writer, string[] headers, IReadOnlyList<string[]> rows)
+    {
+        var widths = headers.Select(header => header.Length).ToArray();
+
+        foreach (var row in rows)
+        {
+            for (var index = 0; index < row.Length; index++)
+            {
+                widths[index] = Math.Max(widths[index], row[index].Length);
+            }
+        }
+
+        await WriteRowAsync(writer, headers, widths);
+        await WriteRowAsync(writer, widths.Select(width => new string('-', width)).ToArray(), widths);
+
+        foreach (var row in rows)
+        {
+            await WriteRowAsync(writer, row, widths);
+        }
+    }
+
+    private static async Task WriteRowAsync(TextWriter writer, string[] columns, int[] widths)
+    {
+        for (var index = 0; index < columns.Length; index++)
+        {
+            if (index > 0)
+            {
+                await writer.WriteAsync("  ");
+            }
+
+            await writer.WriteAsync(columns[index].PadRight(widths[index]));
+        }
+
+        await writer.WriteLineAsync();
+    }
+}

--- a/src/Acmebot.Cli/Program.cs
+++ b/src/Acmebot.Cli/Program.cs
@@ -1,0 +1,11 @@
+﻿using Acmebot.Cli;
+
+using var cancellationTokenSource = new CancellationTokenSource();
+
+Console.CancelKeyPress += (_, eventArgs) =>
+{
+    eventArgs.Cancel = true;
+    cancellationTokenSource.Cancel();
+};
+
+return await CliApplication.RunAsync(args, Console.Out, Console.Error, cancellationTokenSource.Token);

--- a/src/Acmebot.Cli/Properties/AssemblyInfo.cs
+++ b/src/Acmebot.Cli/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Acmebot.Cli.Tests")]

--- a/src/Acmebot.Cli/README.md
+++ b/src/Acmebot.Cli/README.md
@@ -1,0 +1,15 @@
+# Acmebot CLI
+
+Command-line client for Acmebot HTTP API automation.
+
+## Usage
+
+```powershell
+acmebot --endpoint https://<function-app>.azurewebsites.net certificate list --json
+acmebot --endpoint https://<function-app>.azurewebsites.net dns-zone list
+acmebot --endpoint https://<function-app>.azurewebsites.net certificate issue --dns-name "*.example.com" --dns-provider "Azure DNS"
+acmebot --endpoint https://<function-app>.azurewebsites.net certificate renew wildcard-example-com
+acmebot --endpoint https://<function-app>.azurewebsites.net certificate revoke wildcard-example-com
+```
+
+Use `--audience <application-id-uri>` when App Service Authentication protects the API with a custom Microsoft Entra application ID URI. The value should be an application ID URI such as `api://<application-client-id>`, not a token scope.

--- a/tests/Acmebot.Cli.Tests/Acmebot.Cli.Tests.csproj
+++ b/tests/Acmebot.Cli.Tests/Acmebot.Cli.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Acmebot.Cli\Acmebot.Cli.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Acmebot.Cli.Tests/AcmebotApiClientTests.cs
+++ b/tests/Acmebot.Cli.Tests/AcmebotApiClientTests.cs
@@ -88,6 +88,101 @@ public sealed class AcmebotApiClientTests
         Assert.Equal("example.com", document.RootElement.GetProperty("dnsNames")[0].GetString());
     }
 
+    [Fact]
+    public async Task WaitForOperationAsync_WithImmediateOk_DoesNotWaitBeforeFirstRequest()
+    {
+        using var handler = new RecordingHandler();
+        using var httpClient = new HttpClient(handler);
+        using var client = CreateClient(httpClient);
+
+        handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        await client.WaitForOperationAsync(
+            new Uri("https://acmebot.example/api/operations/abc"),
+            TimeSpan.FromDays(1),
+            TimeSpan.FromMilliseconds(100),
+            TextWriter.Null,
+            TestContext.Current.CancellationToken);
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Get, request.Method);
+        Assert.Equal(new Uri("https://acmebot.example/api/operations/abc"), request.RequestUri);
+    }
+
+    [Fact]
+    public async Task WaitForOperationAsync_WithAcceptedThenOk_PollsUntilComplete()
+    {
+        using var handler = new RecordingHandler();
+        using var httpClient = new HttpClient(handler);
+        using var client = CreateClient(httpClient);
+        using var progress = new StringWriter();
+
+        handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.Accepted));
+        handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        await client.WaitForOperationAsync(
+            new Uri("https://acmebot.example/api/operations/abc"),
+            TimeSpan.FromMilliseconds(1),
+            TimeSpan.FromSeconds(5),
+            progress,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Contains("Operation is still running...", progress.ToString());
+    }
+
+    [Fact]
+    public async Task WaitForOperationAsync_WithFailureDuringPolling_ThrowsApiException()
+    {
+        using var handler = new RecordingHandler();
+        using var httpClient = new HttpClient(handler);
+        using var client = CreateClient(httpClient);
+
+        handler.Enqueue(_ => CreateJsonResponse(HttpStatusCode.BadRequest, new
+        {
+            title = "Invalid operation"
+        }));
+
+        var ex = await Assert.ThrowsAsync<AcmebotApiException>(() => client.WaitForOperationAsync(
+            new Uri("https://acmebot.example/api/operations/abc"),
+            TimeSpan.FromMilliseconds(1),
+            TimeSpan.FromSeconds(5),
+            TextWriter.Null,
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        Assert.Equal("Invalid operation", ex.Message);
+    }
+
+    [Fact]
+    public async Task WaitForOperationAsync_WithTimeout_ThrowsTimeoutException()
+    {
+        using var handler = new RecordingHandler();
+        using var httpClient = new HttpClient(handler);
+        using var client = CreateClient(httpClient);
+
+        handler.Enqueue(_ => new HttpResponseMessage(HttpStatusCode.Accepted));
+
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() => client.WaitForOperationAsync(
+            new Uri("https://acmebot.example/api/operations/abc"),
+            TimeSpan.FromDays(1),
+            TimeSpan.FromMilliseconds(10),
+            TextWriter.Null,
+            TestContext.Current.CancellationToken));
+
+        Assert.Contains("Operation did not complete within", ex.Message);
+        Assert.Single(handler.Requests);
+    }
+
+    private static AcmebotApiClient CreateClient(HttpClient httpClient)
+    {
+        return new AcmebotApiClient(
+            httpClient,
+            new Uri("https://acmebot.example/"),
+            new TestCredential("token"),
+            ["api://acmebot/.default"]);
+    }
+
     private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, object content)
     {
         return new HttpResponseMessage(statusCode)

--- a/tests/Acmebot.Cli.Tests/AcmebotApiClientTests.cs
+++ b/tests/Acmebot.Cli.Tests/AcmebotApiClientTests.cs
@@ -1,0 +1,144 @@
+﻿using System.Net;
+using System.Text;
+using System.Text.Json;
+
+using Azure.Core;
+
+using Xunit;
+
+namespace Acmebot.Cli.Tests;
+
+public sealed class AcmebotApiClientTests
+{
+    [Fact]
+    public async Task GetCertificatesAsync_SendsBearerTokenAndDeserializesResponse()
+    {
+        using var handler = new RecordingHandler();
+        using var httpClient = new HttpClient(handler);
+        using var client = new AcmebotApiClient(
+            httpClient,
+            new Uri("https://acmebot.example/"),
+            new TestCredential("token"),
+            ["api://acmebot/.default"]);
+
+        handler.Enqueue(_ => CreateJsonResponse(HttpStatusCode.OK, new[]
+        {
+            new
+            {
+                id = "https://vault.example/certificates/example",
+                name = "example",
+                dnsNames = new[] { "example.com" },
+                createdOn = "2026-06-01T00:00:00+00:00",
+                expiresOn = "2026-09-01T00:00:00+00:00",
+                enabled = true,
+                isIssuedByAcmebot = true,
+                isSameEndpoint = true
+            }
+        }));
+
+        var certificates = await client.GetCertificatesAsync(TestContext.Current.CancellationToken);
+
+        var certificate = Assert.Single(certificates);
+        Assert.Equal("example", certificate.Name);
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Get, request.Method);
+        Assert.Equal(new Uri("https://acmebot.example/api/certificates"), request.RequestUri);
+        Assert.Equal("Bearer", request.AuthorizationScheme);
+        Assert.Equal("token", request.AuthorizationParameter);
+        Assert.Contains("application/json", request.Accept);
+    }
+
+    [Fact]
+    public async Task IssueCertificateAsync_PostsPolicyAndReturnsOperationLocation()
+    {
+        using var handler = new RecordingHandler();
+        using var httpClient = new HttpClient(handler);
+        using var client = new AcmebotApiClient(
+            httpClient,
+            new Uri("https://acmebot.example/"),
+            new TestCredential("token"),
+            ["api://acmebot/.default"]);
+
+        handler.Enqueue(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.Accepted);
+            response.Headers.Location = new Uri("/api/operations/abc", UriKind.Relative);
+
+            return response;
+        });
+
+        var location = await client.IssueCertificateAsync(new CertificatePolicyItem
+        {
+            CertificateName = "example",
+            DnsNames = ["example.com"],
+            KeyType = "RSA",
+            KeySize = 2048
+        }, TestContext.Current.CancellationToken);
+
+        Assert.Equal(new Uri("https://acmebot.example/api/operations/abc"), location);
+
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal(new Uri("https://acmebot.example/api/certificates"), request.RequestUri);
+
+        Assert.NotNull(request.Content);
+        using var document = JsonDocument.Parse(request.Content);
+        Assert.Equal("example", document.RootElement.GetProperty("certificateName").GetString());
+        Assert.Equal("example.com", document.RootElement.GetProperty("dnsNames")[0].GetString());
+    }
+
+    private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, object content)
+    {
+        return new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class TestCredential(string token) : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            return new AccessToken(token, DateTimeOffset.UtcNow.AddHours(1));
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            return new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
+        }
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> _responses = [];
+
+        public List<RecordedRequest> Requests { get; } = [];
+
+        public void Enqueue(Func<HttpRequestMessage, HttpResponseMessage> response)
+        {
+            _responses.Enqueue(response);
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(new RecordedRequest(
+                request.Method,
+                request.RequestUri,
+                request.Headers.Authorization?.Scheme,
+                request.Headers.Authorization?.Parameter,
+                request.Headers.Accept.Select(value => value.MediaType ?? "").ToArray(),
+                request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken)));
+
+            return _responses.Dequeue()(request);
+        }
+    }
+
+    private sealed record RecordedRequest(
+        HttpMethod Method,
+        Uri? RequestUri,
+        string? AuthorizationScheme,
+        string? AuthorizationParameter,
+        IReadOnlyList<string> Accept,
+        string? Content);
+}

--- a/tests/Acmebot.Cli.Tests/AssemblyInfo.cs
+++ b/tests/Acmebot.Cli.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Acmebot.Cli.Tests/AssemblyInfo.cs
+++ b/tests/Acmebot.Cli.Tests/AssemblyInfo.cs
@@ -1,3 +1,3 @@
-using Xunit;
+﻿using Xunit;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Acmebot.Cli.Tests/CertificatePolicyTests.cs
+++ b/tests/Acmebot.Cli.Tests/CertificatePolicyTests.cs
@@ -1,0 +1,79 @@
+﻿using Xunit;
+
+namespace Acmebot.Cli.Tests;
+
+public sealed class CertificatePolicyTests
+{
+    [Fact]
+    public void Create_WithRsaDefaults_CreatesPolicy()
+    {
+        var policy = CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--dns-name",
+            " example.com ",
+            "--dns-name",
+            "EXAMPLE.com",
+            "--tag",
+            "owner=platform"
+        ]));
+
+        Assert.Equal(["example.com"], policy.DnsNames);
+        Assert.Equal("RSA", policy.KeyType);
+        Assert.Equal(2048, policy.KeySize);
+        Assert.Null(policy.KeyCurveName);
+        Assert.NotNull(policy.Tags);
+        Assert.Equal("platform", policy.Tags["owner"]);
+    }
+
+    [Fact]
+    public void Create_WithEcDefaultsToP256()
+    {
+        var policy = CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--dns-name",
+            "example.com",
+            "--key-type",
+            "EC"
+        ]));
+
+        Assert.Equal("EC", policy.KeyType);
+        Assert.Null(policy.KeySize);
+        Assert.Equal("P-256", policy.KeyCurveName);
+    }
+
+    [Fact]
+    public void Create_WithInvalidCertificateName_Throws()
+    {
+        var ex = Assert.Throws<CliException>(() => CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--name",
+            "bad_name",
+            "--dns-name",
+            "example.com"
+        ])));
+
+        Assert.Equal("Option '--name' must contain only letters, numbers, and hyphens.", ex.Message);
+    }
+
+    [Fact]
+    public void Create_WithReservedTag_Throws()
+    {
+        var ex = Assert.Throws<CliException>(() => CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--dns-name",
+            "example.com",
+            "--tag",
+            "Acmebot=true"
+        ])));
+
+        Assert.Equal("The 'Acmebot' tag is reserved for internal metadata.", ex.Message);
+    }
+}

--- a/tests/Acmebot.Cli.Tests/CertificatePolicyTests.cs
+++ b/tests/Acmebot.Cli.Tests/CertificatePolicyTests.cs
@@ -46,6 +46,26 @@ public sealed class CertificatePolicyTests
     }
 
     [Fact]
+    public void Create_WithLowercaseEcCurve_NormalizesCurveName()
+    {
+        var policy = CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--dns-name",
+            "example.com",
+            "--key-type",
+            "ec",
+            "--key-curve",
+            "p-256k"
+        ]));
+
+        Assert.Equal("EC", policy.KeyType);
+        Assert.Null(policy.KeySize);
+        Assert.Equal("P-256K", policy.KeyCurveName);
+    }
+
+    [Fact]
     public void Create_WithInvalidCertificateName_Throws()
     {
         var ex = Assert.Throws<CliException>(() => CertificatePolicyFactory.Create(CommandLine.Parse(

--- a/tests/Acmebot.Cli.Tests/CliApplicationTests.cs
+++ b/tests/Acmebot.Cli.Tests/CliApplicationTests.cs
@@ -1,0 +1,22 @@
+﻿using Xunit;
+
+namespace Acmebot.Cli.Tests;
+
+public sealed class CliApplicationTests
+{
+    [Fact]
+    public async Task RunAsync_WithRemovedScopeOption_ReturnsUsage()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var exitCode = await CliApplication.RunAsync(
+            ["--scope", "api://acmebot/user_impersonation", "--endpoint", "https://acmebot.example", "certificate", "list"],
+            output,
+            error,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(ExitCodes.Usage, exitCode);
+        Assert.Contains("Unknown option '--scope'.", error.ToString());
+    }
+}

--- a/tests/Acmebot.Cli.Tests/CliOptionsTests.cs
+++ b/tests/Acmebot.Cli.Tests/CliOptionsTests.cs
@@ -1,0 +1,63 @@
+﻿using Xunit;
+
+namespace Acmebot.Cli.Tests;
+
+public sealed class CliOptionsTests
+{
+    [Fact]
+    public void Create_WithEndpoint_UsesEndpointOriginAsDefaultAudience()
+    {
+        var options = CliOptions.Create(CommandLine.Parse(["--endpoint", "https://acmebot.example/path", "certificate", "list"]));
+
+        Assert.Equal(new Uri("https://acmebot.example/path/"), options.Endpoint);
+        Assert.Equal(["https://acmebot.example/.default"], options.TokenScopes);
+    }
+
+    [Fact]
+    public void Create_WithAudience_AppendsDefaultScope()
+    {
+        var options = CliOptions.Create(CommandLine.Parse(
+        [
+            "--endpoint",
+            "https://acmebot.example",
+            "--audience",
+            "api://f3b48385-9523-470f-9f85-6ed488a1f6f2",
+            "certificate",
+            "list"
+        ]));
+
+        Assert.Equal(["api://f3b48385-9523-470f-9f85-6ed488a1f6f2/.default"], options.TokenScopes);
+    }
+
+    [Fact]
+    public void Create_WithScopeAsAudience_Throws()
+    {
+        var ex = Assert.Throws<CliException>(() => CliOptions.Create(CommandLine.Parse(
+        [
+            "--endpoint",
+            "https://acmebot.example",
+            "--audience",
+            "api://f3b48385-9523-470f-9f85-6ed488a1f6f2/user_impersonation",
+            "certificate",
+            "list"
+        ])));
+
+        Assert.Equal("Option '--audience' must be an application ID URI or endpoint origin, not a token scope.", ex.Message);
+    }
+
+    [Fact]
+    public void Create_WithCertificatePasswordButNoCertificatePath_Throws()
+    {
+        var ex = Assert.Throws<CliException>(() => CliOptions.Create(CommandLine.Parse(
+        [
+            "--endpoint",
+            "https://acmebot.example",
+            "--client-certificate-password",
+            "secret",
+            "certificate",
+            "list"
+        ])));
+
+        Assert.Equal("Option '--client-certificate-password' requires '--client-certificate-path'.", ex.Message);
+    }
+}

--- a/tests/Acmebot.Cli.Tests/CliOptionsTests.cs
+++ b/tests/Acmebot.Cli.Tests/CliOptionsTests.cs
@@ -48,6 +48,13 @@ public sealed class CliOptionsTests
     [Fact]
     public void Create_WithCertificatePasswordButNoCertificatePath_Throws()
     {
+        using var environment = EnvironmentVariableScope.Set(
+        [
+            ("AZURE_CLIENT_SECRET", null),
+            ("AZURE_CLIENT_CERTIFICATE_PATH", null),
+            ("AZURE_CLIENT_CERTIFICATE_PASSWORD", null)
+        ]);
+
         var ex = Assert.Throws<CliException>(() => CliOptions.Create(CommandLine.Parse(
         [
             "--endpoint",
@@ -59,5 +66,74 @@ public sealed class CliOptionsTests
         ])));
 
         Assert.Equal("Option '--client-certificate-password' requires '--client-certificate-path'.", ex.Message);
+    }
+
+    [Fact]
+    public void Create_WithAzureIdentityClientSecretEnvironmentVariables_UsesClientSecret()
+    {
+        using var environment = EnvironmentVariableScope.Set(
+        [
+            ("AZURE_TENANT_ID", "tenant"),
+            ("AZURE_CLIENT_ID", "client"),
+            ("AZURE_CLIENT_SECRET", "secret"),
+            ("AZURE_CLIENT_CERTIFICATE_PATH", null),
+            ("AZURE_CLIENT_CERTIFICATE_PASSWORD", "unused-password")
+        ]);
+
+        var options = CliOptions.Create(CommandLine.Parse(["--endpoint", "https://acmebot.example", "certificate", "list"]));
+
+        Assert.Equal("tenant", options.CredentialOptions.TenantId);
+        Assert.Equal("client", options.CredentialOptions.ClientId);
+        Assert.Equal("secret", options.CredentialOptions.ClientSecret);
+        Assert.Null(options.CredentialOptions.ClientCertificatePath);
+        Assert.Null(options.CredentialOptions.ClientCertificatePassword);
+    }
+
+    [Fact]
+    public void Create_WithAzureIdentityCertificateEnvironmentVariables_UsesClientCertificate()
+    {
+        using var environment = EnvironmentVariableScope.Set(
+        [
+            ("AZURE_TENANT_ID", "tenant"),
+            ("AZURE_CLIENT_ID", "client"),
+            ("AZURE_CLIENT_SECRET", null),
+            ("AZURE_CLIENT_CERTIFICATE_PATH", "certificate.pfx"),
+            ("AZURE_CLIENT_CERTIFICATE_PASSWORD", "password")
+        ]);
+
+        var options = CliOptions.Create(CommandLine.Parse(["--endpoint", "https://acmebot.example", "certificate", "list"]));
+
+        Assert.Equal("tenant", options.CredentialOptions.TenantId);
+        Assert.Equal("client", options.CredentialOptions.ClientId);
+        Assert.Null(options.CredentialOptions.ClientSecret);
+        Assert.Equal("certificate.pfx", options.CredentialOptions.ClientCertificatePath);
+        Assert.Equal("password", options.CredentialOptions.ClientCertificatePassword);
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly Dictionary<string, string?> _previousValues = [];
+
+        private EnvironmentVariableScope(IReadOnlyList<(string Name, string? Value)> variables)
+        {
+            foreach (var (name, value) in variables)
+            {
+                _previousValues[name] = Environment.GetEnvironmentVariable(name);
+                Environment.SetEnvironmentVariable(name, value);
+            }
+        }
+
+        public static EnvironmentVariableScope Set(IReadOnlyList<(string Name, string? Value)> variables)
+        {
+            return new EnvironmentVariableScope(variables);
+        }
+
+        public void Dispose()
+        {
+            foreach (var (name, value) in _previousValues)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+        }
     }
 }

--- a/tests/Acmebot.Cli.Tests/CommandLineTests.cs
+++ b/tests/Acmebot.Cli.Tests/CommandLineTests.cs
@@ -1,0 +1,35 @@
+﻿using Xunit;
+
+namespace Acmebot.Cli.Tests;
+
+public sealed class CommandLineTests
+{
+    [Fact]
+    public void Parse_WithRepeatedOptions_PreservesAllValues()
+    {
+        var commandLine = CommandLine.Parse(
+        [
+            "--endpoint",
+            "https://acmebot.example",
+            "certificate",
+            "issue",
+            "--dns-name",
+            "example.com",
+            "--dns-name=*.example.com",
+            "--no-wait"
+        ]);
+
+        Assert.Equal(["certificate", "issue"], commandLine.Arguments);
+        Assert.Equal("https://acmebot.example", commandLine.GetOption("endpoint"));
+        Assert.Equal(["example.com", "*.example.com"], commandLine.GetOptions("dns-name"));
+        Assert.True(commandLine.GetFlag("no-wait"));
+    }
+
+    [Fact]
+    public void Parse_WithMissingOptionValue_Throws()
+    {
+        var ex = Assert.Throws<CliException>(() => CommandLine.Parse(["--endpoint"]));
+
+        Assert.Equal("Option '--endpoint' requires a value.", ex.Message);
+    }
+}


### PR DESCRIPTION
Introduce a new Acmebot.Cli command-line tool and corresponding tests and documentation. Adds project files and implementation for CLI features: command parsing, credential handling (Azure.Identity / DefaultAzureCredential and service principal options), API client, models, output formatting, help text, and operation polling. Updates solution to include the new project and test project. Docs updated with a CLI reference and troubleshooting guidance for Azure CLI consent (AADSTS65001) and pre-authorizing the Azure CLI client. Includes unit test project and README for usage and examples.

Close #682 