### PR TITLE
Update Bicep version to 0.44.1 in CI and deployment templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   DOTNET_VERSION: 10.0.x
   NODE_VERSION: 24.x
-  BICEP_VERSION: 0.43.8
+  BICEP_VERSION: 0.44.1
 
 jobs:
   build:

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "13288687504558663844"
+      "version": "0.44.1.10279",
+      "templateHash": "7475699352632478067"
     }
   },
   "definitions": {
@@ -433,8 +433,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "8572463549129250633"
+              "version": "0.44.1.10279",
+              "templateHash": "17722264565150714319"
             }
           },
           "parameters": {
@@ -499,8 +499,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "8572463549129250633"
+              "version": "0.44.1.10279",
+              "templateHash": "17722264565150714319"
             }
           },
           "parameters": {

--- a/deploy/migrate/azuredeploy.json
+++ b/deploy/migrate/azuredeploy.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "18020216459641093548"
+      "version": "0.44.1.10279",
+      "templateHash": "1126300776005262348"
     }
   },
   "parameters": {
@@ -72,8 +72,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "16877996648624795941"
+              "version": "0.44.1.10279",
+              "templateHash": "1642774442966568258"
             }
           },
           "parameters": {

--- a/deploy/update/azuredeploy.json
+++ b/deploy/update/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "10678533054684801357"
+      "version": "0.44.1.10279",
+      "templateHash": "7011516736658645254"
     }
   },
   "parameters": {


### PR DESCRIPTION
This pull request updates the Bicep tooling version used across the CI workflow and all related Azure deployment templates from 0.43.8 to 0.44.1. This ensures that the infrastructure-as-code templates are built and validated with the latest Bicep features and bug fixes. All affected templates have updated version metadata and template hashes to reflect the new Bicep version.

**Bicep Version Upgrades:**

* Updated the `BICEP_VERSION` environment variable in the CI workflow configuration (`.github/workflows/ci.yml`) from `0.43.8` to `0.44.1`.

**Deployment Template Updates:**

* Updated the Bicep generator version and template hashes in `deploy/azuredeploy.json` in the root metadata and in nested module definitions to use version `0.44.1.10279`. [[1]](diffhunk://#diff-150fe65cc616fccb2fd239782a3b8f1fded84c00083e6901e2f09311e3b6288bL8-R9) [[2]](diffhunk://#diff-150fe65cc616fccb2fd239782a3b8f1fded84c00083e6901e2f09311e3b6288bL436-R437) [[3]](diffhunk://#diff-150fe65cc616fccb2fd239782a3b8f1fded84c00083e6901e2f09311e3b6288bL502-R503)
* Updated the Bicep generator version and template hashes in `deploy/migrate/azuredeploy.json` in both the root and nested module metadata. [[1]](diffhunk://#diff-2bef72043e63ef933c4e8b40013932d150edd7622b574d3c8a3eebd5ce2802a1L8-R9) [[2]](diffhunk://#diff-2bef72043e63ef933c4e8b40013932d150edd7622b574d3c8a3eebd5ce2802a1L75-R76)
* Updated the Bicep generator version and template hash in `deploy/update/azuredeploy.json` metadata.