### PR TITLE
Update URL for asking questions in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/polymind-inc/acmebot/discussions/new
+    url: https://github.com/polymind-inc/acmebot/discussions/new?category=q-a
     about: Ask a question about this project


### PR DESCRIPTION
This pull request makes a minor update to the issue template configuration by updating the URL for asking questions to direct users to the Q&A category in project discussions.