### PR TITLE
Add z-index to .modal-panel

### DIFF
--- a/src/Acmebot.App/ClientApp/src/styles/app.css
+++ b/src/Acmebot.App/ClientApp/src/styles/app.css
@@ -976,6 +976,7 @@ button:disabled {
 
 .modal-panel {
   position: relative;
+  z-index: 80;
   width: min(760px, 100%);
   max-height: min(760px, calc(100vh - 40px));
   display: flex;


### PR DESCRIPTION
Add `z-index: 80` to the `.modal-panel` rule to ensure modals stack above other positioned elements and avoid being overlapped by page content. This addresses stacking/context issues where the modal could appear behind other UI layers.

Fixes #1131 