### PR TITLE
Add AzureWebJobsStorageSettings and tests

### DIFF
--- a/Acmebot.slnx
+++ b/Acmebot.slnx
@@ -9,6 +9,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Acmebot.Acme.Tests/Acmebot.Acme.Tests.csproj" />
+    <Project Path="tests/Acmebot.App.Tests/Acmebot.App.Tests.csproj" />
     <Project Path="tests/Acmebot.Cli.Tests/Acmebot.Cli.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/Acmebot.App/Infrastructure/AzureWebJobsStorageSettings.cs
+++ b/src/Acmebot.App/Infrastructure/AzureWebJobsStorageSettings.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Acmebot.App.Infrastructure;
+
+public sealed record AzureWebJobsStorageSettings(string? ConnectionString, string? BlobServiceUri, string? AccountName, string? ClientId)
+{
+    private const string ConnectionName = "AzureWebJobsStorage";
+
+    public static AzureWebJobsStorageSettings FromConfiguration(IConfiguration configuration)
+    {
+        return new AzureWebJobsStorageSettings(
+            configuration[ConnectionName],
+            GetConnectionProperty(configuration, "blobServiceUri"),
+            GetConnectionProperty(configuration, "accountName"),
+            GetConnectionProperty(configuration, "clientId"));
+    }
+
+    public string GetBlobServiceUri()
+    {
+        if (!string.IsNullOrWhiteSpace(BlobServiceUri))
+        {
+            return BlobServiceUri;
+        }
+
+        if (!string.IsNullOrWhiteSpace(AccountName))
+        {
+            return $"https://{AccountName}.blob.core.windows.net";
+        }
+
+        throw new InvalidOperationException("AzureWebJobsStorage, AzureWebJobsStorage__blobServiceUri, or AzureWebJobsStorage__accountName is required.");
+    }
+
+    private static string? GetConnectionProperty(IConfiguration configuration, string name)
+    {
+        var value = configuration[$"{ConnectionName}:{name}"];
+
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        return configuration[$"{ConnectionName}__{name}"];
+    }
+}

--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -100,28 +100,16 @@ builder.Services.AddSingleton(provider =>
     var environment = provider.GetRequiredService<AzureEnvironment>();
     var configuration = provider.GetRequiredService<IConfiguration>();
 
-    var connectionString = configuration["AzureWebJobsStorage"];
+    var storageSettings = AzureWebJobsStorageSettings.FromConfiguration(configuration);
+    var connectionString = storageSettings.ConnectionString;
 
     if (!string.IsNullOrWhiteSpace(connectionString))
     {
         return new BlobContainerClient(connectionString, acmeStateContainerName);
     }
 
-    var blobServiceUri = configuration["AzureWebJobsStorage__blobServiceUri"];
-
-    if (string.IsNullOrWhiteSpace(blobServiceUri))
-    {
-        var accountName = configuration["AzureWebJobsStorage__accountName"];
-
-        if (string.IsNullOrWhiteSpace(accountName))
-        {
-            throw new InvalidOperationException("AzureWebJobsStorage, AzureWebJobsStorage__blobServiceUri, or AzureWebJobsStorage__accountName is required.");
-        }
-
-        blobServiceUri = $"https://{accountName}.blob.core.windows.net";
-    }
-
-    var clientId = configuration["AzureWebJobsStorage__clientId"];
+    var blobServiceUri = storageSettings.GetBlobServiceUri();
+    var clientId = storageSettings.ClientId;
 
     var managedIdentityId = string.IsNullOrWhiteSpace(clientId) ? ManagedIdentityId.SystemAssigned : ManagedIdentityId.FromUserAssignedClientId(clientId);
 

--- a/tests/Acmebot.App.Tests/Acmebot.App.Tests.csproj
+++ b/tests/Acmebot.App.Tests/Acmebot.App.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Acmebot.App\Acmebot.App.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Acmebot.App.Tests/AzureWebJobsStorageSettingsTests.cs
+++ b/tests/Acmebot.App.Tests/AzureWebJobsStorageSettingsTests.cs
@@ -1,0 +1,65 @@
+﻿using Acmebot.App.Infrastructure;
+
+using Microsoft.Extensions.Configuration;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class AzureWebJobsStorageSettingsTests
+{
+    [Fact]
+    public void FromConfiguration_WithConnectionString_ReadsConnectionString()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["AzureWebJobsStorage"] = "UseDevelopmentStorage=true"
+        });
+
+        var settings = AzureWebJobsStorageSettings.FromConfiguration(configuration);
+
+        Assert.Equal("UseDevelopmentStorage=true", settings.ConnectionString);
+    }
+
+    [Fact]
+    public void FromConfiguration_WithDoubleUnderscoreKeys_ReadsIdentityBasedConnectionProperties()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["AzureWebJobsStorage__accountName"] = "storageaccount",
+            ["AzureWebJobsStorage__blobServiceUri"] = "https://custom.blob.core.windows.net",
+            ["AzureWebJobsStorage__clientId"] = "11111111-1111-1111-1111-111111111111"
+        });
+
+        var settings = AzureWebJobsStorageSettings.FromConfiguration(configuration);
+
+        Assert.Equal("storageaccount", settings.AccountName);
+        Assert.Equal("https://custom.blob.core.windows.net", settings.GetBlobServiceUri());
+        Assert.Equal("11111111-1111-1111-1111-111111111111", settings.ClientId);
+    }
+
+    [Fact]
+    public void GetBlobServiceUri_WithAccountName_BuildsDefaultPublicAzureUri()
+    {
+        var settings = new AzureWebJobsStorageSettings(null, null, "storageaccount", null);
+
+        Assert.Equal("https://storageaccount.blob.core.windows.net", settings.GetBlobServiceUri());
+    }
+
+    [Fact]
+    public void GetBlobServiceUri_WithoutBlobServiceUriOrAccountName_Throws()
+    {
+        var settings = new AzureWebJobsStorageSettings(null, null, null, null);
+
+        var ex = Assert.Throws<InvalidOperationException>(settings.GetBlobServiceUri);
+
+        Assert.Equal("AzureWebJobsStorage, AzureWebJobsStorage__blobServiceUri, or AzureWebJobsStorage__accountName is required.", ex.Message);
+    }
+
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+               .AddInMemoryCollection(values)
+               .Build();
+    }
+}


### PR DESCRIPTION
Introduce AzureWebJobsStorageSettings to encapsulate reading AzureWebJobsStorage connection info (ConnectionString, blobServiceUri, accountName, clientId) and to provide GetBlobServiceUri() logic. Update Program.cs to use the new settings and simplify blob client creation and managed identity selection. Add a new test project and unit tests covering configuration parsing and GetBlobServiceUri behavior, and register the test project in the solution.

Fixes #1127 