### PR TITLE
Require DNS provider for certificate requests

### DIFF
--- a/docs/guide/dns-providers.md
+++ b/docs/guide/dns-providers.md
@@ -8,7 +8,7 @@ Configure at least one DNS provider under the `Acmebot` configuration section be
 
 When a certificate is issued, Acmebot lists zones from the configured providers and finds the most specific zone that matches each requested DNS name.
 
-If a certificate request does not specify `dnsProviderName`, Acmebot can infer the provider only when all requested names resolve to zones from a single provider. If multiple providers match, choose the provider explicitly in the dashboard.
+Every certificate request must specify `dnsProviderName`. Choose the provider explicitly in the dashboard or pass it with `--dns-provider` when using the CLI.
 
 ## Credential Storage
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -37,7 +37,7 @@ What to verify:
 
 - DNS zones load successfully in the dashboard.
 - The requested name is under one of the configured zones.
-- `dnsProviderName` is set when multiple providers can match the request.
+- `dnsProviderName` is set to the DNS provider that owns the validation zone.
 - `dnsAlias` has the required CNAME or delegation in place.
 - A TXT record appears at `_acme-challenge.<name>` while the operation runs.
 - `Acmebot__UseSystemNameServer=true` is used only when the validation design requires the platform resolver.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -67,7 +67,7 @@ Accept: application/json
 | --- | --- | --- |
 | `certificateName` | No | Key Vault certificate name. If omitted, Acmebot derives it from the first DNS name. |
 | `dnsNames` | Yes | DNS names to include in the certificate. |
-| `dnsProviderName` | No | Provider display name, such as `Azure DNS` or `Cloudflare`. Required when Acmebot cannot infer a single provider. |
+| `dnsProviderName` | Yes | Provider display name, such as `Azure DNS` or `Cloudflare`. |
 | `keyType` | Yes | `RSA` or `EC`. |
 | `keySize` | For RSA | `2048`, `3072`, or `4096`. |
 | `keyCurveName` | For EC | `P-256`, `P-384`, `P-521`, or `P-256K`. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -140,7 +140,7 @@ acmebot certificate issue --dns-name "*.example.com" --dns-provider "Azure DNS"
 | --- | --- |
 | `--dns-name <value>` | DNS name to include in the certificate. Required and repeatable. Duplicate names are removed case-insensitively. |
 | `--name <value>` | Key Vault certificate name. If omitted, Acmebot derives the name from the first DNS name. Only letters, numbers, and hyphens are allowed. |
-| `--dns-provider <value>` | DNS provider display name, such as `Azure DNS` or `Cloudflare`. Required when Acmebot cannot infer a single provider. |
+| `--dns-provider <value>` | DNS provider display name, such as `Azure DNS` or `Cloudflare`. Required. |
 | `--key-type <type>` | Certificate key type. Valid values are `RSA` and `EC`. Defaults to `RSA`. |
 | `--key-size <size>` | RSA key size. Valid values are `2048`, `3072`, and `4096`. Defaults to `2048`. Valid only with `--key-type RSA`. |
 | `--key-curve <curve>` | EC key curve. Valid values are `P-256`, `P-384`, `P-521`, and `P-256K`. Defaults to `P-256`. Valid only with `--key-type EC`. |

--- a/src/Acmebot.App/ClientApp/src/api/mockData.ts
+++ b/src/Acmebot.App/ClientApp/src/api/mockData.ts
@@ -136,7 +136,7 @@ let mockCertificates: CertificateItem[] = [
     id: 'https://mock.vault/certificates/imported-legacy-net',
     name: 'imported-legacy-net',
     dnsNames: ['legacy.net'],
-    dnsProviderName: null,
+    dnsProviderName: '',
     createdOn: dateBefore(120),
     expiresOn: dateFromNow(144),
     x509Thumbprint: 'E42F40A663778F40DA3CCECFB2D908390F0B4119',

--- a/src/Acmebot.App/ClientApp/src/api/types.ts
+++ b/src/Acmebot.App/ClientApp/src/api/types.ts
@@ -7,7 +7,7 @@ export interface CertificateItem {
   id: string;
   name: string;
   dnsNames: string[];
-  dnsProviderName?: string | null;
+  dnsProviderName: string;
   createdOn: string;
   expiresOn: string;
   x509Thumbprint?: string | null;
@@ -39,7 +39,7 @@ export interface SelectableDnsZone extends DnsZoneItem {
 export interface CertificatePolicyItem {
   certificateName?: string;
   dnsNames: string[];
-  dnsProviderName?: string;
+  dnsProviderName: string;
   keyType: KeyType;
   keySize?: number;
   keyCurveName?: KeyCurveName;

--- a/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
@@ -385,7 +385,7 @@ function submit(): void {
 
   const policy: CertificatePolicyItem = {
     dnsNames: form.dnsNames,
-    dnsProviderName: form.dnsProviderName || undefined,
+    dnsProviderName: form.dnsProviderName,
     certificateName: normalizedCertificateName || undefined,
     keyType: form.keyType,
     reuseKey: form.useAdvancedOptions ? form.reuseKey : false,

--- a/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
+++ b/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
@@ -120,7 +120,7 @@ const filteredCertificates = computed(() => {
   return props.certificates.filter((certificate) => {
     const category = getCertificateCategory(certificate);
     const status = getCertificateStatus(certificate);
-    const provider = certificate.dnsProviderName ?? noProviderValue;
+    const provider = certificate.dnsProviderName || noProviderValue;
     const matchesCategory = filters.category === 'all' || filters.category === category;
     const matchesStatus = filters.status === 'all' || filters.status === status.kind;
     const matchesProvider = filters.provider === 'all' || filters.provider === provider;

--- a/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
+++ b/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
@@ -56,7 +56,7 @@ const metadataRows = computed<MetadataRow[]>(() => {
     rows.push({
       key: 'dnsProvider',
       label: 'DNS provider',
-      value: certificate.dnsProviderName || 'Automatic',
+      value: certificate.dnsProviderName || 'Not set',
     });
   }
 

--- a/src/Acmebot.App/Extensions/CertificateExtensions.cs
+++ b/src/Acmebot.App/Extensions/CertificateExtensions.cs
@@ -92,7 +92,7 @@ internal static class CertificateExtensions
         var metadata = new AcmebotCertificateMetadata
         {
             Endpoint = endpoint.Host,
-            DnsProvider = certificatePolicyItem.DnsProviderName ?? "",
+            DnsProvider = certificatePolicyItem.DnsProviderName,
             DnsAlias = string.IsNullOrEmpty(certificatePolicyItem.DnsAlias) ? null : certificatePolicyItem.DnsAlias
         };
 

--- a/src/Acmebot.App/Extensions/DnsProvidersExtensions.cs
+++ b/src/Acmebot.App/Extensions/DnsProvidersExtensions.cs
@@ -4,52 +4,6 @@ namespace Acmebot.App.Extensions;
 
 internal static class DnsProvidersExtensions
 {
-    public static async Task<IReadOnlyList<(string, IReadOnlyList<DnsZone>?)>> ListAllZonesAsync(this IEnumerable<IDnsProvider> dnsProviders, CancellationToken cancellationToken = default)
-    {
-        async Task<(string, IReadOnlyList<DnsZone>?)> ListDnsZones(IDnsProvider dnsProvider)
-        {
-            try
-            {
-                var dnsZones = await dnsProvider.ListZonesAsync(cancellationToken);
-
-                return (dnsProvider.Name, dnsZones);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch
-            {
-                return (dnsProvider.Name, null);
-            }
-        }
-
-        var zones = await Task.WhenAll(dnsProviders.Select(ListDnsZones));
-
-        return zones;
-    }
-
-    public static async Task<IReadOnlyList<DnsZone>> ListZonesAsync(this IEnumerable<IDnsProvider> dnsProviders, string dnsProviderName, CancellationToken cancellationToken = default)
-    {
-        var dnsProvider = dnsProviders.FirstOrDefault(x => x.Name == dnsProviderName);
-
-        if (dnsProvider is null)
-        {
-            return [];
-        }
-
-        var dnsZones = await dnsProvider.ListZonesAsync(cancellationToken);
-
-        return dnsZones;
-    }
-
-    public static async Task<IReadOnlyList<DnsZone>> FlattenAllZonesAsync(this IEnumerable<IDnsProvider> dnsProviders, CancellationToken cancellationToken = default)
-    {
-        var zones = await dnsProviders.ListAllZonesAsync(cancellationToken);
-
-        return zones.Where(x => x.Item2 is not null).SelectMany(x => x.Item2!).ToArray();
-    }
-
     public static void TryAdd<TOption>(this IList<IDnsProvider> dnsProviders, TOption? options, Func<TOption, IDnsProvider> factory)
     {
         if (options is not null)

--- a/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
@@ -54,7 +54,7 @@ public partial class CertificateIssuanceOrchestrator
                 finally
                 {
                     // 作成した DNS レコードを削除
-                    await context.CallCleanupDnsChallengeAsync((certificatePolicyItem.DnsProviderName ?? "", challengeResults));
+                    await context.CallCleanupDnsChallengeAsync((certificatePolicyItem.DnsProviderName, challengeResults));
                 }
             }
 

--- a/src/Acmebot.App/Functions/Orchestration/DnsChallengeActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/DnsChallengeActivities.cs
@@ -4,6 +4,7 @@ using Acmebot.App.Acme;
 using Acmebot.App.Extensions;
 using Acmebot.App.Models;
 using Acmebot.App.Providers;
+using Acmebot.App.Services;
 
 using DnsClient;
 
@@ -14,12 +15,12 @@ namespace Acmebot.App.Functions.Orchestration;
 public class DnsChallengeActivities(
     LookupClient lookupClient,
     AcmeClientFactory acmeClientFactory,
-    IEnumerable<IDnsProvider> dnsProviders)
+    DnsZoneQueryService dnsZoneQueryService)
 {
     [Function(nameof(Dns01Precondition))]
     public async Task<string> Dns01Precondition([ActivityTrigger] CertificatePolicyItem certificatePolicyItem)
     {
-        var zones = await dnsProviders.FlattenAllZonesAsync();
+        var zones = await dnsZoneQueryService.ListZonesAsync(certificatePolicyItem.DnsProviderName);
 
         var foundZones = new HashSet<DnsZone>();
         var notFoundZoneDnsNames = new List<string>();
@@ -61,21 +62,7 @@ public class DnsChallengeActivities(
             }
         }
 
-        var dnsProvider = foundZones.Select(x => x.DnsProvider).FirstOrDefault(x => x.Name == certificatePolicyItem.DnsProviderName);
-
-        if (dnsProvider is null)
-        {
-            var foundDnsProviders = foundZones.Select(x => x.DnsProvider).DistinctBy(x => x.Name).ToArray();
-
-            if (foundDnsProviders.Length != 1)
-            {
-                return "";
-            }
-
-            dnsProvider = foundDnsProviders[0];
-        }
-
-        return dnsProvider.Name;
+        return certificatePolicyItem.DnsProviderName;
     }
 
     [Function(nameof(Dns01Authorization))]
@@ -114,7 +101,7 @@ public class DnsChallengeActivities(
             });
         }
 
-        var zones = await (string.IsNullOrEmpty(dnsProviderName) ? dnsProviders.FlattenAllZonesAsync(cancellationToken) : dnsProviders.ListZonesAsync(dnsProviderName, cancellationToken));
+        var zones = await dnsZoneQueryService.ListZonesAsync(dnsProviderName, cancellationToken);
 
         var propagationSeconds = 0;
 
@@ -177,7 +164,7 @@ public class DnsChallengeActivities(
     {
         var (dnsProviderName, challengeResults) = input;
 
-        var zones = await (string.IsNullOrEmpty(dnsProviderName) ? dnsProviders.FlattenAllZonesAsync(cancellationToken) : dnsProviders.ListZonesAsync(dnsProviderName, cancellationToken));
+        var zones = await dnsZoneQueryService.ListZonesAsync(dnsProviderName, cancellationToken);
 
         foreach (var lookup in challengeResults.ToLookup(x => x.DnsRecordName))
         {

--- a/src/Acmebot.App/Models/CertificateItem.cs
+++ b/src/Acmebot.App/Models/CertificateItem.cs
@@ -14,7 +14,7 @@ public class CertificateItem
     public required IReadOnlyList<string> DnsNames { get; set; }
 
     [JsonPropertyName("dnsProviderName")]
-    public string? DnsProviderName { get; set; }
+    public required string DnsProviderName { get; set; }
 
     [JsonPropertyName("createdOn")]
     public DateTimeOffset CreatedOn { get; set; }

--- a/src/Acmebot.App/Models/CertificatePolicyItem.cs
+++ b/src/Acmebot.App/Models/CertificatePolicyItem.cs
@@ -13,7 +13,7 @@ public class CertificatePolicyItem : IValidatableObject
     public required string[] DnsNames { get; set; }
 
     [JsonPropertyName("dnsProviderName")]
-    public string? DnsProviderName { get; set; }
+    public required string DnsProviderName { get; set; }
 
     [JsonPropertyName("keyType")]
     [RegularExpression("^(RSA|EC)$")]
@@ -45,6 +45,11 @@ public class CertificatePolicyItem : IValidatableObject
         if (DnsNames.Length == 0)
         {
             yield return new ValidationResult($"The {nameof(DnsNames)} is required.", [nameof(DnsNames)]);
+        }
+
+        if (string.IsNullOrWhiteSpace(DnsProviderName))
+        {
+            yield return new ValidationResult($"The {nameof(DnsProviderName)} is required.", [nameof(DnsProviderName)]);
         }
 
         if (KeyType == "RSA")

--- a/src/Acmebot.App/Services/DnsZoneQueryService.cs
+++ b/src/Acmebot.App/Services/DnsZoneQueryService.cs
@@ -10,14 +10,33 @@ public class DnsZoneQueryService(IEnumerable<IDnsProvider> dnsProviders)
     {
         try
         {
-            var zones = await dnsProviders.ListAllZonesAsync(cancellationToken);
+            var zones = await Task.WhenAll(dnsProviders.Select(async dnsProvider =>
+            {
+                try
+                {
+                    var dnsZones = await dnsProvider.ListZonesAsync(cancellationToken);
 
-            return zones.Where(x => x.Item2 is not null)
-                        .Select(x => new DnsZoneGroup
-                        {
-                            DnsProviderName = x.Item1,
-                            DnsZones = x.Item2!.Select(xs => xs.ToDnsZoneItem()).OrderBy(xs => xs.Name).ToArray()
-                        }).ToArray();
+                    return new DnsZoneGroup
+                    {
+                        DnsProviderName = dnsProvider.Name,
+                        DnsZones = dnsZones.Select(x => x.ToDnsZoneItem()).OrderBy(x => x.Name).ToArray()
+                    };
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch
+                {
+                    return new DnsZoneGroup
+                    {
+                        DnsProviderName = dnsProvider.Name,
+                        DnsZones = []
+                    };
+                }
+            }));
+
+            return zones.ToArray();
         }
         catch (OperationCanceledException)
         {
@@ -27,5 +46,19 @@ public class DnsZoneQueryService(IEnumerable<IDnsProvider> dnsProviders)
         {
             return [];
         }
+    }
+
+    public async Task<IReadOnlyList<DnsZone>> ListZonesAsync(string dnsProviderName, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dnsProviderName);
+
+        var dnsProvider = dnsProviders.FirstOrDefault(x => x.Name == dnsProviderName);
+
+        if (dnsProvider is null)
+        {
+            return [];
+        }
+
+        return await dnsProvider.ListZonesAsync(cancellationToken);
     }
 }

--- a/src/Acmebot.Cli/CertificatePolicyFactory.cs
+++ b/src/Acmebot.Cli/CertificatePolicyFactory.cs
@@ -27,6 +27,13 @@ internal static partial class CertificatePolicyFactory
             throw new CliException("At least one '--dns-name' value is required.");
         }
 
+        var dnsProviderName = NormalizeOptionalValue(commandLine.GetOption("dns-provider"));
+
+        if (dnsProviderName is null)
+        {
+            throw new CliException("Option '--dns-provider' is required.");
+        }
+
         var certificateName = commandLine.GetOption("name");
 
         if (certificateName is not null && !CertificateNameRegex().IsMatch(certificateName))
@@ -75,7 +82,7 @@ internal static partial class CertificatePolicyFactory
         {
             CertificateName = certificateName,
             DnsNames = dnsNames,
-            DnsProviderName = NormalizeOptionalValue(commandLine.GetOption("dns-provider")),
+            DnsProviderName = dnsProviderName,
             KeyType = keyType,
             KeySize = keySize,
             KeyCurveName = keyCurveName,

--- a/src/Acmebot.Cli/HelpText.cs
+++ b/src/Acmebot.Cli/HelpText.cs
@@ -35,7 +35,7 @@ internal static class HelpText
         await writer.WriteLineAsync("Certificate issue options:");
         await writer.WriteLineAsync("  --name <value>                         Key Vault certificate name.");
         await writer.WriteLineAsync("  --dns-name <value>                     DNS name. Repeatable.");
-        await writer.WriteLineAsync("  --dns-provider <value>                 DNS provider display name.");
+        await writer.WriteLineAsync("  --dns-provider <value>                 DNS provider display name. Required.");
         await writer.WriteLineAsync("  --key-type <RSA|EC>                    Key type. Default: RSA.");
         await writer.WriteLineAsync("  --key-size <2048|3072|4096>            RSA key size. Default: 2048.");
         await writer.WriteLineAsync("  --key-curve <P-256|P-384|P-521|P-256K> EC key curve. Default: P-256.");

--- a/src/Acmebot.Cli/Models.cs
+++ b/src/Acmebot.Cli/Models.cs
@@ -11,7 +11,7 @@ internal sealed class CertificatePolicyItem
     public required string[] DnsNames { get; set; }
 
     [JsonPropertyName("dnsProviderName")]
-    public string? DnsProviderName { get; set; }
+    public required string DnsProviderName { get; set; }
 
     [JsonPropertyName("keyType")]
     public required string KeyType { get; set; }
@@ -44,7 +44,7 @@ internal sealed class CertificateItem
     public required IReadOnlyList<string> DnsNames { get; set; }
 
     [JsonPropertyName("dnsProviderName")]
-    public string? DnsProviderName { get; set; }
+    public required string DnsProviderName { get; set; }
 
     [JsonPropertyName("createdOn")]
     public DateTimeOffset CreatedOn { get; set; }

--- a/src/Acmebot.Cli/OutputFormatter.cs
+++ b/src/Acmebot.Cli/OutputFormatter.cs
@@ -37,7 +37,7 @@ internal static class OutputFormatter
                 certificate.Name,
                 certificate.ExpiresOn.ToString("u"),
                 certificate.Enabled ? "enabled" : "disabled",
-                certificate.DnsProviderName ?? "",
+                certificate.DnsProviderName,
                 string.Join(", ", certificate.DnsNames)
             })
             .ToArray();

--- a/tests/Acmebot.Cli.Tests/AcmebotApiClientTests.cs
+++ b/tests/Acmebot.Cli.Tests/AcmebotApiClientTests.cs
@@ -28,6 +28,7 @@ public sealed class AcmebotApiClientTests
                 id = "https://vault.example/certificates/example",
                 name = "example",
                 dnsNames = new[] { "example.com" },
+                dnsProviderName = "Azure DNS",
                 createdOn = "2026-06-01T00:00:00+00:00",
                 expiresOn = "2026-09-01T00:00:00+00:00",
                 enabled = true,
@@ -72,6 +73,7 @@ public sealed class AcmebotApiClientTests
         {
             CertificateName = "example",
             DnsNames = ["example.com"],
+            DnsProviderName = "Azure DNS",
             KeyType = "RSA",
             KeySize = 2048
         }, TestContext.Current.CancellationToken);
@@ -86,6 +88,7 @@ public sealed class AcmebotApiClientTests
         using var document = JsonDocument.Parse(request.Content);
         Assert.Equal("example", document.RootElement.GetProperty("certificateName").GetString());
         Assert.Equal("example.com", document.RootElement.GetProperty("dnsNames")[0].GetString());
+        Assert.Equal("Azure DNS", document.RootElement.GetProperty("dnsProviderName").GetString());
     }
 
     [Fact]

--- a/tests/Acmebot.Cli.Tests/CertificatePolicyTests.cs
+++ b/tests/Acmebot.Cli.Tests/CertificatePolicyTests.cs
@@ -15,11 +15,14 @@ public sealed class CertificatePolicyTests
             " example.com ",
             "--dns-name",
             "EXAMPLE.com",
+            "--dns-provider",
+            "Azure DNS",
             "--tag",
             "owner=platform"
         ]));
 
         Assert.Equal(["example.com"], policy.DnsNames);
+        Assert.Equal("Azure DNS", policy.DnsProviderName);
         Assert.Equal("RSA", policy.KeyType);
         Assert.Equal(2048, policy.KeySize);
         Assert.Null(policy.KeyCurveName);
@@ -36,6 +39,8 @@ public sealed class CertificatePolicyTests
             "issue",
             "--dns-name",
             "example.com",
+            "--dns-provider",
+            "Azure DNS",
             "--key-type",
             "EC"
         ]));
@@ -54,6 +59,8 @@ public sealed class CertificatePolicyTests
             "issue",
             "--dns-name",
             "example.com",
+            "--dns-provider",
+            "Azure DNS",
             "--key-type",
             "ec",
             "--key-curve",
@@ -75,7 +82,9 @@ public sealed class CertificatePolicyTests
             "--name",
             "bad_name",
             "--dns-name",
-            "example.com"
+            "example.com",
+            "--dns-provider",
+            "Azure DNS"
         ])));
 
         Assert.Equal("Option '--name' must be 1 to 127 characters and contain only letters, numbers, and hyphens.", ex.Message);
@@ -91,7 +100,9 @@ public sealed class CertificatePolicyTests
             "--name",
             new string('a', 128),
             "--dns-name",
-            "example.com"
+            "example.com",
+            "--dns-provider",
+            "Azure DNS"
         ])));
 
         Assert.Equal("Option '--name' must be 1 to 127 characters and contain only letters, numbers, and hyphens.", ex.Message);
@@ -106,10 +117,26 @@ public sealed class CertificatePolicyTests
             "issue",
             "--dns-name",
             "example.com",
+            "--dns-provider",
+            "Azure DNS",
             "--tag",
             "Acmebot=true"
         ])));
 
         Assert.Equal("The 'Acmebot' tag is reserved for internal metadata.", ex.Message);
+    }
+
+    [Fact]
+    public void Create_WithoutDnsProvider_Throws()
+    {
+        var ex = Assert.Throws<CliException>(() => CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--dns-name",
+            "example.com"
+        ])));
+
+        Assert.Equal("Option '--dns-provider' is required.", ex.Message);
     }
 }


### PR DESCRIPTION
This pull request enforces that a DNS provider must always be explicitly specified when issuing certificates, both via the dashboard and the CLI. It removes all logic for inferring the DNS provider automatically and updates the codebase, API, CLI, and documentation to reflect this requirement. Several code paths are simplified as a result, and validation is tightened to require `dnsProviderName` throughout.

**Required DNS provider specification**

- All API endpoints, CLI commands, and UI forms now require the `dnsProviderName` field to be set explicitly when issuing a certificate; automatic inference is no longer supported. [[1]](diffhunk://#diff-88b0db26c178a570e078c528829c3fd4c26021f1ea5bccf6c0b36f15bacb6a49L11-R11) [[2]](diffhunk://#diff-370381df31c8d799afe0208a3b1f1c161b3f48ad3c5b5813e481c42f46161797L70-R70) [[3]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711L143-R143) [[4]](diffhunk://#diff-74e5b0ab07db2f541474ba8ddccd8d416f1aed6ff35c1a25b4d75940b3aff394L388-R388) [[5]](diffhunk://#diff-ff49c179456d3ac6e18f9193bded21da8785dba5358e62b8264c4b10c264afe4R30-R36) [[6]](diffhunk://#diff-ff49c179456d3ac6e18f9193bded21da8785dba5358e62b8264c4b10c264afe4L78-R85) [[7]](diffhunk://#diff-2309bb64dfdfd06c6241e0e382d5a750724cc2f8d4effc11c08e7b16e2fb74daL38-R38)
- Validation logic for `CertificatePolicyItem` and `CertificateItem` enforces that `dnsProviderName` is a required, non-empty string, and this is reflected in data models, mock data, and validation checks. [[1]](diffhunk://#diff-1dede859c5c0d96d41465cb9900058f86ebe3e95a60daa1e05e51ad7c642a254L10-R10) [[2]](diffhunk://#diff-1dede859c5c0d96d41465cb9900058f86ebe3e95a60daa1e05e51ad7c642a254L42-R42) [[3]](diffhunk://#diff-cdea3bb27af2a238de5655e0dc14553ed8b16d5d150abf944a09711d06256d52L139-R139) [[4]](diffhunk://#diff-a0b41dedb647cfa21f499888695d33550344639a0c98154d9008ccf3a2f6369aL17-R17) [[5]](diffhunk://#diff-efddb66898db821457a5a5989403528a099cd5dae5fd7bc6d92700455682638bL16-R16) [[6]](diffhunk://#diff-efddb66898db821457a5a5989403528a099cd5dae5fd7bc6d92700455682638bR50-R54)

**Backend and orchestration simplification**

- All orchestration and activity functions now use the explicitly provided `dnsProviderName` to query DNS zones, eliminating fallback or inference logic. [[1]](diffhunk://#diff-3e4dde19aa5f408b974bc112c3e23cdc23f9de2dea53b2c1dc37714a8f2bfdecL17-R23) [[2]](diffhunk://#diff-3e4dde19aa5f408b974bc112c3e23cdc23f9de2dea53b2c1dc37714a8f2bfdecL64-R65) [[3]](diffhunk://#diff-3e4dde19aa5f408b974bc112c3e23cdc23f9de2dea53b2c1dc37714a8f2bfdecL117-R104) [[4]](diffhunk://#diff-3e4dde19aa5f408b974bc112c3e23cdc23f9de2dea53b2c1dc37714a8f2bfdecL180-R167) [[5]](diffhunk://#diff-35b98ac32d04b0cdc95744f3e4d99860b77f9161a53d148acb0706cdec814281L57-R57) [[6]](diffhunk://#diff-7d078dcb7c00987ef2311f1bd66076a5dd4290d58d44d76694cb218a203212fbL95-R95)
- The `DnsProvidersExtensions` class is simplified by removing methods related to provider inference and zone flattening, centralizing zone queries in `DnsZoneQueryService`. [[1]](diffhunk://#diff-0a85596020ca6a8ea63bfcc301c4a2ae232ed8f1eda3fc147d4113b9e8d8b023L7-L52) [[2]](diffhunk://#diff-90a34812539afec8ebce13a99aa4bdd7a9e6d08ad9a0ef211d021783d1f3c365L13-R39) [[3]](diffhunk://#diff-90a34812539afec8ebce13a99aa4bdd7a9e6d08ad9a0ef211d021783d1f3c365R50-R63)

**Documentation updates**

- All relevant documentation (user guides, API reference, CLI reference, and troubleshooting) is updated to indicate that specifying the DNS provider is mandatory for all certificate requests, and to clarify the new expected behaviors. [[1]](diffhunk://#diff-88b0db26c178a570e078c528829c3fd4c26021f1ea5bccf6c0b36f15bacb6a49L11-R11) [[2]](diffhunk://#diff-370381df31c8d799afe0208a3b1f1c161b3f48ad3c5b5813e481c42f46161797L70-R70) [[3]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711L143-R143) [[4]](diffhunk://#diff-591755fcd41dbf3ede4a850f0598f6a1c479db1e22ff5d62a4f1b76574559d81L40-R40)

**UI and display adjustments**

- The UI now shows "Not set" instead of "Automatic" when no DNS provider is specified, though this should not occur with the new validation. Filtering and display logic is updated to treat empty strings consistently. [[1]](diffhunk://#diff-639fd1ec27b63db125d2bca64794ae11641b6d96d2d1a52b5fc3dd1b75f1d40fL123-R123) [[2]](diffhunk://#diff-5119876c339ea28b1c4454991fa0e4d029e5f829f61616dd43e0afc61d8f9784L59-R59)

**Other technical improvements**

- Minor dependency and import changes to support the refactoring (e.g., service injection).

These changes collectively ensure that DNS provider selection is always explicit, making the system more predictable and maintainable.