### PR TITLE
Fix auth check to fail closed when User.Identity is null

### DIFF
--- a/src/Acmebot.App/Functions/Http/AddCertificate.cs
+++ b/src/Acmebot.App/Functions/Http/AddCertificate.cs
@@ -22,7 +22,7 @@ public partial class AddCertificate(IHttpContextAccessor httpContextAccessor, Ap
         [FromBody] CertificatePolicyItem certificatePolicyItem,
         [DurableClient] DurableTaskClient starter)
     {
-        if (!User.Identity?.IsAuthenticated ?? false)
+        if (User.Identity?.IsAuthenticated != true)
         {
             return Unauthorized();
         }

--- a/src/Acmebot.App/Functions/Http/GetCertificateRenewals.cs
+++ b/src/Acmebot.App/Functions/Http/GetCertificateRenewals.cs
@@ -24,7 +24,7 @@ public partial class GetCertificateRenewals(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "api/renewals")] HttpRequest req,
         [DurableClient] DurableTaskClient starter)
     {
-        if (!User.Identity?.IsAuthenticated ?? false)
+        if (User.Identity?.IsAuthenticated != true)
         {
             return Unauthorized();
         }

--- a/src/Acmebot.App/Functions/Http/GetCertificates.cs
+++ b/src/Acmebot.App/Functions/Http/GetCertificates.cs
@@ -18,7 +18,7 @@ public partial class GetCertificates(
     public async Task<IActionResult> HttpStart(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "api/certificates")] HttpRequest req)
     {
-        if (!User.Identity?.IsAuthenticated ?? false)
+        if (User.Identity?.IsAuthenticated != true)
         {
             return Unauthorized();
         }

--- a/src/Acmebot.App/Functions/Http/GetDnsZones.cs
+++ b/src/Acmebot.App/Functions/Http/GetDnsZones.cs
@@ -18,7 +18,7 @@ public partial class GetDnsZones(
     public async Task<IActionResult> HttpStart(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "api/dns-zones")] HttpRequest req)
     {
-        if (!User.Identity?.IsAuthenticated ?? false)
+        if (User.Identity?.IsAuthenticated != true)
         {
             return Unauthorized();
         }

--- a/src/Acmebot.App/Functions/Http/GetOperation.cs
+++ b/src/Acmebot.App/Functions/Http/GetOperation.cs
@@ -16,7 +16,7 @@ public partial class GetOperation(IHttpContextAccessor httpContextAccessor, ILog
         string instanceId,
         [DurableClient] DurableTaskClient starter)
     {
-        if (!User.Identity?.IsAuthenticated ?? false)
+        if (User.Identity?.IsAuthenticated != true)
         {
             return Unauthorized();
         }

--- a/src/Acmebot.App/Functions/Http/RenewCertificate.cs
+++ b/src/Acmebot.App/Functions/Http/RenewCertificate.cs
@@ -23,7 +23,7 @@ public partial class RenewCertificate(
         string certificateName,
         [DurableClient] DurableTaskClient starter)
     {
-        if (!User.Identity?.IsAuthenticated ?? false)
+        if (User.Identity?.IsAuthenticated != true)
         {
             return Unauthorized();
         }

--- a/src/Acmebot.App/Functions/Http/RevokeCertificate.cs
+++ b/src/Acmebot.App/Functions/Http/RevokeCertificate.cs
@@ -20,7 +20,7 @@ public partial class RevokeCertificate(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "api/certificates/{certificateName}/revoke")] HttpRequest req,
         string certificateName)
     {
-        if (!User.Identity?.IsAuthenticated ?? false)
+        if (User.Identity?.IsAuthenticated != true)
         {
             return Unauthorized();
         }

--- a/src/Acmebot.App/Functions/Http/StaticPage.cs
+++ b/src/Acmebot.App/Functions/Http/StaticPage.cs
@@ -12,7 +12,7 @@ public class StaticPage(IHttpContextAccessor httpContextAccessor) : HttpFunction
     public IActionResult Serve(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "{*path}")] HttpRequest req)
     {
-        if (!IsAuthenticationEnabled || !(User.Identity?.IsAuthenticated ?? false))
+        if (!IsAuthenticationEnabled || User.Identity?.IsAuthenticated != true)
         {
             return Unauthorized();
         }


### PR DESCRIPTION
## Summary

- Fix the authenticated-user guard in all HTTP endpoints so it fails closed when `User.Identity` is null.

## Related Issue

- Closes #

## What Changed

- All HTTP endpoints used `if (!User.Identity?.IsAuthenticated ?? false)`. Because `!` binds tighter than `??`, this parses as `(!(User.Identity?.IsAuthenticated)) ?? false`. When `User.Identity` is null the expression evaluates to `false`, so the request was **not** rejected and the handler proceeded (fail-open).
- Replaced the check with the clearer, correct form `if (User.Identity?.IsAuthenticated != true)` so that a null **or** non-authenticated identity always returns `Unauthorized`.
  - `!= true` treats `null`, `false`, and `true` correctly (only an authenticated `true` proceeds). Note `== false` would reintroduce the bug, since `null == false` is `false`.
- Updated files:
  - `AddCertificate`, `RevokeCertificate`, `RenewCertificate`, `GetCertificates`, `GetCertificateRenewals`, `GetDnsZones`, `GetOperation`
  - `StaticPage` aligned to the same form (`!IsAuthenticationEnabled || User.Identity?.IsAuthenticated != true`)

## Validation

- [x] `dotnet build -c Release ./Acmebot.slnx`
- [ ] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx`
- [ ] `az bicep build -f ./deploy/azuredeploy.bicep`
- [ ] Documentation updated if needed

## Notes

- Behavior is unchanged for the normal case where `User.Identity` is non-null; this only hardens the null path. No functional change to authenticated flows.
- Surfaced during a security review of the HTTP API surface.