### PR TITLE
Fall back to registrar domain listing for Gandi LiveDNS zones

### DIFF
--- a/docs/guide/dns-providers.md
+++ b/docs/guide/dns-providers.md
@@ -189,6 +189,8 @@ Use a Gandi LiveDNS API key with access to the domains Acmebot should manage.
 Acmebot__GandiLiveDns__ApiKey=<api-key>
 ```
 
+Acmebot lists zones from `GET /v5/livedns/domains`. Some accounts, most often organization-scoped Personal Access Tokens, receive an empty list from that endpoint even when they manage LiveDNS zones. In that case Acmebot falls back to the registrar listing (`GET /v5/domain/domains`) and keeps the domains whose live nameservers are set to LiveDNS, so the token also needs Domain API access.
+
 ## GoDaddy
 
 Use GoDaddy production API credentials that can list domains and manage DNS records.

--- a/src/Acmebot.App/Providers/GandiLiveDnsProvider.cs
+++ b/src/Acmebot.App/Providers/GandiLiveDnsProvider.cs
@@ -69,6 +69,33 @@ public class GandiLiveDnsProvider(GandiLiveDnsOptions options) : IDnsProvider
 
         public async IAsyncEnumerable<Domain> ListDomainsAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
+            var found = false;
+
+            await foreach (var domain in ListLiveDnsDomainsAsync(cancellationToken))
+            {
+                found = true;
+
+                yield return domain;
+            }
+
+            if (found)
+            {
+                yield break;
+            }
+
+            // Some Gandi accounts (most often organization-scoped Personal Access Tokens) return an
+            // empty list from GET livedns/domains even when they manage LiveDNS zones. In that case fall
+            // back to the registrar domain listing and keep the domains whose live nameservers are set to
+            // LiveDNS. This re-enables the registrar-based zone listing that was the original behavior
+            // before the DNS providers were rewritten for v5.
+            await foreach (var domain in ListRegistrarLiveDnsDomainsAsync(cancellationToken))
+            {
+                yield return domain;
+            }
+        }
+
+        private async IAsyncEnumerable<Domain> ListLiveDnsDomainsAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
             var page = 1;
 
             while (true)
@@ -83,6 +110,42 @@ public class GandiLiveDnsProvider(GandiLiveDnsOptions options) : IDnsProvider
                 foreach (var domain in domains)
                 {
                     yield return domain;
+                }
+
+                page++;
+            }
+        }
+
+        private async IAsyncEnumerable<Domain> ListRegistrarLiveDnsDomainsAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            var page = 1;
+
+            while (true)
+            {
+                Domain[]? domains;
+
+                try
+                {
+                    domains = await _httpClient.GetFromJsonAsync<Domain[]>($"domain/domains?page={page}", cancellationToken);
+                }
+                catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+                {
+                    // The token is not authorized for the registrar API; treat it as no manageable zones.
+                    // Other failures (transient, 5xx, network) are left to surface as actionable errors.
+                    domains = null;
+                }
+
+                if (domains is null or { Length: 0 })
+                {
+                    break;
+                }
+
+                foreach (var domain in domains)
+                {
+                    if (domain.Nameserver?.Current == "livedns")
+                    {
+                        yield return domain;
+                    }
                 }
 
                 page++;
@@ -108,6 +171,15 @@ public class GandiLiveDnsProvider(GandiLiveDnsOptions options) : IDnsProvider
     {
         [JsonPropertyName("fqdn")]
         public required string Fqdn { get; set; }
+
+        [JsonPropertyName("nameserver")]
+        public DomainNameserver? Nameserver { get; set; }
+    }
+
+    internal class DomainNameserver
+    {
+        [JsonPropertyName("current")]
+        public string? Current { get; set; }
     }
 
     internal class Record


### PR DESCRIPTION
## Summary

  - Gandi zone listing returns nothing for some accounts (most often organization-scoped
    Personal Access Tokens) because `GET /v5/livedns/domains` responds with an empty list,
    which leaves the dashboard with no selectable zones. This adds a registrar-based fallback
    so those accounts can list and select their LiveDNS zones again.

  ## Related Issue

  - N/A (no existing issue; the problem and fix are described here)

  ## What Changed

  - `GandiLiveDnsProvider` still queries `GET /v5/livedns/domains` first, so accounts that
    already work are unaffected.
  - When the LiveDNS listing is empty, it falls back to the registrar listing
    `GET /v5/domain/domains` and keeps the domains whose live nameservers are set to LiveDNS.
  - The fallback is treated as "no manageable zones" when the token is not authorized for the
    registrar (Domain) API, so accounts that genuinely have no zones keep the previous behavior
    instead of failing.
  - Updated the Gandi LiveDNS provider guide to document the fallback and the extra Domain API
    access the token needs.

  ## Validation

  - [x] `dotnet build -c Release ./Acmebot.slnx`
  - [x] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx`
  - [x] `az bicep build -f ./deploy/azuredeploy.bicep`
  - [x] Documentation updated if needed

  ## Notes

  - LiveDNS remains the primary source, so domains that use Gandi LiveDNS but are registered
    elsewhere keep working. The registrar fallback only surfaces organization or registrar
    scoped domains that the LiveDNS listing omits.
  - This re-enables the registrar-based zone listing that was the original behavior before the
    DNS providers were rewritten for v5.