### PR TITLE
Rename CI workflow file and update its name to match the purpose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build
+name: CI
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Release
 
 on:
   push:
@@ -10,7 +10,7 @@ env:
   RELEASE_ASSET_NAME: acmebot.zip
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to improve naming consistency and clarify their purposes. The main changes involve renaming workflow files and jobs, as well as updating workflow names.

**Workflow file and job renaming:**

* Renamed `.github/workflows/publish.yml` to `.github/workflows/release.yml` and updated the workflow name from "Publish" to "Release" for clarity.
* Changed the job name in the release workflow from `publish` to `release` for consistency with the workflow name.

**General workflow improvements:**

* Updated the name of the build workflow from "Build" to "CI" in `.github/workflows/ci.yml` to better reflect its purpose.