### PR TITLE
Preserve cert order and reverse chain for merge

### DIFF
--- a/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
@@ -167,7 +167,7 @@ public partial class AcmeOrderActivities(
 
         var mergeCertificateOptions = new MergeCertificateOptions(
             certificateName,
-            // Key Vault exports the merged chain in reverse order, so submit it root-first to produce leaf-first PFX/PEM output.
+            // Key Vault exports the merged chain in reverse order, so submit it issuer-most-first to produce leaf-first PFX/PEM output.
             x509Certificates
                 .Cast<X509Certificate2>()
                 .Reverse()

--- a/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
@@ -111,7 +111,11 @@ public partial class AcmeOrderActivities(
             var certificatePolicy = certificatePolicyItem.ToCertificatePolicy();
             var tags = certificatePolicyItem.ToCertificateTags(_options.Endpoint);
 
-            var certificateOperation = await certificateClient.StartCreateCertificateAsync(certificatePolicyItem.CertificateName, certificatePolicy, tags: tags);
+            var certificateOperation = await certificateClient.StartCreateCertificateAsync(
+                certificatePolicyItem.CertificateName,
+                certificatePolicy,
+                tags: tags,
+                preserveCertificateOrder: true);
 
             csr = certificateOperation.Properties.Csr;
         }
@@ -163,7 +167,12 @@ public partial class AcmeOrderActivities(
 
         var mergeCertificateOptions = new MergeCertificateOptions(
             certificateName,
-            [x509Certificates.Export(X509ContentType.Pfx)]
+            // Key Vault exports the merged chain in reverse order, so submit it root-first to produce leaf-first PFX/PEM output.
+            x509Certificates
+                .Cast<X509Certificate2>()
+                .Reverse()
+                .Select(static certificate => certificate.RawData)
+                .ToArray()
         );
 
         var mergedCertificate = (await certificateClient.MergeCertificateAsync(mergeCertificateOptions)).Value;


### PR DESCRIPTION
This pull request introduces improvements to the certificate creation and merging logic in the `AcmeOrderActivities` orchestration functions. The main changes focus on ensuring certificate order is preserved during creation and correcting the order of certificate chains during merging to produce the desired output format.

**Certificate creation improvements:**

* Updated the call to `StartCreateCertificateAsync` to set `preserveCertificateOrder: true`, ensuring the certificate order is maintained during creation.

**Certificate merging logic:**

* Modified the construction of `MergeCertificateOptions` to reverse the order of certificates before merging, addressing the issue where Key Vault exports the merged chain in reverse order. This ensures the resulting PFX/PEM output is in the correct leaf-first order.

Fixes #984