### PR TITLE
Fix ACME nonce reuse, signer thread-safety, and state durability

### DIFF
--- a/src/Acmebot.Acme/AcmeSigner.cs
+++ b/src/Acmebot.Acme/AcmeSigner.cs
@@ -8,6 +8,9 @@ namespace Acmebot.Acme;
 
 public sealed class AcmeSigner : IDisposable
 {
+    // ECDsa/RSA instance members are not guaranteed to be thread-safe, and a single signer is shared
+    // across concurrent ACME operations, so access to the underlying key is serialized through this lock.
+    private readonly Lock _syncRoot = new();
     private readonly ECDsa? _ecdsa;
     private readonly RSA? _rsa;
     private readonly HashAlgorithmName _hashAlgorithm;
@@ -69,12 +72,15 @@ public sealed class AcmeSigner : IDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        if (_ecdsa is not null)
+        lock (_syncRoot)
         {
-            return _ecdsa.SignData(data, _hashAlgorithm, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
-        }
+            if (_ecdsa is not null)
+            {
+                return _ecdsa.SignData(data, _hashAlgorithm, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+            }
 
-        return _rsa!.SignData(data, _hashAlgorithm, RSASignaturePadding.Pkcs1);
+            return _rsa!.SignData(data, _hashAlgorithm, RSASignaturePadding.Pkcs1);
+        }
     }
 
     public string GetThumbprint()
@@ -92,6 +98,14 @@ public sealed class AcmeSigner : IDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
+        lock (_syncRoot)
+        {
+            return ExportJsonWebKeyCore();
+        }
+    }
+
+    private AcmeJsonWebKey ExportJsonWebKeyCore()
+    {
         if (_ecdsa is not null)
         {
             var parameters = _ecdsa.ExportParameters(false);

--- a/src/Acmebot.Acme/AcmeSigner.cs
+++ b/src/Acmebot.Acme/AcmeSigner.cs
@@ -70,10 +70,10 @@ public sealed class AcmeSigner : IDisposable
 
     public byte[] SignData(ReadOnlySpan<byte> data)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-
         lock (_syncRoot)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
             if (_ecdsa is not null)
             {
                 return _ecdsa.SignData(data, _hashAlgorithm, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
@@ -85,8 +85,6 @@ public sealed class AcmeSigner : IDisposable
 
     public string GetThumbprint()
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-
         var jwk = ExportJsonWebKey();
         var jsonBytes = Encoding.UTF8.GetBytes(jwk.ToThumbprintJson());
         var hash = SHA256.HashData(jsonBytes);
@@ -96,10 +94,10 @@ public sealed class AcmeSigner : IDisposable
 
     internal AcmeJsonWebKey ExportJsonWebKey()
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-
         lock (_syncRoot)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
             return ExportJsonWebKeyCore();
         }
     }
@@ -139,17 +137,22 @@ public sealed class AcmeSigner : IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
+        // Hold the same lock as the key operations so disposal cannot race with an in-progress
+        // SignData/ExportJsonWebKey call and dispose the key out from under it.
+        lock (_syncRoot)
         {
-            return;
-        }
+            if (_disposed)
+            {
+                return;
+            }
 
-        _disposed = true;
+            _disposed = true;
 
-        if (_ownsKey)
-        {
-            _ecdsa?.Dispose();
-            _rsa?.Dispose();
+            if (_ownsKey)
+            {
+                _ecdsa?.Dispose();
+                _rsa?.Dispose();
+            }
         }
     }
 

--- a/src/Acmebot.Acme/Internal/AcmeNonceStore.cs
+++ b/src/Acmebot.Acme/Internal/AcmeNonceStore.cs
@@ -1,15 +1,14 @@
 ﻿using System.Buffers.Text;
-using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Acmebot.Acme.Internal;
 
 internal sealed class AcmeNonceStore
 {
-    private const int MaxNonceCount = 32;
-
-    private readonly ConcurrentQueue<string> _nonces = new();
-    private readonly ConcurrentDictionary<string, byte> _nonceSet = new(StringComparer.Ordinal);
+    // ACME nonces are single-use and expire server-side, so only the most recently received one is
+    // worth keeping. Holding just the latest nonce guarantees a request always uses the freshest one
+    // and a badNonce retry naturally picks up the fresh nonce returned by the error response.
+    private string? _nonce;
 
     public void Add(string? nonce)
     {
@@ -18,34 +17,13 @@ internal sealed class AcmeNonceStore
             return;
         }
 
-        if (!_nonceSet.TryAdd(nonce, 0))
-        {
-            return;
-        }
-
-        _nonces.Enqueue(nonce);
-        Trim();
+        Interlocked.Exchange(ref _nonce, nonce);
     }
 
     public bool TryTake([NotNullWhen(true)] out string? nonce)
     {
-        while (_nonces.TryDequeue(out nonce))
-        {
-            if (_nonceSet.TryRemove(nonce, out _))
-            {
-                return true;
-            }
-        }
+        nonce = Interlocked.Exchange(ref _nonce, null);
 
-        nonce = null;
-        return false;
-    }
-
-    private void Trim()
-    {
-        while (_nonceSet.Count > MaxNonceCount && _nonces.TryDequeue(out var discardedNonce))
-        {
-            _nonceSet.TryRemove(discardedNonce, out _);
-        }
+        return nonce is not null;
     }
 }

--- a/src/Acmebot.App/Acme/FileSystemAcmeStateStore.cs
+++ b/src/Acmebot.App/Acme/FileSystemAcmeStateStore.cs
@@ -64,14 +64,12 @@ internal sealed class FileSystemAcmeStateStore(IOptions<AcmebotOptions> options)
 
     private static void TryDeleteFile(string path)
     {
+        // Best-effort cleanup of the temp file; never let a cleanup failure mask the original error.
         try
         {
             File.Delete(path);
         }
-        catch (IOException)
-        {
-        }
-        catch (UnauthorizedAccessException)
+        catch
         {
         }
     }

--- a/src/Acmebot.App/Acme/FileSystemAcmeStateStore.cs
+++ b/src/Acmebot.App/Acme/FileSystemAcmeStateStore.cs
@@ -40,9 +40,40 @@ internal sealed class FileSystemAcmeStateStore(IOptions<AcmebotOptions> options)
             Directory.CreateDirectory(directoryPath);
         }
 
-        await using var stream = File.Create(fullPath);
+        // Write to a temporary file first and atomically replace the target so that a crash or host
+        // recycle mid-write cannot leave a truncated state file (a corrupt account_key.json would
+        // permanently orphan the ACME account).
+        var tempPath = $"{fullPath}.{Guid.NewGuid():N}.tmp";
 
-        await JsonSerializer.SerializeAsync(stream, value, s_jsonSerializerOptions, cancellationToken);
+        try
+        {
+            await using (var stream = File.Create(tempPath))
+            {
+                await JsonSerializer.SerializeAsync(stream, value, s_jsonSerializerOptions, cancellationToken);
+            }
+
+            File.Move(tempPath, fullPath, overwrite: true);
+        }
+        catch
+        {
+            TryDeleteFile(tempPath);
+
+            throw;
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
     }
 
     private string ResolveStateFullPath(string path) => Environment.ExpandEnvironmentVariables($"%HOME%/data/.acmebot/{_endpoint.Host}/{path}");

--- a/tests/Acmebot.Acme.Tests/Internal/AcmeNonceStoreTests.cs
+++ b/tests/Acmebot.Acme.Tests/Internal/AcmeNonceStoreTests.cs
@@ -25,27 +25,26 @@ public sealed class AcmeNonceStoreTests
     }
 
     [Fact]
-    public void Add_TrimsOldestNonceWhenCapacityExceeded()
+    public void Add_KeepsOnlyMostRecentNonce()
     {
         var store = new AcmeNonceStore();
-        var nonces = Enumerable.Range(0, 33)
-            .Select(static value => Base64Url.EncodeToString([(byte)value]))
-            .ToArray();
+        var older = Base64Url.EncodeToString([1]);
+        var newer = Base64Url.EncodeToString([2]);
 
-        foreach (var nonce in nonces)
-        {
-            store.Add(nonce);
-        }
+        store.Add(older);
+        store.Add(newer);
 
-        var taken = new List<string>();
+        Assert.True(store.TryTake(out var nonce));
+        Assert.Equal(newer, nonce);
+        Assert.False(store.TryTake(out _));
+    }
 
-        while (store.TryTake(out var nonce))
-        {
-            taken.Add(nonce);
-        }
+    [Fact]
+    public void TryTake_ReturnsFalseWhenEmpty()
+    {
+        var store = new AcmeNonceStore();
 
-        Assert.Equal(32, taken.Count);
-        Assert.DoesNotContain(nonces[0], taken);
-        Assert.Contains(nonces[^1], taken);
+        Assert.False(store.TryTake(out var nonce));
+        Assert.Null(nonce);
     }
 }


### PR DESCRIPTION
## Summary

- Resolve a `badNonce` ("JWS has an invalid anti-replay nonce") failure observed during testing, and harden the long-lived singleton `AcmeClient` for concurrent use.

## Related Issue

- Closes #

## What Changed

- **`AcmeNonceStore`** — replaced the 32-entry FIFO pool with a single-slot store that keeps only the most recent nonce. The FIFO pool could hand out an expired nonce ahead of a fresh one, and because a `badNonce` retry pulled the *next* nonce from the queue, the retry could pick up yet another stale nonce and let the error surface. Keeping only the latest nonce means every request uses the freshest one and a `badNonce` retry naturally reuses the fresh nonce returned by the error response. Access is serialized with `Interlocked`, and the retry loop in `AcmeClient` is back to the simple `continue` form.
- **`AcmeSigner`** — serialized key operations (`SignData` / `ExportJsonWebKey`) behind a `Lock`. `ECDsa`/`RSA` instance members are not guaranteed thread-safe, and a single signer is cached and shared across renewal orchestrations that run concurrently, so parallel signing could throw or corrupt results.
- **`FileSystemAcmeStateStore`** — write state to a temp file and atomically rename it into place. The previous in-place `File.Create` truncated the target before writing, so a crash or host recycle mid-write could corrupt `account_key.json` and permanently orphan the ACME account. (The Blob store is already atomic via a single `UploadAsync`.)
- Updated `AcmeNonceStore` tests for the single-slot semantics.

## Validation

- [x] `dotnet build -c Release ./Acmebot.slnx`
- [x] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx`
- [ ] `az bicep build -f ./deploy/azuredeploy.bicep` (no infra changes)
- [ ] Documentation updated if needed (no doc-facing changes)

Tests: `dotnet test tests/Acmebot.Acme.Tests` — 57 passed.

## Notes

Out of scope for this PR, noted for awareness:
- **Cross-instance bootstrap race**: on a brand-new deployment with no account yet, two instances processing the first request simultaneously could each create an ACME account (last-writer-wins on the state write). Avoiding this needs a distributed lease; it does not occur in typical single-instance first-run operation.
- **Blob writes have no concurrency token** (last-writer-wins). State writes are already serialized within a process by `AcmeClientFactory`, so there is no in-process race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)