### PR TITLE
Add support for delegated DNS-01 validation mode

### DIFF
--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -46,7 +46,7 @@ The default is RSA 2048. Use EC only when the downstream service supports the se
 
 ### Certificate Name
 
-Certificate names can contain letters, numbers, and hyphens. If omitted, Acmebot derives a name from the first DNS name by replacing `*` with `wildcard` and dots with hyphens.
+Certificate names can contain letters, numbers, and hyphens. If omitted in the dashboard, the dashboard derives a name from the first DNS name by replacing `*` with `wildcard` and dots with hyphens before sending the request.
 
 ### Delegated DNS-01
 

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -48,9 +48,13 @@ The default is RSA 2048. Use EC only when the downstream service supports the se
 
 Certificate names can contain letters, numbers, and hyphens. If omitted, Acmebot derives a name from the first DNS name by replacing `*` with `wildcard` and dots with hyphens.
 
+### Delegated DNS-01
+
+Use the delegated DNS-01 issue mode when the DNS provider selected in Acmebot manages only the validation zone, not the certificate's public DNS zone. Enter full DNS names for the certificate, select the DNS alias zone that Acmebot can update, and create the displayed CNAME records in the authoritative DNS provider before submitting.
+
 ### DNS Alias
 
-Set DNS Alias when the ACME challenge should be created under another domain. Acmebot then validates through `_acme-challenge.<dnsAlias>`. This is useful when you delegate validation to a separate zone; confirm the required CNAME or delegation exists before submitting.
+Set DNS Alias when the ACME challenge should be created under another domain. Acmebot then writes TXT records at `_acme-challenge.<dnsAlias>` with the selected DNS provider. The alias value must not include the `_acme-challenge` prefix. In delegated DNS-01 mode, the dashboard generates a unique alias record in the selected alias zone and shows the CNAME records to create in the certificate domain's DNS provider.
 
 ### Tags
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -67,13 +67,15 @@ Accept: application/json
 | --- | --- | --- |
 | `certificateName` | No | Key Vault certificate name. If omitted, Acmebot derives it from the first DNS name. |
 | `dnsNames` | Yes | DNS names to include in the certificate. |
-| `dnsProviderName` | Yes | Provider display name, such as `Azure DNS` or `Cloudflare`. |
+| `dnsProviderName` | Yes | Provider display name, such as `Azure DNS` or `Cloudflare`. When `dnsAlias` is set, this provider must manage the DNS alias zone. |
 | `keyType` | Yes | `RSA` or `EC`. |
 | `keySize` | For RSA | `2048`, `3072`, or `4096`. |
 | `keyCurveName` | For EC | `P-256`, `P-384`, `P-521`, or `P-256K`. |
 | `reuseKey` | No | Whether Key Vault should reuse the certificate key. |
-| `dnsAlias` | No | Alternate domain used for DNS-01 validation. |
+| `dnsAlias` | No | Alternate domain used for DNS-01 validation. Acmebot writes TXT records at `_acme-challenge.<dnsAlias>`, so omit the `_acme-challenge` prefix from this value. |
 | `tags` | No | Custom Key Vault certificate tags. `Acmebot` is reserved. |
+
+For delegated DNS-01 validation, set `dnsNames` to the certificate names and set `dnsAlias` to a unique record in a zone Acmebot can update. For each DNS name, create a CNAME from `_acme-challenge.<dnsName>` to `_acme-challenge.<dnsAlias>` in the authoritative DNS provider for the certificate domain.
 
 ## List Certificates
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -65,14 +65,14 @@ Accept: application/json
 
 | Property | Required | Description |
 | --- | --- | --- |
-| `certificateName` | No | Key Vault certificate name. If omitted, Acmebot derives it from the first DNS name. |
-| `dnsNames` | Yes | DNS names to include in the certificate. |
+| `certificateName` | Yes | Key Vault certificate name. API clients must provide this value. It must be 1 to 127 characters and contain only letters, numbers, and hyphens. |
+| `dnsNames` | Yes | ASCII/punycode DNS names to include in the certificate. Omit trailing dots. Wildcards are allowed only as the leftmost label. |
 | `dnsProviderName` | Yes | Provider display name, such as `Azure DNS` or `Cloudflare`. When `dnsAlias` is set, this provider must manage the DNS alias zone. |
 | `keyType` | Yes | `RSA` or `EC`. |
 | `keySize` | For RSA | `2048`, `3072`, or `4096`. |
 | `keyCurveName` | For EC | `P-256`, `P-384`, `P-521`, or `P-256K`. |
 | `reuseKey` | No | Whether Key Vault should reuse the certificate key. |
-| `dnsAlias` | No | Alternate domain used for DNS-01 validation. Acmebot writes TXT records at `_acme-challenge.<dnsAlias>`, so omit the `_acme-challenge` prefix from this value. |
+| `dnsAlias` | No | Alternate ASCII/punycode domain used for DNS-01 validation. Acmebot writes TXT records at `_acme-challenge.<dnsAlias>`, so omit the `_acme-challenge` prefix and trailing dot from this value. |
 | `tags` | No | Custom Key Vault certificate tags. `Acmebot` is reserved. |
 
 For delegated DNS-01 validation, set `dnsNames` to the certificate names and set `dnsAlias` to a unique record in a zone Acmebot can update. For each DNS name, create a CNAME from `_acme-challenge.<dnsName>` to `_acme-challenge.<dnsAlias>` in the authoritative DNS provider for the certificate domain.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -140,16 +140,18 @@ acmebot certificate issue --dns-name "*.example.com" --dns-provider "Azure DNS"
 | --- | --- |
 | `--dns-name <value>` | DNS name to include in the certificate. Required and repeatable. Duplicate names are removed case-insensitively. |
 | `--name <value>` | Key Vault certificate name. If omitted, Acmebot derives the name from the first DNS name. Only letters, numbers, and hyphens are allowed. |
-| `--dns-provider <value>` | DNS provider display name, such as `Azure DNS` or `Cloudflare`. Required. |
+| `--dns-provider <value>` | DNS provider display name, such as `Azure DNS` or `Cloudflare`. Required. When `--dns-alias` is set, this provider must manage the DNS alias zone. |
 | `--key-type <type>` | Certificate key type. Valid values are `RSA` and `EC`. Defaults to `RSA`. |
 | `--key-size <size>` | RSA key size. Valid values are `2048`, `3072`, and `4096`. Defaults to `2048`. Valid only with `--key-type RSA`. |
 | `--key-curve <curve>` | EC key curve. Valid values are `P-256`, `P-384`, `P-521`, and `P-256K`. Defaults to `P-256`. Valid only with `--key-type EC`. |
 | `--reuse-key` | Reuse the existing Key Vault certificate key. |
-| `--dns-alias <value>` | DNS-01 validation alias. |
+| `--dns-alias <value>` | DNS-01 validation alias. Omit the `_acme-challenge` prefix. |
 | `--tag <name=value>` | Key Vault certificate tag. Repeatable. The `Acmebot` tag name is reserved. |
 | `--no-wait` | Return after the operation is accepted instead of polling until completion. |
 
 By default, `certificate issue` waits for the Durable Functions operation to complete and prints the operation instance ID. Use `--no-wait` for asynchronous scripts.
+
+For delegated DNS-01 validation, pass full certificate DNS names with `--dns-name`, pass a unique alias record with `--dns-alias`, and create CNAME records from `_acme-challenge.<dns-name>` to `_acme-challenge.<dns-alias>` before issuing.
 
 ### `certificate renew`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -139,7 +139,7 @@ acmebot certificate issue --dns-name "*.example.com" --dns-provider "Azure DNS"
 | Option | Description |
 | --- | --- |
 | `--dns-name <value>` | DNS name to include in the certificate. Required and repeatable. Duplicate names are removed case-insensitively. |
-| `--name <value>` | Key Vault certificate name. If omitted, Acmebot derives the name from the first DNS name. Only letters, numbers, and hyphens are allowed. |
+| `--name <value>` | Key Vault certificate name. If omitted, the CLI derives the name from the first DNS name before calling the API. Only letters, numbers, and hyphens are allowed. |
 | `--dns-provider <value>` | DNS provider display name, such as `Azure DNS` or `Cloudflare`. Required. When `--dns-alias` is set, this provider must manage the DNS alias zone. |
 | `--key-type <type>` | Certificate key type. Valid values are `RSA` and `EC`. Defaults to `RSA`. |
 | `--key-size <size>` | RSA key size. Valid values are `2048`, `3072`, and `4096`. Defaults to `2048`. Valid only with `--key-type RSA`. |

--- a/src/Acmebot.App/ClientApp/src/api/mockData.ts
+++ b/src/Acmebot.App/ClientApp/src/api/mockData.ts
@@ -154,7 +154,7 @@ let mockCertificates: CertificateItem[] = [
 const mockDnsZoneGroups: DnsZoneGroup[] = [
   {
     dnsProviderName: 'Azure DNS',
-    dnsZones: [{ name: 'example.com' }, { name: 'example.co.jp' }, { name: 'www.example.co.jp' }, { name: 'example.org' }, { name: 'fabrikam.net' }],
+    dnsZones: [{ name: 'example.com' }, { name: 'acme.example.com' }, { name: 'example.co.jp' }, { name: 'www.example.co.jp' }, { name: 'example.org' }, { name: 'fabrikam.net' }],
   },
   {
     dnsProviderName: 'Cloudflare',

--- a/src/Acmebot.App/ClientApp/src/api/mockData.ts
+++ b/src/Acmebot.App/ClientApp/src/api/mockData.ts
@@ -213,13 +213,12 @@ export async function getMockCertificateRenewals(): Promise<CertificateRenewalIt
 
 export async function mockIssueCertificate(policy: CertificatePolicyItem): Promise<void> {
   await delay(700);
-  const certificateName = policy.certificateName || policy.dnsNames[0].replaceAll('*', 'wildcard').replaceAll('.', '-');
 
   mockCertificates = [
     ...mockCertificates,
     {
-      id: `https://mock.vault/certificates/${certificateName}`,
-      name: certificateName,
+      id: `https://mock.vault/certificates/${policy.certificateName}`,
+      name: policy.certificateName,
       dnsNames: [...policy.dnsNames],
       dnsProviderName: policy.dnsProviderName,
       createdOn: new Date().toISOString(),

--- a/src/Acmebot.App/ClientApp/src/api/types.ts
+++ b/src/Acmebot.App/ClientApp/src/api/types.ts
@@ -37,7 +37,7 @@ export interface SelectableDnsZone extends DnsZoneItem {
 }
 
 export interface CertificatePolicyItem {
-  certificateName?: string;
+  certificateName: string;
   dnsNames: string[];
   dnsProviderName: string;
   keyType: KeyType;

--- a/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
@@ -4,7 +4,7 @@ import { CirclePlus, KeyRound, Plus, ShieldPlus, Tag, Trash2, X } from 'lucide-v
 
 import type { CertificatePolicyItem, DnsZoneGroup, KeyCurveName, KeyType, SelectableDnsZone } from '@/api/types';
 import { displayDnsName } from '@/utils/certificates';
-import { createDelegatedDnsAlias, validateOptionalDnsAlias } from '@/utils/dnsNames';
+import { createCertificateName, createDelegatedDnsAlias, validateOptionalDnsAlias } from '@/utils/dnsNames';
 
 import DelegatedDnsNameEditor from './DelegatedDnsNameEditor.vue';
 import ManagedDnsNameEditor from './ManagedDnsNameEditor.vue';
@@ -79,7 +79,10 @@ const form = reactive({
 
 const activeIssueMode = computed(() => issueModeOptions[form.issueMode]);
 const dnsNameEditorComponent = computed(() => activeIssueMode.value.editor);
-const certificateNameError = computed(() => (form.useAdvancedOptions ? validateCertificateName(form.certificateName) : ''));
+const customCertificateName = computed(() => form.certificateName.trim());
+const defaultCertificateName = computed(() => (form.dnsNames.length > 0 ? createCertificateName(form.dnsNames[0]) : ''));
+const effectiveCertificateName = computed(() => (form.useAdvancedOptions && customCertificateName.value ? customCertificateName.value : defaultCertificateName.value));
+const certificateNameError = computed(() => (effectiveCertificateName.value ? validateCertificateName(effectiveCertificateName.value) : ''));
 const keyOptionError = computed(() => validateKeyOptions());
 const tagValidation = computed(() => (form.useAdvancedOptions ? validateTags(form.tags) : { tags: {}, message: '' }));
 const tagError = computed(() => tagValidation.value.message);
@@ -289,13 +292,12 @@ function submit(): void {
     return;
   }
 
-  const certificateName = form.useAdvancedOptions ? form.certificateName.trim() : '';
   const dnsAlias = activeIssueMode.value.useGeneratedDnsAlias ? delegatedDnsAlias.value : dnsAliasValidation.value.value;
 
   const policy: CertificatePolicyItem = {
     dnsNames: form.dnsNames,
     dnsProviderName: form.dnsProviderName,
-    certificateName: certificateName || undefined,
+    certificateName: effectiveCertificateName.value,
     keyType: form.keyType,
     reuseKey: form.useAdvancedOptions ? form.reuseKey : false,
     dnsAlias: dnsAlias || undefined,
@@ -487,7 +489,7 @@ function submit(): void {
                 <input
                   v-model="form.certificateName"
                   type="text"
-                  placeholder="Optional certificate name"
+                  placeholder="Defaults to first DNS name"
                   :aria-invalid="certificateNameError ? 'true' : 'false'"
                 >
                 <span

--- a/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
@@ -4,7 +4,7 @@ import { CirclePlus, KeyRound, Plus, ShieldPlus, Tag, Trash2, X } from 'lucide-v
 
 import type { CertificatePolicyItem, DnsZoneGroup, KeyCurveName, KeyType, SelectableDnsZone } from '@/api/types';
 import { displayDnsName } from '@/utils/certificates';
-import { createDelegatedDnsAlias, readOptionalDnsAlias } from '@/utils/dnsNames';
+import { createDelegatedDnsAlias } from '@/utils/dnsNames';
 
 import DelegatedDnsNameEditor from './DelegatedDnsNameEditor.vue';
 import ManagedDnsNameEditor from './ManagedDnsNameEditor.vue';
@@ -77,12 +77,9 @@ const form = reactive({
   tags: [] as CertificateTagInput[],
 });
 
-const emptyValidation = { value: '', message: '' };
 const activeIssueMode = computed(() => issueModeOptions[form.issueMode]);
 const dnsNameEditorComponent = computed(() => activeIssueMode.value.editor);
 const certificateNameError = computed(() => (form.useAdvancedOptions ? validateCertificateName(form.certificateName) : ''));
-const dnsAliasValidation = computed(() => (form.useAdvancedOptions && activeIssueMode.value.showManualDnsAlias ? readOptionalDnsAlias(form.dnsAlias) : emptyValidation));
-const dnsAliasError = computed(() => dnsAliasValidation.value.message);
 const keyOptionError = computed(() => validateKeyOptions());
 const tagValidation = computed(() => (form.useAdvancedOptions ? validateTags(form.tags) : { tags: {}, message: '' }));
 const tagError = computed(() => tagValidation.value.message);
@@ -94,11 +91,7 @@ const submitValidationMessage = computed(() => {
     return 'Add at least one DNS name.';
   }
 
-  if (activeIssueMode.value.useGeneratedDnsAlias && !delegatedDnsAlias.value) {
-    return 'Select a DNS alias zone.';
-  }
-
-  return certificateNameError.value || dnsAliasError.value || keyOptionError.value || tagError.value;
+  return certificateNameError.value || keyOptionError.value || tagError.value;
 });
 const canSubmit = computed(() => !props.sending && submitValidationMessage.value === '');
 const keySummary = computed(() => (form.keyType === 'RSA' ? `${form.keySize} bit RSA` : `${form.keyCurveName} EC`));
@@ -295,7 +288,7 @@ function submit(): void {
   }
 
   const certificateName = form.useAdvancedOptions ? form.certificateName.trim() : '';
-  const dnsAlias = activeIssueMode.value.useGeneratedDnsAlias ? delegatedDnsAlias.value : dnsAliasValidation.value.value;
+  const dnsAlias = activeIssueMode.value.useGeneratedDnsAlias ? delegatedDnsAlias.value : form.dnsAlias;
 
   const policy: CertificatePolicyItem = {
     dnsNames: form.dnsNames,
@@ -544,19 +537,13 @@ function submit(): void {
               <label
                 v-if="activeIssueMode.showManualDnsAlias"
                 class="form-field"
-                :class="{ 'is-invalid': dnsAliasError }"
               >
                 <span class="form-label">DNS Alias</span>
                 <input
                   v-model="form.dnsAlias"
                   type="text"
                   placeholder="alias.example.com"
-                  :aria-invalid="dnsAliasError ? 'true' : 'false'"
                 >
-                <span
-                  v-if="dnsAliasError"
-                  class="form-error"
-                >{{ dnsAliasError }}</span>
               </label>
 
               <label class="toggle-row advanced-grid__toggle">

--- a/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
@@ -4,7 +4,7 @@ import { CirclePlus, KeyRound, Plus, ShieldPlus, Tag, Trash2, X } from 'lucide-v
 
 import type { CertificatePolicyItem, DnsZoneGroup, KeyCurveName, KeyType, SelectableDnsZone } from '@/api/types';
 import { displayDnsName } from '@/utils/certificates';
-import { createDelegatedDnsAlias } from '@/utils/dnsNames';
+import { createDelegatedDnsAlias, validateOptionalDnsAlias } from '@/utils/dnsNames';
 
 import DelegatedDnsNameEditor from './DelegatedDnsNameEditor.vue';
 import ManagedDnsNameEditor from './ManagedDnsNameEditor.vue';
@@ -86,12 +86,14 @@ const tagError = computed(() => tagValidation.value.message);
 const zoneLabel = computed(() => activeIssueMode.value.zoneLabel);
 const zoneStepLabel = computed(() => activeIssueMode.value.zoneStepLabel);
 const delegatedDnsAlias = computed(() => (activeIssueMode.value.useGeneratedDnsAlias && selectedZone.value ? createDelegatedDnsAlias(form.dnsNames, selectedZone.value) : ''));
+const dnsAliasValidation = computed(() => (form.useAdvancedOptions && activeIssueMode.value.showManualDnsAlias ? validateOptionalDnsAlias(form.dnsAlias) : { value: '', message: '' }));
+const dnsAliasError = computed(() => dnsAliasValidation.value.message);
 const submitValidationMessage = computed(() => {
   if (form.dnsNames.length === 0) {
     return 'Add at least one DNS name.';
   }
 
-  return certificateNameError.value || keyOptionError.value || tagError.value;
+  return certificateNameError.value || dnsAliasError.value || keyOptionError.value || tagError.value;
 });
 const canSubmit = computed(() => !props.sending && submitValidationMessage.value === '');
 const keySummary = computed(() => (form.keyType === 'RSA' ? `${form.keySize} bit RSA` : `${form.keyCurveName} EC`));
@@ -288,7 +290,7 @@ function submit(): void {
   }
 
   const certificateName = form.useAdvancedOptions ? form.certificateName.trim() : '';
-  const dnsAlias = activeIssueMode.value.useGeneratedDnsAlias ? delegatedDnsAlias.value : form.dnsAlias;
+  const dnsAlias = activeIssueMode.value.useGeneratedDnsAlias ? delegatedDnsAlias.value : dnsAliasValidation.value.value;
 
   const policy: CertificatePolicyItem = {
     dnsNames: form.dnsNames,
@@ -537,13 +539,19 @@ function submit(): void {
               <label
                 v-if="activeIssueMode.showManualDnsAlias"
                 class="form-field"
+                :class="{ 'is-invalid': dnsAliasError }"
               >
                 <span class="form-label">DNS Alias</span>
                 <input
                   v-model="form.dnsAlias"
                   type="text"
                   placeholder="alias.example.com"
+                  :aria-invalid="dnsAliasError ? 'true' : 'false'"
                 >
+                <span
+                  v-if="dnsAliasError"
+                  class="form-error"
+                >{{ dnsAliasError }}</span>
               </label>
 
               <label class="toggle-row advanced-grid__toggle">

--- a/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue';
 import { CirclePlus, KeyRound, Plus, ShieldPlus, Tag, Trash2, X } from 'lucide-vue-next';
-import { toASCII } from 'punycode/';
 
 import type { CertificatePolicyItem, DnsZoneGroup, KeyCurveName, KeyType, SelectableDnsZone } from '@/api/types';
 import { displayDnsName } from '@/utils/certificates';
+import { createDelegatedDnsAlias, readOptionalDnsAlias } from '@/utils/dnsNames';
 
+import DelegatedDnsNameEditor from './DelegatedDnsNameEditor.vue';
+import ManagedDnsNameEditor from './ManagedDnsNameEditor.vue';
 import SearchableZoneSelect from './SearchableZoneSelect.vue';
 
 const props = defineProps<{
@@ -21,11 +23,6 @@ const emit = defineEmits<{
   'load-zones': [];
 }>();
 
-interface ValidationOutcome {
-  value: string;
-  message: string;
-}
-
 interface CertificateTagInput {
   id: number;
   key: string;
@@ -37,17 +34,37 @@ interface TagValidationOutcome {
   message: string;
 }
 
+const issueModeOptions = {
+  managed: {
+    editor: ManagedDnsNameEditor,
+    zoneLabel: 'DNS Zone',
+    zoneStepLabel: 'Zone',
+    emptyStatusLabel: 'Select zone',
+    showManualDnsAlias: true,
+    useSelectedZoneProvider: false,
+    useGeneratedDnsAlias: false,
+  },
+  delegated: {
+    editor: DelegatedDnsNameEditor,
+    zoneLabel: 'DNS Alias Zone',
+    zoneStepLabel: 'Alias zone',
+    emptyStatusLabel: 'Select alias zone',
+    showManualDnsAlias: false,
+    useSelectedZoneProvider: true,
+    useGeneratedDnsAlias: true,
+  },
+} as const;
+
+type IssueMode = keyof typeof issueModeOptions;
+
 const selectedZone = ref<SelectableDnsZone | null>(null);
-const validationErrors = reactive({
-  dnsName: '',
-});
 let certificateTagId = 0;
 
 const validKeySizes = [2048, 3072, 4096];
 const validKeyCurves: KeyCurveName[] = ['P-256', 'P-384', 'P-521', 'P-256K'];
 
 const form = reactive({
-  recordName: '',
+  issueMode: 'managed' as IssueMode,
   dnsNames: [] as string[],
   dnsProviderName: '',
   useAdvancedOptions: false,
@@ -60,21 +77,30 @@ const form = reactive({
   tags: [] as CertificateTagInput[],
 });
 
+const emptyValidation = { value: '', message: '' };
+const activeIssueMode = computed(() => issueModeOptions[form.issueMode]);
+const dnsNameEditorComponent = computed(() => activeIssueMode.value.editor);
 const certificateNameError = computed(() => (form.useAdvancedOptions ? validateCertificateName(form.certificateName) : ''));
-const dnsAliasValidation = computed(() => (form.useAdvancedOptions ? validateOptionalDnsAlias(form.dnsAlias) : { value: '', message: '' }));
+const dnsAliasValidation = computed(() => (form.useAdvancedOptions && activeIssueMode.value.showManualDnsAlias ? readOptionalDnsAlias(form.dnsAlias) : emptyValidation));
 const dnsAliasError = computed(() => dnsAliasValidation.value.message);
 const keyOptionError = computed(() => validateKeyOptions());
 const tagValidation = computed(() => (form.useAdvancedOptions ? validateTags(form.tags) : { tags: {}, message: '' }));
 const tagError = computed(() => tagValidation.value.message);
+const zoneLabel = computed(() => activeIssueMode.value.zoneLabel);
+const zoneStepLabel = computed(() => activeIssueMode.value.zoneStepLabel);
+const delegatedDnsAlias = computed(() => (activeIssueMode.value.useGeneratedDnsAlias && selectedZone.value ? createDelegatedDnsAlias(form.dnsNames, selectedZone.value) : ''));
 const submitValidationMessage = computed(() => {
   if (form.dnsNames.length === 0) {
     return 'Add at least one DNS name.';
   }
 
+  if (activeIssueMode.value.useGeneratedDnsAlias && !delegatedDnsAlias.value) {
+    return 'Select a DNS alias zone.';
+  }
+
   return certificateNameError.value || dnsAliasError.value || keyOptionError.value || tagError.value;
 });
 const canSubmit = computed(() => !props.sending && submitValidationMessage.value === '');
-const fullDnsName = computed(() => (selectedZone.value ? validateRecordDnsName(form.recordName, selectedZone.value).value || null : null));
 const keySummary = computed(() => (form.keyType === 'RSA' ? `${form.keySize} bit RSA` : `${form.keyCurveName} EC`));
 const issueStatusLabel = computed(() => {
   if (form.dnsNames.length > 0) {
@@ -85,7 +111,7 @@ const issueStatusLabel = computed(() => {
     return 'Add DNS name';
   }
 
-  return 'Select zone';
+  return activeIssueMode.value.emptyStatusLabel;
 });
 const dnsNamesSummary = computed(() => {
   if (form.dnsNames.length === 0) {
@@ -115,6 +141,29 @@ watch(
 );
 
 watch(
+  () => form.issueMode,
+  () => {
+    form.dnsNames = [];
+    form.dnsProviderName = activeIssueMode.value.useSelectedZoneProvider && selectedZone.value ? selectedZone.value.dnsProviderName : '';
+
+    if (!activeIssueMode.value.showManualDnsAlias) {
+      form.dnsAlias = '';
+    }
+  },
+);
+
+watch(
+  selectedZone,
+  (zone) => {
+    if (activeIssueMode.value.useSelectedZoneProvider) {
+      form.dnsProviderName = zone?.dnsProviderName ?? '';
+    } else if (form.dnsNames.length === 0) {
+      form.dnsProviderName = '';
+    }
+  },
+);
+
+watch(
   () => form.useAdvancedOptions,
   (useAdvancedOptions) => {
     if (!useAdvancedOptions) {
@@ -131,8 +180,7 @@ watch(
 
 function resetForm(): void {
   selectedZone.value = null;
-  validationErrors.dnsName = '';
-  form.recordName = '';
+  form.issueMode = 'managed';
   form.dnsNames = [];
   form.dnsProviderName = '';
   form.useAdvancedOptions = false;
@@ -149,125 +197,22 @@ function createTagInput(): CertificateTagInput {
   return { id: ++certificateTagId, key: '', value: '' };
 }
 
-function normalizeRecordName(recordName: string): string {
-  return recordName.trim().replace(/\.+$/, '');
-}
-
-function toAsciiDnsName(value: string): string | null {
-  try {
-    return toASCII(value).toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
 function validateCertificateName(certificateName: string): string {
-  const normalizedCertificateName = certificateName.trim();
+  const trimmedCertificateName = certificateName.trim();
 
-  if (!normalizedCertificateName) {
+  if (!trimmedCertificateName) {
     return '';
   }
 
-  if (normalizedCertificateName.length > 127) {
+  if (trimmedCertificateName.length > 127) {
     return 'Certificate Name must be 127 characters or fewer.';
   }
 
-  if (!/^[0-9a-zA-Z-]+$/.test(normalizedCertificateName)) {
+  if (!/^[0-9a-zA-Z-]+$/.test(trimmedCertificateName)) {
     return 'Certificate Name can contain only letters, numbers, and hyphens.';
   }
 
   return '';
-}
-
-function validateDnsName(value: string, fieldLabel: string, allowWildcard: boolean): ValidationOutcome {
-  const normalizedInput = normalizeRecordName(value);
-
-  if (!normalizedInput) {
-    return { value: '', message: `${fieldLabel} is required.` };
-  }
-
-  const asciiName = toAsciiDnsName(normalizedInput);
-
-  if (!asciiName) {
-    return { value: '', message: `${fieldLabel} contains characters that cannot be converted to a DNS name.` };
-  }
-
-  if (asciiName.length > 253) {
-    return { value: '', message: `${fieldLabel} must be 253 characters or fewer.` };
-  }
-
-  const labels = asciiName.split('.');
-
-  if (labels.length < 2) {
-    return { value: '', message: `${fieldLabel} must include a domain suffix.` };
-  }
-
-  for (const [labelIndex, label] of labels.entries()) {
-    if (!label) {
-      return { value: '', message: `${fieldLabel} cannot contain empty DNS labels.` };
-    }
-
-    if (label.length > 63) {
-      return { value: '', message: 'Each DNS label must be 63 characters or fewer.' };
-    }
-
-    if (label === '*') {
-      if (!allowWildcard) {
-        return { value: '', message: `${fieldLabel} cannot be a wildcard.` };
-      }
-
-      if (labelIndex !== 0) {
-        return { value: '', message: 'A wildcard can only be the leftmost DNS label.' };
-      }
-
-      continue;
-    }
-
-    if (label.includes('*') || !/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label)) {
-      return { value: '', message: `${fieldLabel} can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.` };
-    }
-  }
-
-  return { value: asciiName, message: '' };
-}
-
-function validateOptionalDnsAlias(dnsAlias: string): ValidationOutcome {
-  if (!dnsAlias.trim()) {
-    return { value: '', message: '' };
-  }
-
-  return validateDnsName(dnsAlias, 'DNS Alias', false);
-}
-
-function validateRecordDnsName(recordName: string, zone: SelectableDnsZone): ValidationOutcome {
-  const zoneValidation = validateDnsName(zone.name, 'DNS zone', false);
-
-  if (zoneValidation.message) {
-    return zoneValidation;
-  }
-
-  const normalizedRecordName = normalizeRecordName(recordName);
-  let candidateDnsName: string;
-
-  if (!normalizedRecordName || normalizedRecordName === '@') {
-    candidateDnsName = zoneValidation.value;
-  } else {
-    const asciiRecordName = toAsciiDnsName(normalizedRecordName);
-
-    if (!asciiRecordName) {
-      return { value: '', message: 'DNS Name contains characters that cannot be converted to a DNS name.' };
-    }
-
-    if (asciiRecordName === zoneValidation.value) {
-      candidateDnsName = zoneValidation.value;
-    } else if (asciiRecordName.endsWith(`.${zoneValidation.value}`)) {
-      candidateDnsName = asciiRecordName;
-    } else {
-      candidateDnsName = `${asciiRecordName}.${zoneValidation.value}`;
-    }
-  }
-
-  return validateDnsName(candidateDnsName, 'DNS Name', true);
 }
 
 function validateKeyOptions(): string {
@@ -302,13 +247,13 @@ function validateTags(items: CertificateTagInput[]): TagValidationOutcome {
       return { tags: {}, message: 'The Acmebot tag is managed by Acmebot.' };
     }
 
-    const normalizedKey = key.toLowerCase();
+    const tagKey = key.toLowerCase();
 
-    if (seenKeys.has(normalizedKey)) {
+    if (seenKeys.has(tagKey)) {
       return { tags: {}, message: 'Tag names must be unique.' };
     }
 
-    seenKeys.add(normalizedKey);
+    seenKeys.add(tagKey);
     tags[key] = value;
   }
 
@@ -327,52 +272,21 @@ function removeTag(id: number): void {
   form.tags = form.tags.filter((tag) => tag.id !== id);
 }
 
-function clearDnsNameError(): void {
-  validationErrors.dnsName = '';
-}
-
-function addDnsName(): void {
-  validationErrors.dnsName = '';
-
-  if (!selectedZone.value) {
-    validationErrors.dnsName = 'Select a DNS zone before adding a DNS name.';
-    return;
-  }
-
-  if (form.dnsProviderName && form.dnsProviderName !== selectedZone.value.dnsProviderName) {
-    validationErrors.dnsName = 'DNS names in one certificate must use the same DNS provider.';
-    return;
-  }
-
-  const dnsNameValidation = validateRecordDnsName(form.recordName, selectedZone.value);
-
-  if (dnsNameValidation.message) {
-    validationErrors.dnsName = dnsNameValidation.message;
-    return;
-  }
-
-  if (form.dnsNames.some((dnsName) => dnsName.toLowerCase() === dnsNameValidation.value)) {
-    validationErrors.dnsName = 'This DNS name is already in the certificate.';
-    return;
-  }
-
-  form.dnsNames.push(dnsNameValidation.value);
-  form.dnsProviderName = selectedZone.value.dnsProviderName;
-  form.recordName = '';
+function addDnsName(dnsName: string, dnsProviderName: string): void {
+  form.dnsNames.push(dnsName);
+  form.dnsProviderName = dnsProviderName;
 }
 
 function removeDnsName(dnsName: string): void {
   form.dnsNames = form.dnsNames.filter((candidate) => candidate !== dnsName);
 
   if (form.dnsNames.length === 0) {
-    form.dnsProviderName = '';
-    validationErrors.dnsName = '';
+    form.dnsProviderName = activeIssueMode.value.useSelectedZoneProvider && selectedZone.value ? selectedZone.value.dnsProviderName : '';
   }
 }
 
 function submit(): void {
   if (form.dnsNames.length === 0) {
-    validationErrors.dnsName = 'Add at least one DNS name before issuing the certificate.';
     return;
   }
 
@@ -380,16 +294,16 @@ function submit(): void {
     return;
   }
 
-  const normalizedCertificateName = form.useAdvancedOptions ? form.certificateName.trim() : '';
-  const normalizedDnsAlias = form.useAdvancedOptions ? dnsAliasValidation.value.value : '';
+  const certificateName = form.useAdvancedOptions ? form.certificateName.trim() : '';
+  const dnsAlias = activeIssueMode.value.useGeneratedDnsAlias ? delegatedDnsAlias.value : dnsAliasValidation.value.value;
 
   const policy: CertificatePolicyItem = {
     dnsNames: form.dnsNames,
     dnsProviderName: form.dnsProviderName,
-    certificateName: normalizedCertificateName || undefined,
+    certificateName: certificateName || undefined,
     keyType: form.keyType,
     reuseKey: form.useAdvancedOptions ? form.reuseKey : false,
-    dnsAlias: normalizedDnsAlias || undefined,
+    dnsAlias: dnsAlias || undefined,
   };
 
   if (form.keyType === 'RSA') {
@@ -464,7 +378,7 @@ function submit(): void {
                 aria-hidden="true"
               />
               <div class="setup-step__body">
-                <span>Zone</span>
+                <span>{{ zoneStepLabel }}</span>
                 <strong>{{ selectedZone ? displayDnsName(selectedZone.name) : 'Not selected' }}</strong>
                 <small v-if="selectedZone">{{ selectedZone.dnsProviderName }}</small>
               </div>
@@ -515,7 +429,31 @@ function submit(): void {
 
           <div class="wizard-body">
             <div class="form-section">
-              <label class="form-label">DNS Zone</label>
+              <span class="form-label">Issue Mode</span>
+              <div
+                class="segmented-control issue-mode-control"
+                role="group"
+                aria-label="Issue mode"
+              >
+                <button
+                  type="button"
+                  :class="{ 'is-selected': form.issueMode === 'managed' }"
+                  @click="form.issueMode = 'managed'"
+                >
+                  Managed zone
+                </button>
+                <button
+                  type="button"
+                  :class="{ 'is-selected': form.issueMode === 'delegated' }"
+                  @click="form.issueMode = 'delegated'"
+                >
+                  Delegated DNS-01
+                </button>
+              </div>
+            </div>
+
+            <div class="form-section">
+              <label class="form-label">{{ zoneLabel }}</label>
               <SearchableZoneSelect
                 v-model:selected="selectedZone"
                 :groups="zones"
@@ -523,69 +461,14 @@ function submit(): void {
               />
             </div>
 
-            <div class="form-section">
-              <label
-                class="form-label"
-                for="record-name"
-              >DNS Name</label>
-              <div class="compound-input">
-                <input
-                  id="record-name"
-                  v-model="form.recordName"
-                  type="text"
-                  placeholder="@, www, api, *"
-                  :disabled="!selectedZone"
-                  :aria-invalid="validationErrors.dnsName ? 'true' : 'false'"
-                  @keydown.enter.prevent="addDnsName"
-                  @input="clearDnsNameError"
-                >
-                <span class="compound-input__suffix">.{{ selectedZone ? displayDnsName(selectedZone.name) : 'zone' }}</span>
-                <button
-                  class="icon-button"
-                  type="button"
-                  :disabled="!selectedZone"
-                  @click="addDnsName"
-                >
-                  <Plus
-                    :size="16"
-                    aria-hidden="true"
-                  />
-                  <span>Add</span>
-                </button>
-              </div>
-              <div
-                v-if="fullDnsName"
-                class="form-result"
-              >
-                <span>Full DNS name</span>
-                <strong>{{ displayDnsName(fullDnsName) }}</strong>
-              </div>
-              <p
-                v-if="validationErrors.dnsName"
-                class="form-error"
-              >
-                {{ validationErrors.dnsName }}
-              </p>
-              <div class="dns-list dns-list--editable">
-                <span
-                  v-for="dnsName in form.dnsNames"
-                  :key="dnsName"
-                  class="dns-chip dns-chip--removable"
-                >
-                  {{ displayDnsName(dnsName) }}
-                  <button
-                    type="button"
-                    title="Remove DNS name"
-                    @click="removeDnsName(dnsName)"
-                  >
-                    <Trash2
-                      :size="13"
-                      aria-hidden="true"
-                    />
-                  </button>
-                </span>
-              </div>
-            </div>
+            <component
+              :is="dnsNameEditorComponent"
+              :selected-zone="selectedZone"
+              :dns-names="form.dnsNames"
+              :dns-provider-name="form.dnsProviderName"
+              @add-dns-name="addDnsName"
+              @remove-dns-name="removeDnsName"
+            />
 
             <div class="form-section form-section--inline">
               <label class="toggle-row">
@@ -659,6 +542,7 @@ function submit(): void {
               </label>
 
               <label
+                v-if="activeIssueMode.showManualDnsAlias"
                 class="form-field"
                 :class="{ 'is-invalid': dnsAliasError }"
               >

--- a/src/Acmebot.App/ClientApp/src/components/DelegatedDnsNameEditor.vue
+++ b/src/Acmebot.App/ClientApp/src/components/DelegatedDnsNameEditor.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { Plus, Trash2 } from 'lucide-vue-next';
+
+import type { SelectableDnsZone } from '@/api/types';
+import { displayDnsName } from '@/utils/certificates';
+import { createDelegatedCnameInstructions, createDelegatedDnsAlias, readDnsNameInput } from '@/utils/dnsNames';
+
+const props = defineProps<{
+  selectedZone: SelectableDnsZone | null;
+  dnsNames: string[];
+  dnsProviderName: string;
+}>();
+
+const emit = defineEmits<{
+  'add-dns-name': [dnsName: string, dnsProviderName: string];
+  'remove-dns-name': [dnsName: string];
+}>();
+
+const recordName = ref('');
+const dnsNameError = ref('');
+
+const requestedDnsName = computed(() => readDnsNameInput(recordName.value, 'DNS Name').value || null);
+const delegatedDnsAlias = computed(() => (props.selectedZone ? createDelegatedDnsAlias(props.dnsNames, props.selectedZone) : ''));
+const delegatedCnameInstructions = computed(() => createDelegatedCnameInstructions(props.dnsNames, delegatedDnsAlias.value));
+
+watch(
+  () => props.selectedZone,
+  () => {
+    dnsNameError.value = '';
+  },
+);
+
+function clearDnsNameError(): void {
+  dnsNameError.value = '';
+}
+
+function addDnsName(): void {
+  dnsNameError.value = '';
+
+  if (!props.selectedZone) {
+    dnsNameError.value = 'Select a DNS alias zone before adding a DNS name.';
+    return;
+  }
+
+  const dnsNameValidation = readDnsNameInput(recordName.value, 'DNS Name');
+
+  if (dnsNameValidation.message) {
+    dnsNameError.value = dnsNameValidation.message;
+    return;
+  }
+
+  if (props.dnsNames.some((dnsName) => dnsName.toLowerCase() === dnsNameValidation.value.toLowerCase())) {
+    dnsNameError.value = 'This DNS name is already in the certificate.';
+    return;
+  }
+
+  emit('add-dns-name', dnsNameValidation.value, props.selectedZone.dnsProviderName);
+  recordName.value = '';
+}
+</script>
+
+<template>
+  <div class="form-section">
+    <label
+      class="form-label"
+      for="delegated-record-name"
+    >DNS Name</label>
+    <div class="compound-input compound-input--plain">
+      <input
+        id="delegated-record-name"
+        v-model="recordName"
+        type="text"
+        placeholder="www.example.com, *.example.com"
+        :disabled="!selectedZone"
+        :aria-invalid="dnsNameError ? 'true' : 'false'"
+        @keydown.enter.prevent="addDnsName"
+        @input="clearDnsNameError"
+      >
+      <button
+        class="icon-button"
+        type="button"
+        :disabled="!selectedZone"
+        @click="addDnsName"
+      >
+        <Plus
+          :size="16"
+          aria-hidden="true"
+        />
+        <span>Add</span>
+      </button>
+    </div>
+    <div
+      v-if="requestedDnsName"
+      class="form-result"
+    >
+      <span>Requested DNS name</span>
+      <strong>{{ displayDnsName(requestedDnsName) }}</strong>
+    </div>
+    <p
+      v-if="dnsNameError"
+      class="form-error"
+    >
+      {{ dnsNameError }}
+    </p>
+    <div class="dns-list dns-list--editable">
+      <span
+        v-for="dnsName in dnsNames"
+        :key="dnsName"
+        class="dns-chip dns-chip--removable"
+      >
+        {{ displayDnsName(dnsName) }}
+        <button
+          type="button"
+          title="Remove DNS name"
+          @click="emit('remove-dns-name', dnsName)"
+        >
+          <Trash2
+            :size="13"
+            aria-hidden="true"
+          />
+        </button>
+      </span>
+    </div>
+    <div
+      v-if="delegatedDnsAlias"
+      class="delegated-alias"
+    >
+      <div class="form-result">
+        <span>DNS alias</span>
+        <strong>{{ displayDnsName(delegatedDnsAlias) }}</strong>
+      </div>
+      <div class="cname-list">
+        <div
+          v-for="instruction in delegatedCnameInstructions"
+          :key="instruction.source"
+          class="cname-row"
+        >
+          <span>{{ displayDnsName(instruction.source) }}</span>
+          <strong>{{ displayDnsName(instruction.target) }}</strong>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/Acmebot.App/ClientApp/src/components/ManagedDnsNameEditor.vue
+++ b/src/Acmebot.App/ClientApp/src/components/ManagedDnsNameEditor.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { Plus, Trash2 } from 'lucide-vue-next';
+
+import type { SelectableDnsZone } from '@/api/types';
+import { displayDnsName } from '@/utils/certificates';
+import { createManagedDnsName, readDnsNameInput } from '@/utils/dnsNames';
+
+const props = defineProps<{
+  selectedZone: SelectableDnsZone | null;
+  dnsNames: string[];
+  dnsProviderName: string;
+}>();
+
+const emit = defineEmits<{
+  'add-dns-name': [dnsName: string, dnsProviderName: string];
+  'remove-dns-name': [dnsName: string];
+}>();
+
+const recordName = ref('');
+const dnsNameError = ref('');
+
+const fullDnsName = computed(() => (props.selectedZone ? createManagedDnsName(recordName.value, props.selectedZone) || null : null));
+
+watch(
+  () => props.selectedZone,
+  () => {
+    dnsNameError.value = '';
+  },
+);
+
+function clearDnsNameError(): void {
+  dnsNameError.value = '';
+}
+
+function addDnsName(): void {
+  dnsNameError.value = '';
+
+  if (!props.selectedZone) {
+    dnsNameError.value = 'Select a DNS zone before adding a DNS name.';
+    return;
+  }
+
+  if (props.dnsProviderName && props.dnsProviderName !== props.selectedZone.dnsProviderName) {
+    dnsNameError.value = 'DNS names in one certificate must use the same DNS provider.';
+    return;
+  }
+
+  const dnsNameValidation = readDnsNameInput(createManagedDnsName(recordName.value, props.selectedZone), 'DNS Name');
+
+  if (dnsNameValidation.message) {
+    dnsNameError.value = dnsNameValidation.message;
+    return;
+  }
+
+  if (props.dnsNames.some((dnsName) => dnsName.toLowerCase() === dnsNameValidation.value.toLowerCase())) {
+    dnsNameError.value = 'This DNS name is already in the certificate.';
+    return;
+  }
+
+  emit('add-dns-name', dnsNameValidation.value, props.selectedZone.dnsProviderName);
+  recordName.value = '';
+}
+</script>
+
+<template>
+  <div class="form-section">
+    <label
+      class="form-label"
+      for="managed-record-name"
+    >DNS Name</label>
+    <div class="compound-input">
+      <input
+        id="managed-record-name"
+        v-model="recordName"
+        type="text"
+        placeholder="@, www, api, *"
+        :disabled="!selectedZone"
+        :aria-invalid="dnsNameError ? 'true' : 'false'"
+        @keydown.enter.prevent="addDnsName"
+        @input="clearDnsNameError"
+      >
+      <span class="compound-input__suffix">.{{ selectedZone ? displayDnsName(selectedZone.name) : 'zone' }}</span>
+      <button
+        class="icon-button"
+        type="button"
+        :disabled="!selectedZone"
+        @click="addDnsName"
+      >
+        <Plus
+          :size="16"
+          aria-hidden="true"
+        />
+        <span>Add</span>
+      </button>
+    </div>
+    <div
+      v-if="fullDnsName"
+      class="form-result"
+    >
+      <span>Full DNS name</span>
+      <strong>{{ displayDnsName(fullDnsName) }}</strong>
+    </div>
+    <p
+      v-if="dnsNameError"
+      class="form-error"
+    >
+      {{ dnsNameError }}
+    </p>
+    <div class="dns-list dns-list--editable">
+      <span
+        v-for="dnsName in dnsNames"
+        :key="dnsName"
+        class="dns-chip dns-chip--removable"
+      >
+        {{ displayDnsName(dnsName) }}
+        <button
+          type="button"
+          title="Remove DNS name"
+          @click="emit('remove-dns-name', dnsName)"
+        >
+          <Trash2
+            :size="13"
+            aria-hidden="true"
+          />
+        </button>
+      </span>
+    </div>
+  </div>
+</template>

--- a/src/Acmebot.App/ClientApp/src/styles/app.css
+++ b/src/Acmebot.App/ClientApp/src/styles/app.css
@@ -463,6 +463,14 @@ button:disabled {
   color: var(--color-accent);
 }
 
+.issue-mode-control {
+  width: 100%;
+}
+
+.issue-mode-control button {
+  flex: 1 1 0;
+}
+
 .table-wrap {
   overflow-x: auto;
 }
@@ -1185,6 +1193,11 @@ button:disabled {
   padding: 0 10px;
 }
 
+.compound-input--plain input {
+  border-right: 1px solid var(--color-border);
+  border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+}
+
 .compound-input__suffix {
   min-height: 38px;
   max-width: 260px;
@@ -1226,6 +1239,46 @@ button:disabled {
   min-width: 0;
   overflow-wrap: anywhere;
   font-size: 0.86rem;
+}
+
+.delegated-alias {
+  margin-top: 10px;
+  display: grid;
+  gap: 8px;
+}
+
+.cname-list {
+  display: grid;
+  gap: 6px;
+}
+
+.cname-row {
+  min-width: 0;
+  min-height: 34px;
+  padding: 7px 8px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+}
+
+.cname-row span,
+.cname-row strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: 0.8rem;
+}
+
+.cname-row span {
+  color: var(--color-muted);
+  font-weight: 650;
+}
+
+.cname-row strong {
+  font-weight: 750;
 }
 
 .toggle-row {
@@ -1690,6 +1743,11 @@ button:disabled {
     max-width: none;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
+  }
+
+  .cname-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
   }
 
   .advanced-grid,

--- a/src/Acmebot.App/ClientApp/src/utils/dnsNames.ts
+++ b/src/Acmebot.App/ClientApp/src/utils/dnsNames.ts
@@ -88,7 +88,11 @@ function validateDnsName(value: string, fieldLabel: string, allowWildcard: boole
     }
 
     if (label.includes('*') || !/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label)) {
-      return { value: '', message: `${fieldLabel} can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.` };
+      const message = allowWildcard
+        ? `${fieldLabel} can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.`
+        : `${fieldLabel} can contain only letters, numbers, hyphens, and dots.`;
+
+      return { value: '', message };
     }
   }
 

--- a/src/Acmebot.App/ClientApp/src/utils/dnsNames.ts
+++ b/src/Acmebot.App/ClientApp/src/utils/dnsNames.ts
@@ -20,10 +20,6 @@ export function readDnsNameInput(value: string, fieldLabel: string): ValidationO
   return { value: dnsName, message: '' };
 }
 
-export function readOptionalDnsAlias(dnsAlias: string): ValidationOutcome {
-  return { value: dnsAlias.trim(), message: '' };
-}
-
 export function createManagedDnsName(recordName: string, zone: SelectableDnsZone): string {
   const record = recordName.trim();
   const zoneName = zone.name.trim();

--- a/src/Acmebot.App/ClientApp/src/utils/dnsNames.ts
+++ b/src/Acmebot.App/ClientApp/src/utils/dnsNames.ts
@@ -1,3 +1,5 @@
+import { toASCII } from 'punycode/';
+
 import type { SelectableDnsZone } from '@/api/types';
 
 export interface ValidationOutcome {
@@ -11,24 +13,100 @@ export interface CnameInstruction {
 }
 
 export function readDnsNameInput(value: string, fieldLabel: string): ValidationOutcome {
-  const dnsName = value.trim();
+  return validateDnsName(value, fieldLabel, true);
+}
 
-  if (!dnsName) {
-    return { value: '', message: `${fieldLabel} is required.` };
+export function validateOptionalDnsAlias(dnsAlias: string): ValidationOutcome {
+  if (!dnsAlias.trim()) {
+    return { value: '', message: '' };
   }
 
-  return { value: dnsName, message: '' };
+  return validateDnsName(dnsAlias, 'DNS Alias', false);
 }
 
 export function createManagedDnsName(recordName: string, zone: SelectableDnsZone): string {
-  const record = recordName.trim();
-  const zoneName = zone.name.trim();
+  const zoneName = toAsciiDnsName(zone.name);
+  const record = toAsciiDnsName(recordName);
 
   if (!record || record === '@') {
     return zoneName;
   }
 
+  if (record === zoneName || record.endsWith(`.${zoneName}`)) {
+    return record;
+  }
+
   return `${record}.${zoneName}`;
+}
+
+function validateDnsName(value: string, fieldLabel: string, allowWildcard: boolean): ValidationOutcome {
+  const input = value.trim().replace(/\.+$/, '');
+
+  if (!input) {
+    return { value: '', message: `${fieldLabel} is required.` };
+  }
+
+  const asciiName = toAsciiOrNull(input);
+
+  if (asciiName === null) {
+    return { value: '', message: `${fieldLabel} contains characters that cannot be converted to a DNS name.` };
+  }
+
+  if (asciiName.length > 253) {
+    return { value: '', message: `${fieldLabel} must be 253 characters or fewer.` };
+  }
+
+  const labels = asciiName.split('.');
+
+  if (labels.length < 2) {
+    return { value: '', message: `${fieldLabel} must include a domain suffix.` };
+  }
+
+  for (const [labelIndex, label] of labels.entries()) {
+    if (!label) {
+      return { value: '', message: `${fieldLabel} cannot contain empty DNS labels.` };
+    }
+
+    if (label.length > 63) {
+      return { value: '', message: 'Each DNS label must be 63 characters or fewer.' };
+    }
+
+    if (label === '*') {
+      if (!allowWildcard) {
+        return { value: '', message: `${fieldLabel} cannot be a wildcard.` };
+      }
+
+      if (labelIndex !== 0) {
+        return { value: '', message: 'A wildcard can only be the leftmost DNS label.' };
+      }
+
+      continue;
+    }
+
+    if (label.includes('*') || !/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label)) {
+      return { value: '', message: `${fieldLabel} can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.` };
+    }
+  }
+
+  return { value: asciiName, message: '' };
+}
+
+function toAsciiDnsName(value: string): string {
+  const normalized = value.trim().replace(/\.+$/, '');
+
+  try {
+    return toASCII(normalized).toLowerCase();
+  } catch {
+    return normalized.toLowerCase();
+  }
+}
+
+function toAsciiOrNull(value: string): string | null {
+  try {
+    return toASCII(value).toLowerCase();
+  } catch {
+    return null;
+  }
 }
 
 export function createDelegatedDnsAlias(dnsNames: string[], zone: SelectableDnsZone): string {

--- a/src/Acmebot.App/ClientApp/src/utils/dnsNames.ts
+++ b/src/Acmebot.App/ClientApp/src/utils/dnsNames.ts
@@ -1,0 +1,92 @@
+import type { SelectableDnsZone } from '@/api/types';
+
+export interface ValidationOutcome {
+  value: string;
+  message: string;
+}
+
+export interface CnameInstruction {
+  source: string;
+  target: string;
+}
+
+export function readDnsNameInput(value: string, fieldLabel: string): ValidationOutcome {
+  const dnsName = value.trim();
+
+  if (!dnsName) {
+    return { value: '', message: `${fieldLabel} is required.` };
+  }
+
+  return { value: dnsName, message: '' };
+}
+
+export function readOptionalDnsAlias(dnsAlias: string): ValidationOutcome {
+  return { value: dnsAlias.trim(), message: '' };
+}
+
+export function createManagedDnsName(recordName: string, zone: SelectableDnsZone): string {
+  const record = recordName.trim();
+  const zoneName = zone.name.trim();
+
+  if (!record || record === '@') {
+    return zoneName;
+  }
+
+  return `${record}.${zoneName}`;
+}
+
+export function createDelegatedDnsAlias(dnsNames: string[], zone: SelectableDnsZone): string {
+  if (dnsNames.length === 0) {
+    return '';
+  }
+
+  const zoneName = zone.name.trim();
+
+  if (!zoneName) {
+    return '';
+  }
+
+  return `${createAliasRecordName(dnsNames)}.${zoneName}`;
+}
+
+export function createDelegatedCnameInstructions(dnsNames: string[], dnsAlias: string): CnameInstruction[] {
+  if (!dnsAlias) {
+    return [];
+  }
+
+  const target = `_acme-challenge.${dnsAlias}`;
+
+  return dnsNames.map((dnsName) => ({
+    source: createChallengeRecordName(dnsName),
+    target,
+  }));
+}
+
+function hashDnsNames(dnsNames: string[]): string {
+  const value = [...dnsNames].sort((left, right) => left.localeCompare(right)).join(',');
+  let hash = 0x811c9dc5;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+
+  return hash.toString(16).padStart(8, '0');
+}
+
+function createAliasRecordName(dnsNames: string[]): string {
+  const firstDnsName = dnsNames[0]?.replace(/^\*\./, 'wildcard.') ?? 'certificate';
+  const hash = hashDnsNames(dnsNames);
+  const stem = firstDnsName
+    .toLowerCase()
+    .replaceAll('*', 'wildcard')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'certificate';
+  const maxStemLength = 63 - hash.length - 1;
+
+  return `${stem.slice(0, maxStemLength).replace(/-+$/g, '') || 'certificate'}-${hash}`;
+}
+
+function createChallengeRecordName(dnsName: string): string {
+  return `_acme-challenge.${dnsName.replace(/^\*\./, '')}`;
+}

--- a/src/Acmebot.App/ClientApp/src/utils/dnsNames.ts
+++ b/src/Acmebot.App/ClientApp/src/utils/dnsNames.ts
@@ -39,6 +39,10 @@ export function createManagedDnsName(recordName: string, zone: SelectableDnsZone
   return `${record}.${zoneName}`;
 }
 
+export function createCertificateName(dnsName: string): string {
+  return dnsName.replaceAll('*', 'wildcard').replaceAll('.', '-');
+}
+
 function validateDnsName(value: string, fieldLabel: string, allowWildcard: boolean): ValidationOutcome {
   const input = value.trim().replace(/\.+$/, '');
 
@@ -114,7 +118,7 @@ export function createDelegatedDnsAlias(dnsNames: string[], zone: SelectableDnsZ
     return '';
   }
 
-  const zoneName = zone.name.trim();
+  const zoneName = toAsciiDnsName(zone.name);
 
   if (!zoneName) {
     return '';

--- a/src/Acmebot.App/Functions/Http/AddCertificate.cs
+++ b/src/Acmebot.App/Functions/Http/AddCertificate.cs
@@ -37,11 +37,6 @@ public partial class AddCertificate(IHttpContextAccessor httpContextAccessor, Ap
             return ValidationProblem(ModelState);
         }
 
-        if (string.IsNullOrEmpty(certificatePolicyItem.CertificateName))
-        {
-            certificatePolicyItem.CertificateName = certificatePolicyItem.DnsNames[0].Replace("*", "wildcard").Replace(".", "-");
-        }
-
         // Function input comes from the request content.
         var instanceId = await starter.ScheduleNewOrchestrationInstanceAsync(nameof(CertificateIssuanceOrchestrator.IssueCertificate), certificatePolicyItem);
 

--- a/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
@@ -14,11 +14,6 @@ public partial class CertificateIssuanceOrchestrator
     {
         var logger = context.CreateReplaySafeLogger<CertificateIssuanceOrchestrator>();
 
-        if (string.IsNullOrEmpty(certificatePolicyItem.CertificateName))
-        {
-            return;
-        }
-
         LogCertificateIssuanceStarted(logger, certificatePolicyItem.CertificateName, string.Join(",", certificatePolicyItem.DnsNames));
 
         try

--- a/src/Acmebot.App/Models/CertificatePolicyItem.cs
+++ b/src/Acmebot.App/Models/CertificatePolicyItem.cs
@@ -1,10 +1,14 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 
 namespace Acmebot.App.Models;
 
-public class CertificatePolicyItem : IValidatableObject
+public partial class CertificatePolicyItem : IValidatableObject
 {
+    private static readonly IdnMapping s_idnMapping = new();
+
     [JsonPropertyName("certificateName")]
     [RegularExpression("^[0-9A-Za-z-]{1,127}$")]
     public string? CertificateName { get; set; }
@@ -52,6 +56,16 @@ public class CertificatePolicyItem : IValidatableObject
             yield return new ValidationResult($"The {nameof(DnsProviderName)} is required.", [nameof(DnsProviderName)]);
         }
 
+        foreach (var result in ValidateDnsNames())
+        {
+            yield return result;
+        }
+
+        foreach (var result in ValidateDnsAlias())
+        {
+            yield return result;
+        }
+
         foreach (var result in ValidateKeyOptions())
         {
             yield return result;
@@ -62,6 +76,117 @@ public class CertificatePolicyItem : IValidatableObject
             yield return result;
         }
     }
+
+    private IEnumerable<ValidationResult> ValidateDnsNames()
+    {
+        if (DnsNames is not { Length: > 0 })
+        {
+            yield break;
+        }
+
+        foreach (var dnsName in DnsNames)
+        {
+            var message = ValidateDnsName(dnsName, nameof(DnsNames), allowWildcard: true);
+
+            if (message is not null)
+            {
+                yield return new ValidationResult(message, [nameof(DnsNames)]);
+            }
+        }
+    }
+
+    private IEnumerable<ValidationResult> ValidateDnsAlias()
+    {
+        if (string.IsNullOrWhiteSpace(DnsAlias))
+        {
+            yield break;
+        }
+
+        var message = ValidateDnsName(DnsAlias, nameof(DnsAlias), allowWildcard: false);
+
+        if (message is not null)
+        {
+            yield return new ValidationResult(message, [nameof(DnsAlias)]);
+        }
+    }
+
+    private static string? ValidateDnsName(string value, string fieldName, bool allowWildcard)
+    {
+        var input = value.Trim().TrimEnd('.');
+
+        if (input.Length == 0)
+        {
+            return $"The {fieldName} contains an empty DNS name.";
+        }
+
+        var rawLabels = input.Split('.');
+
+        if (rawLabels.Length < 2)
+        {
+            return $"The {fieldName} must include a domain suffix.";
+        }
+
+        var asciiLabels = new string[rawLabels.Length];
+
+        for (var labelIndex = 0; labelIndex < rawLabels.Length; labelIndex++)
+        {
+            var rawLabel = rawLabels[labelIndex];
+
+            if (rawLabel.Length == 0)
+            {
+                return $"The {fieldName} cannot contain empty DNS labels.";
+            }
+
+            if (rawLabel == "*")
+            {
+                if (!allowWildcard)
+                {
+                    return $"The {fieldName} cannot be a wildcard.";
+                }
+
+                if (labelIndex != 0)
+                {
+                    return "A wildcard can only be the leftmost DNS label.";
+                }
+
+                asciiLabels[labelIndex] = rawLabel;
+                continue;
+            }
+
+            string asciiLabel;
+
+            try
+            {
+                asciiLabel = s_idnMapping.GetAscii(rawLabel).ToLowerInvariant();
+            }
+            catch (ArgumentException)
+            {
+                return $"The {fieldName} contains characters that cannot be converted to a DNS name.";
+            }
+
+            if (asciiLabel.Length > 63)
+            {
+                return "Each DNS label must be 63 characters or fewer.";
+            }
+
+            if (asciiLabel.Contains('*') || !DnsLabelRegex().IsMatch(asciiLabel))
+            {
+                return $"The {fieldName} can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.";
+            }
+
+            asciiLabels[labelIndex] = asciiLabel;
+        }
+
+        if (string.Join('.', asciiLabels).Length > 253)
+        {
+            return $"The {fieldName} must be 253 characters or fewer.";
+        }
+
+        return null;
+    }
+
+    [GeneratedRegex("^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")]
+    private static partial Regex DnsLabelRegex();
 
     private IEnumerable<ValidationResult> ValidateKeyOptions()
     {

--- a/src/Acmebot.App/Models/CertificatePolicyItem.cs
+++ b/src/Acmebot.App/Models/CertificatePolicyItem.cs
@@ -178,7 +178,9 @@ public partial class CertificatePolicyItem : IValidatableObject
 
             if (rawLabel.Contains('*') || !DnsLabelRegex().IsMatch(rawLabel))
             {
-                return $"The {fieldName} must be an ASCII DNS name containing only letters, numbers, hyphens, dots, and a leftmost wildcard.";
+                return allowWildcard
+                    ? $"The {fieldName} must be an ASCII DNS name containing only letters, numbers, hyphens, dots, and a leftmost wildcard."
+                    : $"The {fieldName} must be an ASCII DNS name containing only letters, numbers, hyphens, and dots.";
             }
 
         }

--- a/src/Acmebot.App/Models/CertificatePolicyItem.cs
+++ b/src/Acmebot.App/Models/CertificatePolicyItem.cs
@@ -42,7 +42,7 @@ public class CertificatePolicyItem : IValidatableObject
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
-        if (DnsNames.Length == 0)
+        if (DnsNames is not { Length: > 0 })
         {
             yield return new ValidationResult($"The {nameof(DnsNames)} is required.", [nameof(DnsNames)]);
         }
@@ -52,6 +52,19 @@ public class CertificatePolicyItem : IValidatableObject
             yield return new ValidationResult($"The {nameof(DnsProviderName)} is required.", [nameof(DnsProviderName)]);
         }
 
+        foreach (var result in ValidateKeyOptions())
+        {
+            yield return result;
+        }
+
+        foreach (var result in ValidateTags())
+        {
+            yield return result;
+        }
+    }
+
+    private IEnumerable<ValidationResult> ValidateKeyOptions()
+    {
         if (KeyType == "RSA")
         {
             if (KeySize is not (2048 or 3072 or 4096))
@@ -66,30 +79,35 @@ public class CertificatePolicyItem : IValidatableObject
                 yield return new ValidationResult($"The {nameof(KeyCurveName)} must be P-256, P-384, P-521, or P-256K when {nameof(KeyType)} is EC.", [nameof(KeyCurveName)]);
             }
         }
+    }
 
-        if (Tags is not null)
+    private IEnumerable<ValidationResult> ValidateTags()
+    {
+        if (Tags is null)
         {
-            var tagNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            yield break;
+        }
 
-            foreach (var tag in Tags)
+        var tagNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var tag in Tags)
+        {
+            if (string.IsNullOrWhiteSpace(tag.Key))
             {
-                if (string.IsNullOrWhiteSpace(tag.Key))
-                {
-                    yield return new ValidationResult($"The {nameof(Tags)} contains an empty tag name.", [nameof(Tags)]);
-                    continue;
-                }
+                yield return new ValidationResult($"The {nameof(Tags)} contains an empty tag name.", [nameof(Tags)]);
+                continue;
+            }
 
-                var tagName = tag.Key.Trim();
+            var tagName = tag.Key.Trim();
 
-                if (string.Equals(tagName, "Acmebot", StringComparison.OrdinalIgnoreCase))
-                {
-                    yield return new ValidationResult($"The Acmebot tag is reserved for internal metadata.", [nameof(Tags)]);
-                }
+            if (string.Equals(tagName, "Acmebot", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return new ValidationResult($"The Acmebot tag is reserved for internal metadata.", [nameof(Tags)]);
+            }
 
-                if (!tagNames.Add(tagName))
-                {
-                    yield return new ValidationResult($"The {nameof(Tags)} contains duplicate tag names.", [nameof(Tags)]);
-                }
+            if (!tagNames.Add(tagName))
+            {
+                yield return new ValidationResult($"The {nameof(Tags)} contains duplicate tag names.", [nameof(Tags)]);
             }
         }
     }

--- a/src/Acmebot.App/Models/CertificatePolicyItem.cs
+++ b/src/Acmebot.App/Models/CertificatePolicyItem.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.Globalization;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
@@ -7,11 +6,8 @@ namespace Acmebot.App.Models;
 
 public partial class CertificatePolicyItem : IValidatableObject
 {
-    private static readonly IdnMapping s_idnMapping = new();
-
     [JsonPropertyName("certificateName")]
-    [RegularExpression("^[0-9A-Za-z-]{1,127}$")]
-    public string? CertificateName { get; set; }
+    public required string CertificateName { get; set; }
 
     [JsonPropertyName("dnsNames")]
     public required string[] DnsNames { get; set; }
@@ -51,6 +47,11 @@ public partial class CertificatePolicyItem : IValidatableObject
             yield return new ValidationResult($"The {nameof(DnsNames)} is required.", [nameof(DnsNames)]);
         }
 
+        foreach (var result in ValidateCertificateName())
+        {
+            yield return result;
+        }
+
         if (string.IsNullOrWhiteSpace(DnsProviderName))
         {
             yield return new ValidationResult($"The {nameof(DnsProviderName)} is required.", [nameof(DnsProviderName)]);
@@ -77,6 +78,23 @@ public partial class CertificatePolicyItem : IValidatableObject
         }
     }
 
+    private IEnumerable<ValidationResult> ValidateCertificateName()
+    {
+        if (string.IsNullOrWhiteSpace(CertificateName))
+        {
+            yield return new ValidationResult($"The {nameof(CertificateName)} is required.", [nameof(CertificateName)]);
+            yield break;
+        }
+
+        if (!CertificateNameRegex().IsMatch(CertificateName))
+        {
+            yield return new ValidationResult($"The {nameof(CertificateName)} must be 1 to 127 characters and contain only letters, numbers, and hyphens.", [nameof(CertificateName)]);
+        }
+    }
+
+    [GeneratedRegex("^[0-9A-Za-z-]{1,127}$")]
+    private static partial Regex CertificateNameRegex();
+
     private IEnumerable<ValidationResult> ValidateDnsNames()
     {
         if (DnsNames is not { Length: > 0 })
@@ -97,7 +115,7 @@ public partial class CertificatePolicyItem : IValidatableObject
 
     private IEnumerable<ValidationResult> ValidateDnsAlias()
     {
-        if (string.IsNullOrWhiteSpace(DnsAlias))
+        if (string.IsNullOrEmpty(DnsAlias))
         {
             yield break;
         }
@@ -110,23 +128,24 @@ public partial class CertificatePolicyItem : IValidatableObject
         }
     }
 
-    private static string? ValidateDnsName(string value, string fieldName, bool allowWildcard)
+    private static string? ValidateDnsName(string? value, string fieldName, bool allowWildcard)
     {
-        var input = value.Trim().TrimEnd('.');
-
-        if (input.Length == 0)
+        if (string.IsNullOrEmpty(value))
         {
             return $"The {fieldName} contains an empty DNS name.";
         }
 
-        var rawLabels = input.Split('.');
+        if (value.Length > 253)
+        {
+            return $"The {fieldName} must be 253 characters or fewer.";
+        }
+
+        var rawLabels = value.Split('.');
 
         if (rawLabels.Length < 2)
         {
             return $"The {fieldName} must include a domain suffix.";
         }
-
-        var asciiLabels = new string[rawLabels.Length];
 
         for (var labelIndex = 0; labelIndex < rawLabels.Length; labelIndex++)
         {
@@ -149,43 +168,25 @@ public partial class CertificatePolicyItem : IValidatableObject
                     return "A wildcard can only be the leftmost DNS label.";
                 }
 
-                asciiLabels[labelIndex] = rawLabel;
                 continue;
             }
 
-            string asciiLabel;
-
-            try
-            {
-                asciiLabel = s_idnMapping.GetAscii(rawLabel).ToLowerInvariant();
-            }
-            catch (ArgumentException)
-            {
-                return $"The {fieldName} contains characters that cannot be converted to a DNS name.";
-            }
-
-            if (asciiLabel.Length > 63)
+            if (rawLabel.Length > 63)
             {
                 return "Each DNS label must be 63 characters or fewer.";
             }
 
-            if (asciiLabel.Contains('*') || !DnsLabelRegex().IsMatch(asciiLabel))
+            if (rawLabel.Contains('*') || !DnsLabelRegex().IsMatch(rawLabel))
             {
-                return $"The {fieldName} can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.";
+                return $"The {fieldName} must be an ASCII DNS name containing only letters, numbers, hyphens, dots, and a leftmost wildcard.";
             }
 
-            asciiLabels[labelIndex] = asciiLabel;
-        }
-
-        if (string.Join('.', asciiLabels).Length > 253)
-        {
-            return $"The {fieldName} must be 253 characters or fewer.";
         }
 
         return null;
     }
 
-    [GeneratedRegex("^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")]
+    [GeneratedRegex("^[0-9A-Za-z](?:[0-9A-Za-z-]{0,61}[0-9A-Za-z])?$")]
     private static partial Regex DnsLabelRegex();
 
     private IEnumerable<ValidationResult> ValidateKeyOptions()

--- a/src/Acmebot.Cli/CertificatePolicyFactory.cs
+++ b/src/Acmebot.Cli/CertificatePolicyFactory.cs
@@ -18,7 +18,7 @@ internal static partial class CertificatePolicyFactory
     public static CertificatePolicyItem Create(CommandLine commandLine)
     {
         var dnsNames = commandLine.GetOptions("dns-name")
-            .Select(dnsName => NormalizeDnsNameOption(dnsName, "--dns-name"))
+            .Select(dnsName => NormalizeDnsNameOption(dnsName, "--dns-name", allowWildcard: true))
             .Where(dnsName => dnsName is not null)
             .Select(dnsName => dnsName!)
             .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -92,7 +92,7 @@ internal static partial class CertificatePolicyFactory
             KeySize = keySize,
             KeyCurveName = keyCurveName,
             ReuseKey = commandLine.HasOption("reuse-key") ? commandLine.GetFlag("reuse-key") : null,
-            DnsAlias = NormalizeDnsNameOption(commandLine.GetOption("dns-alias"), "--dns-alias"),
+            DnsAlias = NormalizeDnsNameOption(commandLine.GetOption("dns-alias"), "--dns-alias", allowWildcard: false),
             Tags = ParseTags(commandLine.GetOptions("tag"))
         };
     }
@@ -154,7 +154,7 @@ internal static partial class CertificatePolicyFactory
 
     private static string? NormalizeOptionalValue(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
-    private static string? NormalizeDnsNameOption(string? value, string optionName)
+    private static string? NormalizeDnsNameOption(string? value, string optionName, bool allowWildcard)
     {
         var normalizedValue = NormalizeOptionalValue(value);
 
@@ -176,6 +176,16 @@ internal static partial class CertificatePolicyFactory
         {
             if (labels[index] == "*")
             {
+                if (!allowWildcard)
+                {
+                    throw new CliException($"Option '{optionName}' cannot be a wildcard.");
+                }
+
+                if (index != 0)
+                {
+                    throw new CliException("A wildcard can only be the leftmost DNS label.");
+                }
+
                 continue;
             }
 

--- a/src/Acmebot.Cli/CertificatePolicyFactory.cs
+++ b/src/Acmebot.Cli/CertificatePolicyFactory.cs
@@ -5,6 +5,7 @@ namespace Acmebot.Cli;
 
 internal static partial class CertificatePolicyFactory
 {
+    private static readonly IdnMapping s_idnMapping = new();
     private static readonly HashSet<int> s_rsaKeySizes = [2048, 3072, 4096];
     private static readonly Dictionary<string, string> s_ecKeyCurves = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -17,8 +18,9 @@ internal static partial class CertificatePolicyFactory
     public static CertificatePolicyItem Create(CommandLine commandLine)
     {
         var dnsNames = commandLine.GetOptions("dns-name")
-            .Select(dnsName => dnsName.Trim())
-            .Where(dnsName => dnsName.Length > 0)
+            .Select(dnsName => NormalizeDnsNameOption(dnsName, "--dns-name"))
+            .Where(dnsName => dnsName is not null)
+            .Select(dnsName => dnsName!)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
@@ -34,11 +36,14 @@ internal static partial class CertificatePolicyFactory
             throw new CliException("Option '--dns-provider' is required.");
         }
 
-        var certificateName = commandLine.GetOption("name");
+        var customCertificateName = NormalizeOptionalValue(commandLine.GetOption("name"));
+        var certificateName = customCertificateName ?? CreateCertificateName(dnsNames[0]);
 
-        if (certificateName is not null && !CertificateNameRegex().IsMatch(certificateName))
+        if (!CertificateNameRegex().IsMatch(certificateName))
         {
-            throw new CliException("Option '--name' must be 1 to 127 characters and contain only letters, numbers, and hyphens.");
+            throw new CliException(customCertificateName is null
+                ? "Generated certificate name must be 1 to 127 characters and contain only letters, numbers, and hyphens. Specify '--name' to use a shorter name."
+                : "Option '--name' must be 1 to 127 characters and contain only letters, numbers, and hyphens.");
         }
 
         var keyType = commandLine.GetOption("key-type")?.ToUpperInvariant() ?? "RSA";
@@ -87,7 +92,7 @@ internal static partial class CertificatePolicyFactory
             KeySize = keySize,
             KeyCurveName = keyCurveName,
             ReuseKey = commandLine.HasOption("reuse-key") ? commandLine.GetFlag("reuse-key") : null,
-            DnsAlias = NormalizeOptionalValue(commandLine.GetOption("dns-alias")),
+            DnsAlias = NormalizeDnsNameOption(commandLine.GetOption("dns-alias"), "--dns-alias"),
             Tags = ParseTags(commandLine.GetOptions("tag"))
         };
     }
@@ -148,6 +153,46 @@ internal static partial class CertificatePolicyFactory
     }
 
     private static string? NormalizeOptionalValue(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? NormalizeDnsNameOption(string? value, string optionName)
+    {
+        var normalizedValue = NormalizeOptionalValue(value);
+
+        if (normalizedValue is null)
+        {
+            return null;
+        }
+
+        var dnsName = normalizedValue.TrimEnd('.');
+
+        if (dnsName.Length == 0)
+        {
+            throw new CliException($"Option '{optionName}' cannot be empty.");
+        }
+
+        var labels = dnsName.Split('.');
+
+        for (var index = 0; index < labels.Length; index++)
+        {
+            if (labels[index] == "*")
+            {
+                continue;
+            }
+
+            try
+            {
+                labels[index] = s_idnMapping.GetAscii(labels[index]).ToLowerInvariant();
+            }
+            catch (ArgumentException)
+            {
+                throw new CliException($"Option '{optionName}' contains characters that cannot be converted to a DNS name.");
+            }
+        }
+
+        return string.Join('.', labels);
+    }
+
+    private static string CreateCertificateName(string dnsName) => dnsName.Replace("*", "wildcard").Replace(".", "-");
 
     private static string? NormalizeEcKeyCurve(string? value)
     {

--- a/src/Acmebot.Cli/HelpText.cs
+++ b/src/Acmebot.Cli/HelpText.cs
@@ -33,7 +33,7 @@ internal static class HelpText
         await writer.WriteLineAsync("  --timeout <seconds>                    Operation wait timeout. Default: 1800.");
         await writer.WriteLineAsync();
         await writer.WriteLineAsync("Certificate issue options:");
-        await writer.WriteLineAsync("  --name <value>                         Key Vault certificate name.");
+        await writer.WriteLineAsync("  --name <value>                         Key Vault certificate name. Defaults from first DNS name.");
         await writer.WriteLineAsync("  --dns-name <value>                     DNS name. Repeatable.");
         await writer.WriteLineAsync("  --dns-provider <value>                 DNS provider display name. Required.");
         await writer.WriteLineAsync("  --key-type <RSA|EC>                    Key type. Default: RSA.");

--- a/src/Acmebot.Cli/HelpText.cs
+++ b/src/Acmebot.Cli/HelpText.cs
@@ -33,7 +33,7 @@ internal static class HelpText
         await writer.WriteLineAsync("  --timeout <seconds>                    Operation wait timeout. Default: 1800.");
         await writer.WriteLineAsync();
         await writer.WriteLineAsync("Certificate issue options:");
-        await writer.WriteLineAsync("  --name <value>                         Key Vault certificate name. Defaults from first DNS name.");
+        await writer.WriteLineAsync("  --name <value>                         Key Vault certificate name. Defaults to the first DNS name.");
         await writer.WriteLineAsync("  --dns-name <value>                     DNS name. Repeatable.");
         await writer.WriteLineAsync("  --dns-provider <value>                 DNS provider display name. Required.");
         await writer.WriteLineAsync("  --key-type <RSA|EC>                    Key type. Default: RSA.");

--- a/src/Acmebot.Cli/Models.cs
+++ b/src/Acmebot.Cli/Models.cs
@@ -5,7 +5,7 @@ namespace Acmebot.Cli;
 internal sealed class CertificatePolicyItem
 {
     [JsonPropertyName("certificateName")]
-    public string? CertificateName { get; set; }
+    public required string CertificateName { get; set; }
 
     [JsonPropertyName("dnsNames")]
     public required string[] DnsNames { get; set; }

--- a/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
+++ b/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
@@ -36,6 +36,62 @@ public sealed class CertificatePolicyItemTests
         Assert.Equal(["mail-fabrikam-com.acme.example.com"], policy.AliasedDnsNames);
     }
 
+    [Theory]
+    [InlineData("example.com")]
+    [InlineData("www.example.com")]
+    [InlineData("*.example.com")]
+    [InlineData("WWW.Example.COM")]
+    [InlineData("café.example.jp")]
+    public void Validate_WithValidDnsName_ReturnsNoError(string dnsName)
+    {
+        var policy = CreatePolicy(dnsNames: [dnsName]);
+
+        Assert.Empty(Validate(policy));
+    }
+
+    [Theory]
+    [InlineData("www", "The DnsNames must include a domain suffix.")]
+    [InlineData("a..b", "The DnsNames cannot contain empty DNS labels.")]
+    [InlineData("sub.*.example.com", "A wildcard can only be the leftmost DNS label.")]
+    [InlineData("*foo.example.com", "The DnsNames can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.")]
+    [InlineData("under_score.example.com", "The DnsNames can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.")]
+    public void Validate_WithInvalidDnsName_ReturnsError(string dnsName, string expectedMessage)
+    {
+        var policy = CreatePolicy(dnsNames: [dnsName]);
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal(expectedMessage, result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_WithWildcardDnsAlias_ReturnsError()
+    {
+        var policy = CreatePolicy(dnsAlias: "*.acme.example.com");
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal("The DnsAlias cannot be a wildcard.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_WithChallengePrefixedDnsAlias_ReturnsError()
+    {
+        var policy = CreatePolicy(dnsAlias: "_acme-challenge.acme.example.com");
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal("The DnsAlias can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_WithValidDnsAlias_ReturnsNoError()
+    {
+        var policy = CreatePolicy(dnsAlias: "mail-fabrikam-com.acme.example.com");
+
+        Assert.Empty(Validate(policy));
+    }
+
     private static CertificatePolicyItem CreatePolicy(
         string[]? dnsNames = null,
         string dnsProviderName = "Azure DNS",

--- a/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
+++ b/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
@@ -9,16 +9,6 @@ namespace Acmebot.App.Tests;
 public sealed class CertificatePolicyItemTests
 {
     [Fact]
-    public void Validate_WithDelegatedDnsAlias_Succeeds()
-    {
-        var policy = CreatePolicy(dnsNames: ["mail.fabrikam.com"], dnsAlias: "mail-fabrikam-com.acme.example.com");
-
-        var results = Validate(policy);
-
-        Assert.Empty(results);
-    }
-
-    [Fact]
     public void Validate_WithEmptyDnsNames_ReturnsError()
     {
         var policy = CreatePolicy(dnsNames: []);

--- a/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
+++ b/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
@@ -114,7 +114,7 @@ public sealed class CertificatePolicyItemTests
 
         var result = Assert.Single(Validate(policy));
 
-        Assert.Equal("The DnsAlias must be an ASCII DNS name containing only letters, numbers, hyphens, dots, and a leftmost wildcard.", result.ErrorMessage);
+        Assert.Equal("The DnsAlias must be an ASCII DNS name containing only letters, numbers, hyphens, and dots.", result.ErrorMessage);
     }
 
     [Fact]

--- a/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
+++ b/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel.DataAnnotations;
+
+using Acmebot.App.Models;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class CertificatePolicyItemTests
+{
+    [Fact]
+    public void Validate_WithDelegatedDnsAlias_Succeeds()
+    {
+        var policy = CreatePolicy(dnsNames: ["mail.fabrikam.com"], dnsAlias: "mail-fabrikam-com.acme.example.com");
+
+        var results = Validate(policy);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Validate_WithEmptyDnsNames_ReturnsError()
+    {
+        var policy = CreatePolicy(dnsNames: []);
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal("The DnsNames is required.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_WithMissingDnsProvider_ReturnsError()
+    {
+        var policy = CreatePolicy(dnsProviderName: "");
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal("The DnsProviderName is required.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void AliasedDnsNames_WithDnsAlias_ReturnsAliasOnly()
+    {
+        var policy = CreatePolicy(dnsNames: ["mail.fabrikam.com"], dnsAlias: "mail-fabrikam-com.acme.example.com");
+
+        Assert.Equal(["mail-fabrikam-com.acme.example.com"], policy.AliasedDnsNames);
+    }
+
+    private static CertificatePolicyItem CreatePolicy(
+        string[]? dnsNames = null,
+        string dnsProviderName = "Azure DNS",
+        string? dnsAlias = null)
+    {
+        return new CertificatePolicyItem
+        {
+            DnsNames = dnsNames ?? ["example.com"],
+            DnsProviderName = dnsProviderName,
+            KeyType = "RSA",
+            KeySize = 2048,
+            DnsAlias = dnsAlias
+        };
+    }
+
+    private static IReadOnlyList<ValidationResult> Validate(CertificatePolicyItem policy)
+    {
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(policy, new ValidationContext(policy), results, validateAllProperties: true);
+        return results;
+    }
+}

--- a/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
+++ b/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
@@ -29,6 +29,26 @@ public sealed class CertificatePolicyItemTests
     }
 
     [Fact]
+    public void Validate_WithMissingCertificateName_ReturnsError()
+    {
+        var policy = CreatePolicy(certificateName: "");
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal("The CertificateName is required.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_WithInvalidCertificateName_ReturnsError()
+    {
+        var policy = CreatePolicy(certificateName: "bad_name");
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal("The CertificateName must be 1 to 127 characters and contain only letters, numbers, and hyphens.", result.ErrorMessage);
+    }
+
+    [Fact]
     public void AliasedDnsNames_WithDnsAlias_ReturnsAliasOnly()
     {
         var policy = CreatePolicy(dnsNames: ["mail.fabrikam.com"], dnsAlias: "mail-fabrikam-com.acme.example.com");
@@ -41,7 +61,7 @@ public sealed class CertificatePolicyItemTests
     [InlineData("www.example.com")]
     [InlineData("*.example.com")]
     [InlineData("WWW.Example.COM")]
-    [InlineData("café.example.jp")]
+    [InlineData("xn--caf-dma.example.jp")]
     public void Validate_WithValidDnsName_ReturnsNoError(string dnsName)
     {
         var policy = CreatePolicy(dnsNames: [dnsName]);
@@ -52,9 +72,12 @@ public sealed class CertificatePolicyItemTests
     [Theory]
     [InlineData("www", "The DnsNames must include a domain suffix.")]
     [InlineData("a..b", "The DnsNames cannot contain empty DNS labels.")]
+    [InlineData("example.com.", "The DnsNames cannot contain empty DNS labels.")]
     [InlineData("sub.*.example.com", "A wildcard can only be the leftmost DNS label.")]
-    [InlineData("*foo.example.com", "The DnsNames can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.")]
-    [InlineData("under_score.example.com", "The DnsNames can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.")]
+    [InlineData("*foo.example.com", "The DnsNames must be an ASCII DNS name containing only letters, numbers, hyphens, dots, and a leftmost wildcard.")]
+    [InlineData("under_score.example.com", "The DnsNames must be an ASCII DNS name containing only letters, numbers, hyphens, dots, and a leftmost wildcard.")]
+    [InlineData("café.example.jp", "The DnsNames must be an ASCII DNS name containing only letters, numbers, hyphens, dots, and a leftmost wildcard.")]
+    [InlineData(" example.com", "The DnsNames must be an ASCII DNS name containing only letters, numbers, hyphens, dots, and a leftmost wildcard.")]
     public void Validate_WithInvalidDnsName_ReturnsError(string dnsName, string expectedMessage)
     {
         var policy = CreatePolicy(dnsNames: [dnsName]);
@@ -62,6 +85,16 @@ public sealed class CertificatePolicyItemTests
         var result = Assert.Single(Validate(policy));
 
         Assert.Equal(expectedMessage, result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_WithNullDnsName_ReturnsError()
+    {
+        var policy = CreatePolicy(dnsNames: [null!]);
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal("The DnsNames contains an empty DNS name.", result.ErrorMessage);
     }
 
     [Fact]
@@ -81,7 +114,7 @@ public sealed class CertificatePolicyItemTests
 
         var result = Assert.Single(Validate(policy));
 
-        Assert.Equal("The DnsAlias can contain only letters, numbers, hyphens, dots, and a leftmost wildcard.", result.ErrorMessage);
+        Assert.Equal("The DnsAlias must be an ASCII DNS name containing only letters, numbers, hyphens, dots, and a leftmost wildcard.", result.ErrorMessage);
     }
 
     [Fact]
@@ -93,12 +126,14 @@ public sealed class CertificatePolicyItemTests
     }
 
     private static CertificatePolicyItem CreatePolicy(
+        string certificateName = "example-com",
         string[]? dnsNames = null,
         string dnsProviderName = "Azure DNS",
         string? dnsAlias = null)
     {
         return new CertificatePolicyItem
         {
+            CertificateName = certificateName,
             DnsNames = dnsNames ?? ["example.com"],
             DnsProviderName = dnsProviderName,
             KeyType = "RSA",

--- a/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
+++ b/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 using Acmebot.App.Models;
 

--- a/tests/Acmebot.Cli.Tests/CertificatePolicyTests.cs
+++ b/tests/Acmebot.Cli.Tests/CertificatePolicyTests.cs
@@ -21,6 +21,7 @@ public sealed class CertificatePolicyTests
             "owner=platform"
         ]));
 
+        Assert.Equal("example-com", policy.CertificateName);
         Assert.Equal(["example.com"], policy.DnsNames);
         Assert.Equal("Azure DNS", policy.DnsProviderName);
         Assert.Equal("RSA", policy.KeyType);
@@ -28,6 +29,59 @@ public sealed class CertificatePolicyTests
         Assert.Null(policy.KeyCurveName);
         Assert.NotNull(policy.Tags);
         Assert.Equal("platform", policy.Tags["owner"]);
+    }
+
+    [Fact]
+    public void Create_WithCertificateName_UsesProvidedName()
+    {
+        var policy = CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--name",
+            "custom-example",
+            "--dns-name",
+            "example.com",
+            "--dns-provider",
+            "Azure DNS"
+        ]));
+
+        Assert.Equal("custom-example", policy.CertificateName);
+    }
+
+    [Fact]
+    public void Create_WithUnicodeDnsName_CanonicalizesDnsName()
+    {
+        var policy = CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--dns-name",
+            "Café.Example.JP.",
+            "--dns-provider",
+            "Azure DNS"
+        ]));
+
+        Assert.Equal("xn--caf-dma-example-jp", policy.CertificateName);
+        Assert.Equal(["xn--caf-dma.example.jp"], policy.DnsNames);
+    }
+
+    [Fact]
+    public void Create_WithDnsAlias_CanonicalizesDnsAlias()
+    {
+        var policy = CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--dns-name",
+            "example.com",
+            "--dns-provider",
+            "Azure DNS",
+            "--dns-alias",
+            "Alias.Example.NET."
+        ]));
+
+        Assert.Equal("alias.example.net", policy.DnsAlias);
     }
 
     [Fact]
@@ -106,6 +160,22 @@ public sealed class CertificatePolicyTests
         ])));
 
         Assert.Equal("Option '--name' must be 1 to 127 characters and contain only letters, numbers, and hyphens.", ex.Message);
+    }
+
+    [Fact]
+    public void Create_WithTooLongGeneratedCertificateName_Throws()
+    {
+        var ex = Assert.Throws<CliException>(() => CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--dns-name",
+            $"{new string('a', 63)}.{new string('b', 63)}.example.com",
+            "--dns-provider",
+            "Azure DNS"
+        ])));
+
+        Assert.Equal("Generated certificate name must be 1 to 127 characters and contain only letters, numbers, and hyphens. Specify '--name' to use a shorter name.", ex.Message);
     }
 
     [Fact]

--- a/tests/Acmebot.Cli.Tests/CertificatePolicyTests.cs
+++ b/tests/Acmebot.Cli.Tests/CertificatePolicyTests.cs
@@ -85,6 +85,40 @@ public sealed class CertificatePolicyTests
     }
 
     [Fact]
+    public void Create_WithWildcardDnsAlias_Throws()
+    {
+        var ex = Assert.Throws<CliException>(() => CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--dns-name",
+            "example.com",
+            "--dns-provider",
+            "Azure DNS",
+            "--dns-alias",
+            "*.example.net"
+        ])));
+
+        Assert.Equal("Option '--dns-alias' cannot be a wildcard.", ex.Message);
+    }
+
+    [Fact]
+    public void Create_WithNonLeftmostWildcardDnsName_Throws()
+    {
+        var ex = Assert.Throws<CliException>(() => CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--dns-name",
+            "sub.*.example.com",
+            "--dns-provider",
+            "Azure DNS"
+        ])));
+
+        Assert.Equal("A wildcard can only be the leftmost DNS label.", ex.Message);
+    }
+
+    [Fact]
     public void Create_WithEcDefaultsToP256()
     {
         var policy = CertificatePolicyFactory.Create(CommandLine.Parse(


### PR DESCRIPTION
- Introduced a new section in the dashboard documentation for delegated DNS-01.
- Updated API documentation to clarify requirements for `dnsProviderName` and `dnsAlias`.
- Enhanced CLI documentation to include details about the new issue mode.
- Modified the AddCertificateDialog component to support both managed and delegated DNS name editing.
- Created DelegatedDnsNameEditor component for handling DNS names in delegated mode.
- Implemented ManagedDnsNameEditor component for managing DNS names in managed mode.
- Updated styles to accommodate new UI elements for issue mode selection.
- Added utility functions for handling DNS name validation and alias creation.
- Enhanced CertificatePolicyItem model to validate DNS names and aliases.
- Added unit tests for CertificatePolicyItem to ensure validation logic works as expected.

Fixes #995