### PR TITLE
Clarify renewal behavior, auth roles, and UI sort

### DIFF
--- a/docs/guide/certificate-authorities.md
+++ b/docs/guide/certificate-authorities.md
@@ -85,7 +85,7 @@ Acmebot tags each certificate with the endpoint that issued it and renews only c
 
 ## Renewal Behavior
 
-During scheduled renewal, Acmebot checks each managed certificate in Key Vault. When the ACME directory supports renewal information, it uses the server-provided renewal window; otherwise it renews when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent. See [Operations](./operations) for the full renewal schedule.
+During scheduled renewal, Acmebot checks each enabled managed certificate in Key Vault. When the ACME directory supports renewal information, it uses the server-provided `suggestedWindow` and `Retry-After` timing; otherwise it renews when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent. See [Operations](./operations) for the full renewal schedule.
 
 ## CA Selection Guidance
 

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -14,7 +14,7 @@ The dashboard lists certificates from the configured Key Vault and marks each on
 - Managed by Acmebot but issued for another ACME endpoint.
 - Not managed by Acmebot.
 
-Only certificates with Acmebot metadata for the current endpoint are selected for scheduled renewal.
+Only enabled certificates with Acmebot metadata for the current endpoint are selected for scheduled renewal.
 
 ## DNS Zone List
 
@@ -64,7 +64,7 @@ Custom tags are written to the Key Vault certificate. The `Acmebot` tag is reser
 
 Manual renewal reuses the existing Key Vault certificate policy and starts a new issuance orchestration. Use it to rotate a certificate before its scheduled renewal window.
 
-Scheduled renewals run daily and add a random delay of up to 600 seconds before processing due certificates.
+Scheduled renewals run daily. Certificates with ACME renewal information use the CA's suggested window and `Retry-After` timing; certificates without renewal information use the configured fallback threshold.
 
 ## Revoke a Certificate
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -2,7 +2,7 @@
 
 ## How does automatic renewal work?
 
-The `RenewCertificates` timer runs daily for enabled managed certificates. When ACME renewal information is available, Acmebot renews after the CA reports that the renewal window has opened. Otherwise, it renews when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent (default 30):
+The `RenewCertificates` timer runs daily for enabled managed certificates. When ACME renewal information is available, Acmebot uses the CA's suggested renewal window and `Retry-After` timing to decide the next check, then renews after the suggested window has started. Otherwise, it renews when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent (default 30):
 
 ```text
 Acmebot__RenewBeforeExpiry=30

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -54,7 +54,7 @@ When possible, store provider secrets in Key Vault and reference them from Funct
 
 The dashboard and HTTP API require authenticated requests. Configure App Service Authentication on the Function App and require sign-in before requests reach the app. A typical setup uses Microsoft Entra ID as the identity provider.
 
-After authentication is enabled, browse to the Function App URL and sign in. To require app roles for issue and revoke operations, see [Security](../reference/security).
+After authentication is enabled, browse to the Function App URL and sign in. To require app roles for issue, manual renewal, and revoke operations, see [Security](../reference/security).
 
 ## 5. Issue Your First Certificate
 
@@ -80,7 +80,7 @@ After the operation completes:
 
 ## 7. Let Renewals Run
 
-The `RenewCertificates` timer runs daily. When ACME renewal information is available for a certificate, Acmebot renews after the suggested renewal window starts. Otherwise, it renews when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent (default 30).
+The `RenewCertificates` timer runs daily. When ACME renewal information is available for a certificate, Acmebot evaluates the certificate authority's suggested renewal window and `Retry-After` timing before renewing. Otherwise, it renews when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent (default 30).
 
 See [Operations](./operations) for monitoring and troubleshooting guidance.
 

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -4,12 +4,15 @@ This page covers day-to-day operation after Acmebot has been deployed.
 
 ## Scheduled Renewal
 
-The `RenewCertificates` timer runs once per day. It lists Key Vault certificates and selects those that:
+The `RenewCertificates` timer runs once per day. It lists Key Vault certificates and starts renewal schedulers for certificates that:
 
+- Are enabled.
 - Are tagged as issued by Acmebot.
 - Match the currently configured ACME endpoint.
-- Are inside the ACME renewal information window, when renewal information is available for the certificate.
-- Have no more than `Acmebot__RenewBeforeExpiry` percent of their lifetime remaining (used when renewal information is unavailable for the certificate).
+
+When ACME renewal information is available, Acmebot follows the certificate authority's `suggestedWindow` when choosing the next check. It selects a random time inside that window, but checks renewal information again first when `Retry-After` is earlier. When a scheduler evaluation runs after the suggested window starts, Acmebot renews the certificate.
+
+When renewal information is unavailable for a certificate, Acmebot falls back to `Acmebot__RenewBeforeExpiry`.
 
 The default fallback renewal threshold is 30% of the certificate lifetime:
 
@@ -19,9 +22,9 @@ Acmebot__RenewBeforeExpiry=30
 
 For example, a 90-day certificate is renewed when about 27 days remain. Use a larger value when downstream distribution takes longer or your organization requires a longer safety margin.
 
-## Renewal Jitter
+No separate pre-processing delay is added before due certificates are renewed.
 
-Before processing due certificates, the renewal orchestrator waits for a random delay of up to 600 seconds. This reduces simultaneous renewal starts across deployments.
+If automatic renewal fails, the certificate scheduler records a retrying state and checks again after six hours.
 
 ## Durable Functions History
 
@@ -79,7 +82,7 @@ The most frequent operational issues are:
 - **Name server precondition fails**: the domain is not delegated to the provider's name servers.
 - **TXT record is not found**: propagation is slow, or the validation design requires an internal resolver (`Acmebot__UseSystemNameServer=true`).
 - **ACME order becomes invalid**: review the ACME problem details; persistent configuration errors require a new operation after the DNS issue is fixed.
-- **Certificate is not renewed**: the certificate lacks Acmebot metadata, was issued for a different endpoint, is outside the renewal window, or is not readable by the Function App identity.
+- **Certificate is not renewed**: the certificate is disabled, lacks Acmebot metadata, was issued for a different endpoint, is outside the renewal window, or is not readable by the Function App identity.
 - **Endpoint still serves the old certificate**: the certificate is current in Key Vault, but the consuming Azure service has not synced it.
 
 See [Troubleshooting](./troubleshooting) for the full decision tree, and [Azure Service Integration](./service-integration) for downstream sync behavior.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -66,7 +66,7 @@ What to verify:
 Typical symptoms:
 
 - The dashboard or an API call returns `401`.
-- A signed-in caller can list data but cannot issue or revoke certificates.
+- A signed-in caller can list data but cannot issue, manually renew, or revoke certificates.
 - Azure CLI token acquisition fails with `AADSTS65001` or `consent_required`.
 
 What to verify:
@@ -74,7 +74,7 @@ What to verify:
 - App Service Authentication is configured for the Function App.
 - Requests reach the app with an authenticated principal.
 - Microsoft Entra ID uses the intended tenant and application registration.
-- When `Acmebot__RequireAppRoles=true`, the token contains `Acmebot.IssueCertificate` or `Acmebot.RevokeCertificate`.
+- When `Acmebot__RequireAppRoles=true`, the token contains `Acmebot.IssueCertificate` for issue or manual renewal operations, or `Acmebot.RevokeCertificate` for revoke operations.
 - For Azure CLI-backed automation, the application registration used by App Service Authentication exposes a `user_impersonation` scope and pre-authorizes the Microsoft Azure CLI client ID `04b07795-8ddb-461a-bbee-02f9e1bf7b46`.
 
 The HTTP triggers use anonymous trigger authorization so App Service Authentication can populate the user identity before application code runs. A Functions host key alone does not satisfy the authenticated-user requirement for the v5 dashboard and API. See [Security](../reference/security) for the authorization model.
@@ -87,6 +87,7 @@ Typical causes:
 
 - The certificate was not issued by Acmebot, or no longer has Acmebot metadata.
 - The certificate was issued against a different ACME endpoint than the configured one.
+- The certificate is disabled.
 - The certificate is not inside the renewal window.
 - The timer host is stopped or the Function App is unhealthy.
 - DNS or Key Vault permissions changed after first issuance.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -26,6 +26,7 @@ When app role enforcement is enabled, issue and renew operations require `Acmebo
 | `POST` | `/api/certificates/{certificateName}/renew` | Start manual renewal. |
 | `POST` | `/api/certificates/{certificateName}/revoke` | Revoke a certificate through the ACME certificate authority. |
 | `GET` | `/api/dns-zones` | List DNS zones from configured providers. |
+| `GET` | `/api/renewals` | List automatic renewal status for certificates. |
 | `GET` | `/api/operations/{instanceId}` | Poll an issuance or renewal operation. |
 
 ## Operation Lifecycle
@@ -125,6 +126,28 @@ Accept: application/json
     "dnsZones": [
       { "name": "example.com" }
     ]
+  }
+]
+```
+
+## List Renewal Status
+
+```http
+GET /api/renewals
+Accept: application/json
+```
+
+Returns automatic renewal status for certificates visible to Acmebot.
+
+```json
+[
+  {
+    "certificateName": "wildcard-example-com",
+    "status": "Scheduled",
+    "statusKind": "scheduled",
+    "message": "Renewal is scheduled within the certificate authority's suggested renewal window.",
+    "nextCheck": "2026-06-20T00:00:00+00:00",
+    "lastCheckedAt": "2026-06-19T00:00:00+00:00"
   }
 ]
 ```

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -40,14 +40,13 @@ The scheduled renewal timer runs daily and starts the renewal orchestrator.
 The orchestrator:
 
 1. Lists certificates in the configured Key Vault.
-2. Filters to certificates tagged as Acmebot-managed.
+2. Filters to enabled certificates tagged as Acmebot-managed.
 3. Filters to the current ACME endpoint.
-4. Uses ACME renewal information when available for the certificate.
-5. Falls back to `RenewBeforeExpiry` lifetime-percentage renewal when renewal information is unavailable for the certificate.
-6. Adds random jitter up to 600 seconds.
-7. Reissues each due certificate with its stored Key Vault policy.
+4. Uses ACME renewal information when available, selecting the next check from the CA's suggested window and `Retry-After` timing.
+5. Renews after the suggested window has started, or falls back to `RenewBeforeExpiry` lifetime-percentage renewal when renewal information is unavailable for the certificate.
+6. Reissues each due certificate with its stored Key Vault policy.
 
-Persistent DNS-related ACME validation errors can be retried by the renewal workflow. Other failures are logged and the orchestrator continues with the next due certificate.
+Automatic renewal failures put the certificate scheduler into a retrying state. The scheduler waits six hours, then evaluates that certificate again.
 
 ## State Storage
 
@@ -115,6 +114,6 @@ Monitor:
 
 - The Function App HTTP triggers use anonymous trigger authorization but application code requires an authenticated user.
 - Dashboard access should be enforced with App Service Authentication.
-- Optional app roles can restrict issue and revoke operations.
+- Optional app roles can restrict issue, manual renewal, and revoke operations.
 - Key Vault access is handled through Azure identity and RBAC.
 - DNS provider secrets are app settings and should be scoped and rotated like other operational credentials.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -185,11 +185,11 @@ TransIP signs requests with an Azure Key Vault key under `Acmebot__VaultBaseUrl`
 
 ## Dashboard Authorization Setting
 
-Issue and revoke operations can optionally require Microsoft Entra app roles.
+Issue, manual renewal, and revoke operations can optionally require Microsoft Entra app roles.
 
 | Setting | Default | Description |
 | --- | --- | --- |
-| `Acmebot__RequireAppRoles` | `false` | When `true`, issue operations require `Acmebot.IssueCertificate` and revoke operations require `Acmebot.RevokeCertificate`. |
+| `Acmebot__RequireAppRoles` | `false` | When `true`, issue and manual renewal operations require `Acmebot.IssueCertificate`, and revoke operations require `Acmebot.RevokeCertificate`. |
 
 This value is read at startup, so restart the Function App after changing it.
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -12,7 +12,7 @@ The HTTP triggers are configured with anonymous trigger authorization so App Ser
 
 ## App Roles
 
-By default, any authenticated dashboard user can issue and revoke certificates. To require app roles for sensitive operations, set:
+By default, any authenticated dashboard user can issue, manually renew, and revoke certificates. To require app roles for sensitive operations, set:
 
 ```text
 Acmebot__RequireAppRoles=true
@@ -33,7 +33,7 @@ Listing certificates and DNS zones still requires authentication.
 2. Assign the roles to users, groups, or service principals that should operate Acmebot.
 3. Set `Acmebot__RequireAppRoles=true` on the Function App.
 4. Restart the Function App so the new configuration value is applied.
-5. Confirm a caller without the role receives `403` for issue or revoke operations.
+5. Confirm a caller without the role receives `403` for issue, manual renewal, or revoke operations.
 
 ## Managed Identity
 

--- a/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
+++ b/src/Acmebot.App/ClientApp/src/components/CertificateTable.vue
@@ -186,7 +186,7 @@ const zoneGroups = computed<ZoneGroup[]>(() => {
     }
   }
 
-  return groups;
+  return groups.toSorted((left, right) => left.zoneName.localeCompare(right.zoneName));
 });
 
 const allZoneGroupsCollapsed = computed(() => zoneGroups.value.length > 0 && zoneGroups.value.every((group) => collapsedZones.value.has(group.zoneName)));


### PR DESCRIPTION
Update documentation and a UI component to reflect runtime behavior and UX improvements: describe that only enabled certificates are considered for scheduled renewal; explain use of ACME CA-provided suggestedWindow and Retry-After timing (with a fallback to Acmebot__RenewBeforeExpiry) and that schedulers retry after six hours on failure; remove the prior global renewal jitter; add documentation for a new /api/renewals endpoint; and update security docs to require app roles for issue, manual renewal, and revoke operations. Also change CertificateTable.vue to use toSorted with localeCompare for deterministic zone name sorting.