### PR TITLE
Show key reuse and refactor metadata handling

### DIFF
--- a/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
+++ b/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
@@ -2,16 +2,13 @@
 import { computed, reactive, ref } from 'vue';
 import { createColumnHelper, FlexRender, getCoreRowModel, getSortedRowModel, useVueTable, type Row, type SortingState } from '@tanstack/vue-table';
 import {
-  AlertTriangle,
   ArrowDown,
   ArrowUp,
   ArrowUpDown,
-  CalendarClock,
   ChevronDown,
   ChevronRight,
   ChevronsDownUp,
   ChevronsUpDown,
-  Clock3,
   CirclePlus,
   Filter,
   LoaderCircle,
@@ -27,13 +24,13 @@ import type { CertificateCategory, CertificateItem, CertificateRenewalItem, Cert
 import {
   displayDnsName,
   formatDate,
-  formatDateTime,
   getCategoryLabel,
   getCertificateCategory,
   getCertificateStatus,
   getPrimaryZone,
   isShortLived,
 } from '@/utils/certificates';
+import { renewalIcon, renewalLabel, renewalSubtext, renewalTone } from '@/utils/renewals';
 
 import StatusBadge from './StatusBadge.vue';
 
@@ -243,53 +240,19 @@ function getRenewal(certificate: CertificateItem): CertificateRenewalItem | null
 }
 
 function getRenewalTone(renewal: CertificateRenewalItem | null): string {
-  if (!renewal) {
-    return props.renewalsLoading ? 'pending' : 'neutral';
-  }
-
-  if (renewal.statusKind === 'scheduled' || renewal.statusKind === 'active' || renewal.statusKind === 'attention' || renewal.statusKind === 'pending') {
-    return renewal.statusKind;
-  }
-
-  return 'neutral';
+  return renewalTone(renewal, props.renewalsLoading);
 }
 
 function getRenewalLabel(renewal: CertificateRenewalItem | null): string {
-  if (!renewal) {
-    return props.renewalsLoading ? 'Loading' : '-';
-  }
-
-  return renewal.status;
+  return renewalLabel(renewal, props.renewalsLoading);
 }
 
 function getRenewalSubtext(renewal: CertificateRenewalItem | null): string {
-  if (!renewal) {
-    return props.renewalsLoading ? 'Refreshing status' : '';
-  }
-
-  if (renewal.nextCheck) {
-    return `Next ${formatDateTime(renewal.nextCheck)}`;
-  }
-
-  return '';
+  return renewalSubtext(renewal, props.renewalsLoading);
 }
 
 function getRenewalIcon(renewal: CertificateRenewalItem | null) {
-  const tone = getRenewalTone(renewal);
-
-  if (tone === 'attention') {
-    return AlertTriangle;
-  }
-
-  if (tone === 'active') {
-    return RefreshCw;
-  }
-
-  if (tone === 'scheduled') {
-    return CalendarClock;
-  }
-
-  return Clock3;
+  return renewalIcon(renewal, props.renewalsLoading);
 }
 </script>
 

--- a/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
+++ b/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
@@ -22,8 +22,66 @@ const emit = defineEmits<{
   copy: [label: string, value: string];
 }>();
 
+interface MetadataRow {
+  key: string;
+  label: string;
+  value: string;
+  mono?: boolean;
+  stacked?: boolean;
+}
+
 const customTags = computed(() => Object.entries(props.certificate?.tags ?? {}).toSorted(([left], [right]) => left.localeCompare(right)));
 const customTagsCopyText = computed(() => customTags.value.map(([key, value]) => `${key}: ${value}`).join('\n'));
+const metadataRows = computed<MetadataRow[]>(() => {
+  const certificate = props.certificate;
+
+  if (!certificate) {
+    return [];
+  }
+
+  const rows: MetadataRow[] = [];
+
+  if (certificate.acmeEndpoint) {
+    rows.push({
+      key: 'acmeEndpoint',
+      label: 'ACME endpoint',
+      value: certificate.acmeEndpoint,
+      mono: true,
+      stacked: true,
+    });
+  }
+
+  if (certificate.isIssuedByAcmebot || certificate.dnsProviderName) {
+    rows.push({
+      key: 'dnsProvider',
+      label: 'DNS provider',
+      value: certificate.dnsProviderName || 'Automatic',
+    });
+  }
+
+  if (certificate.dnsAlias) {
+    rows.push({
+      key: 'dnsAlias',
+      label: 'DNS alias',
+      value: displayDnsName(certificate.dnsAlias),
+      stacked: true,
+    });
+  }
+
+  return rows;
+});
+
+function getReuseKeyLabel(certificate: CertificateItem): string {
+  if (certificate.reuseKey === true) {
+    return 'Enabled';
+  }
+
+  if (certificate.reuseKey === false) {
+    return 'Disabled';
+  }
+
+  return 'Unknown';
+}
 
 function getRenewalTone(): string {
   const kind = props.renewal?.statusKind;
@@ -171,6 +229,16 @@ function getRenewalMessage(): string {
               <strong>{{ certificate.keyType ?? '-' }} {{ certificate.keySize ? `${certificate.keySize} bit` : certificate.keyCurveName ?? '' }}</strong>
             </div>
           </div>
+          <div class="detail-item">
+            <RotateCw
+              :size="17"
+              aria-hidden="true"
+            />
+            <div>
+              <span>Key reuse</span>
+              <strong>{{ getReuseKeyLabel(certificate) }}</strong>
+            </div>
+          </div>
           <div class="detail-item detail-item--wide">
             <Fingerprint
               :size="17"
@@ -234,65 +302,26 @@ function getRenewalMessage(): string {
           </dl>
         </section>
 
-        <section class="detail-section">
+        <section
+          v-if="metadataRows.length > 0"
+          class="detail-section"
+        >
           <h3>Metadata</h3>
           <dl class="metadata-list">
-            <div class="metadata-row">
-              <dt>Issuer</dt>
-              <dd>
-                <span
-                  class="metadata-chip"
-                  :class="certificate.isIssuedByAcmebot ? 'metadata-chip--success' : 'metadata-chip--neutral'"
-                >
-                  {{ certificate.isIssuedByAcmebot ? 'Acmebot' : 'External' }}
-                </span>
-              </dd>
-            </div>
-            <div class="metadata-row">
-              <dt>Current ACME endpoint</dt>
-              <dd>
-                <span
-                  class="metadata-chip"
-                  :class="certificate.isSameEndpoint ? 'metadata-chip--success' : 'metadata-chip--warning'"
-                >
-                  {{ certificate.isSameEndpoint ? 'Current' : 'Different' }}
-                </span>
-              </dd>
-            </div>
-            <div class="metadata-row">
-              <dt>Reuse key</dt>
-              <dd>
-                <span
-                  class="metadata-chip"
-                  :class="certificate.reuseKey ? 'metadata-chip--success' : 'metadata-chip--neutral'"
-                >
-                  {{ certificate.reuseKey ? 'Enabled' : 'Disabled' }}
-                </span>
-              </dd>
-            </div>
             <div
-              v-if="certificate.dnsProviderName"
+              v-for="row in metadataRows"
+              :key="row.key"
               class="metadata-row"
+              :class="{ 'metadata-row--stacked': row.stacked }"
             >
-              <dt>DNS provider</dt>
-              <dd>{{ certificate.dnsProviderName }}</dd>
-            </div>
-            <div
-              v-if="certificate.dnsAlias"
-              class="metadata-row metadata-row--stacked"
-            >
-              <dt>DNS alias</dt>
+              <dt>{{ row.label }}</dt>
               <dd class="metadata-value-line">
-                <span class="metadata-value">{{ displayDnsName(certificate.dnsAlias ?? '') }}</span>
-              </dd>
-            </div>
-            <div
-              v-if="certificate.acmeEndpoint"
-              class="metadata-row metadata-row--stacked"
-            >
-              <dt>ACME endpoint</dt>
-              <dd class="metadata-value-line">
-                <span class="metadata-value metadata-value--mono">{{ certificate.acmeEndpoint }}</span>
+                <span
+                  class="metadata-value"
+                  :class="{ 'metadata-value--mono': row.mono }"
+                >
+                  {{ row.value }}
+                </span>
               </dd>
             </div>
           </dl>

--- a/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
+++ b/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { AlertTriangle, CalendarClock, CalendarDays, Clock3, Copy, Fingerprint, KeyRound, RotateCw, ShieldCheck, Trash2, X } from 'lucide-vue-next';
+import { AlertTriangle, CalendarDays, Copy, Fingerprint, KeyRound, RotateCw, ShieldCheck, Trash2, X } from 'lucide-vue-next';
 
 import type { CertificateItem, CertificateRenewalItem } from '@/api/types';
 import { displayDnsName, formatDateTime, getCategoryLabel, getCertificateCategory, getValidityDays, isCertificateExpired } from '@/utils/certificates';
+import { renewalIcon, renewalLabel, renewalTone } from '@/utils/renewals';
 
 import StatusBadge from './StatusBadge.vue';
 
@@ -84,39 +85,15 @@ function getReuseKeyLabel(certificate: CertificateItem): string {
 }
 
 function getRenewalTone(): string {
-  const kind = props.renewal?.statusKind;
-
-  if (kind === 'scheduled' || kind === 'active' || kind === 'attention' || kind === 'pending') {
-    return kind;
-  }
-
-  return props.renewalLoading ? 'pending' : 'neutral';
+  return renewalTone(props.renewal ?? null, props.renewalLoading);
 }
 
 function getRenewalLabel(): string {
-  if (!props.renewal) {
-    return props.renewalLoading ? 'Loading' : '-';
-  }
-
-  return props.renewal.status;
+  return renewalLabel(props.renewal ?? null, props.renewalLoading);
 }
 
 function getRenewalIcon() {
-  const tone = getRenewalTone();
-
-  if (tone === 'attention') {
-    return AlertTriangle;
-  }
-
-  if (tone === 'active') {
-    return RotateCw;
-  }
-
-  if (tone === 'scheduled') {
-    return CalendarClock;
-  }
-
-  return Clock3;
+  return renewalIcon(props.renewal ?? null, props.renewalLoading);
 }
 
 function getRenewalMessage(): string {

--- a/src/Acmebot.App/ClientApp/src/utils/renewals.ts
+++ b/src/Acmebot.App/ClientApp/src/utils/renewals.ts
@@ -1,0 +1,57 @@
+import type { Component } from 'vue';
+import { AlertTriangle, CalendarClock, Clock3, RotateCw } from 'lucide-vue-next';
+
+import type { CertificateRenewalItem } from '@/api/types';
+import { formatDateTime } from '@/utils/certificates';
+
+export type RenewalTone = 'scheduled' | 'active' | 'attention' | 'pending' | 'neutral';
+
+const knownTones: ReadonlySet<RenewalTone> = new Set(['scheduled', 'active', 'attention', 'pending']);
+
+export function renewalTone(renewal: CertificateRenewalItem | null, loading = false): RenewalTone {
+  if (!renewal) {
+    return loading ? 'pending' : 'neutral';
+  }
+
+  const kind = renewal.statusKind as RenewalTone;
+
+  return knownTones.has(kind) ? kind : 'neutral';
+}
+
+export function renewalLabel(renewal: CertificateRenewalItem | null, loading = false): string {
+  if (!renewal) {
+    return loading ? 'Loading' : '-';
+  }
+
+  return renewal.status;
+}
+
+export function renewalSubtext(renewal: CertificateRenewalItem | null, loading = false): string {
+  if (!renewal) {
+    return loading ? 'Refreshing status' : '';
+  }
+
+  if (renewal.nextCheck) {
+    return `Next ${formatDateTime(renewal.nextCheck)}`;
+  }
+
+  return '';
+}
+
+export function renewalIcon(renewal: CertificateRenewalItem | null, loading = false): Component {
+  const tone = renewalTone(renewal, loading);
+
+  if (tone === 'attention') {
+    return AlertTriangle;
+  }
+
+  if (tone === 'active') {
+    return RotateCw;
+  }
+
+  if (tone === 'scheduled') {
+    return CalendarClock;
+  }
+
+  return Clock3;
+}

--- a/src/Acmebot.App/Extensions/CertificateExtensions.cs
+++ b/src/Acmebot.App/Extensions/CertificateExtensions.cs
@@ -85,7 +85,7 @@ internal static class CertificateExtensions
                     continue;
                 }
 
-                tags[tag.Key.Trim()] = tag.Value?.Trim() ?? "";
+                tags[tag.Key.Trim()] = tag.Value.Trim();
             }
         }
 
@@ -170,11 +170,6 @@ internal static class CertificateExtensions
 
     private static Dictionary<string, string> GetCustomCertificateTags(this IDictionary<string, string> tags)
     {
-        if (tags is null)
-        {
-            return [];
-        }
-
         string[] internalTagKeys = tags.Keys.Contains(AcmebotTagKey, StringComparer.OrdinalIgnoreCase)
             ? [AcmebotTagKey]
             : [AcmebotTagKey, LegacyIssuerKey, LegacyEndpointKey, LegacyDnsProviderKey, LegacyDnsAliasKey];
@@ -189,13 +184,13 @@ internal static class CertificateExtensions
     private sealed class AcmebotCertificateMetadata
     {
         [JsonPropertyName("endpoint")]
-        public string? Endpoint { get; set; }
+        public string? Endpoint { get; init; }
 
         [JsonPropertyName("dnsProvider")]
-        public string? DnsProvider { get; set; }
+        public string? DnsProvider { get; init; }
 
         [JsonPropertyName("dnsAlias")]
-        public string? DnsAlias { get; set; }
+        public string? DnsAlias { get; init; }
 
         [JsonPropertyName("certificateId")]
         public string? CertificateId { get; set; }

--- a/src/Acmebot.App/Functions/Orchestration/CertificateActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateActivities.cs
@@ -19,6 +19,9 @@ public class CertificateActivities(
 {
     private readonly AcmebotOptions _options = options.Value;
 
+    // How long to wait before checking the ACME renewal information (ARI) again when it cannot be used right now.
+    private static readonly TimeSpan s_renewalInfoCheckInterval = TimeSpan.FromHours(6);
+
     [Function(nameof(EvaluateCertificateRenewal))]
     public async Task<CertificateRenewalEvaluation> EvaluateCertificateRenewal([ActivityTrigger] string certificateName)
     {
@@ -82,7 +85,7 @@ public class CertificateActivities(
                         IsActive = true,
                         ShouldRenew = suggestedWindow.Start <= now,
                         NextCheck = SelectNextCheck(now, suggestedWindow.Start, suggestedWindow.End, renewalInfo.RetryAfter),
-                        Reason = "ARI"
+                        Reason = "Renewal is scheduled within the certificate authority's suggested renewal window."
                     };
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
@@ -92,8 +95,8 @@ public class CertificateActivities(
                     {
                         IsActive = true,
                         ShouldRenew = CheckShouldRenew(properties, now),
-                        NextCheck = now.AddHours(6),
-                        Reason = "ARI unavailable"
+                        NextCheck = now.Add(s_renewalInfoCheckInterval),
+                        Reason = "Renewal information is temporarily unavailable. Using the configured schedule and rechecking soon."
                     };
                 }
             }
@@ -104,7 +107,7 @@ public class CertificateActivities(
             IsActive = true,
             ShouldRenew = CheckShouldRenew(properties, now),
             NextCheck = now.AddDays(1),
-            Reason = "Schedule"
+            Reason = "Renewal is scheduled based on the configured renewal threshold."
         };
     }
 
@@ -142,7 +145,7 @@ public class CertificateActivities(
         var window = suggestedWindowEnd - suggestedWindowStart;
 
         var randomRenewalTime = suggestedWindowStart.AddTicks(Random.Shared.NextInt64(window.Ticks));
-        var nextRenewalInfoCheck = now.Add(retryAfter ?? TimeSpan.FromHours(6));
+        var nextRenewalInfoCheck = now.Add(retryAfter ?? s_renewalInfoCheckInterval);
 
         return randomRenewalTime <= nextRenewalInfoCheck ? randomRenewalTime : nextRenewalInfoCheck;
     }

--- a/src/Acmebot.App/Functions/Orchestration/CertificateRenewalSchedulerOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateRenewalSchedulerOrchestrator.cs
@@ -32,7 +32,7 @@ public partial class CertificateRenewalSchedulerOrchestrator
 
         if (evaluation.ShouldRenew)
         {
-            SetSchedulerStatus(context, certificateName, "Renewing", null, evaluation.Reason);
+            SetSchedulerStatus(context, certificateName, "Renewing", null, "Automatic renewal is in progress.");
 
             try
             {

--- a/src/Acmebot.App/Functions/Orchestration/RenewCertificates.cs
+++ b/src/Acmebot.App/Functions/Orchestration/RenewCertificates.cs
@@ -22,7 +22,7 @@ public partial class RenewCertificates(
 
         foreach (var certificate in certificates)
         {
-            if (!certificate.Enabled || !certificate.IsIssuedByAcmebot || !certificate.IsSameEndpoint)
+            if (!certificate.IsRenewable)
             {
                 skipped++;
                 continue;

--- a/src/Acmebot.App/Services/CertificateQueryService.cs
+++ b/src/Acmebot.App/Services/CertificateQueryService.cs
@@ -67,4 +67,7 @@ public class CertificateQueryService(
     }
 }
 
-public sealed record CertificateRenewalTarget(string Name, bool Enabled, bool IsIssuedByAcmebot, bool IsSameEndpoint);
+public sealed record CertificateRenewalTarget(string Name, bool Enabled, bool IsIssuedByAcmebot, bool IsSameEndpoint)
+{
+    public bool IsRenewable => Enabled && IsIssuedByAcmebot && IsSameEndpoint;
+}


### PR DESCRIPTION
Vue: Add a MetadataRow type and metadataRows computed property to build metadata entries (ACME endpoint, DNS provider/alias) and render them dynamically with stacked/mono styling; add getReuseKeyLabel and display a Key reuse detail in the certificate details drawer. C#: Trim tag values when populating tags, remove an unnecessary null-check/invalid return in GetCustomCertificateTags, and make AcmebotCertificateMetadata properties (Endpoint, DnsProvider, DnsAlias) init-only to favor immutability. These changes centralize metadata rendering, fix trimming behavior, and expose key reuse state in the UI.