### PR TITLE
Fix selector specificity for empty table SVG color

### DIFF
--- a/src/Acmebot.App/ClientApp/src/styles/app.css
+++ b/src/Acmebot.App/ClientApp/src/styles/app.css
@@ -813,7 +813,7 @@ button:disabled {
   font-size: 0.95rem;
 }
 
-.table-empty svg {
+.table-empty > svg {
   color: var(--color-faint);
 }
 


### PR DESCRIPTION
This pull request makes a minor CSS selector adjustment to improve styling specificity for empty table icons.

- Changed the selector from `.table-empty svg` to `.table-empty > svg` in `app.css` to ensure only direct child SVG elements of `.table-empty` are targeted for color styling.