### PR TITLE
Add per-certificate ACME profile support

### DIFF
--- a/docs/guide/certificate-authorities.md
+++ b/docs/guide/certificate-authorities.md
@@ -63,13 +63,15 @@ If no matching alternate chain is found, Acmebot uses the default chain returned
 
 ## Preferred Profile
 
-If the ACME server advertises certificate profiles, use `PreferredProfile` to request one.
+If the ACME server advertises certificate profiles, use `PreferredProfile` to request one by default.
 
 ```text
 Acmebot__PreferredProfile=<profile-name>
 ```
 
-Acmebot validates advertised profiles before using them. If the profile is not advertised by the directory, certificate issuance fails early.
+You can override the deployment default for a single certificate by setting an ACME profile in the dashboard advanced options, passing `--profile <profile-name>` to `acmebot certificate issue`, or sending the `profile` field to `POST /api/certificates`.
+
+Acmebot sends the requested profile to the CA when creating the order. If the CA does not recognize the profile, it rejects the order and issuance fails. Per-certificate profiles are saved in Acmebot metadata and reused during manual and scheduled renewal.
 
 ## Staging and Production
 

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -56,6 +56,10 @@ Use the delegated DNS-01 issue mode when the DNS provider selected in Acmebot ma
 
 Set DNS Alias when the ACME challenge should be created under another domain. Acmebot then writes TXT records at `_acme-challenge.<dnsAlias>` with the selected DNS provider. The alias value must not include the `_acme-challenge` prefix. In delegated DNS-01 mode, the dashboard generates a unique alias record in the selected alias zone and shows the CNAME records to create in the certificate domain's DNS provider.
 
+### ACME Profile
+
+Set ACME Profile when the certificate should use a specific profile advertised by the configured ACME directory. If omitted, Acmebot uses the deployment-level `Acmebot__PreferredProfile` setting when configured. The selected profile is saved with the certificate metadata and reused during renewal.
+
 ### Tags
 
 Custom tags are written to the Key Vault certificate. The `Acmebot` tag is reserved for internal metadata and cannot be set manually.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -56,6 +56,7 @@ Accept: application/json
   "keySize": 2048,
   "reuseKey": false,
   "dnsAlias": "acme-validation.example.net",
+  "profile": "tlsserver",
   "tags": {
     "owner": "platform"
   }
@@ -74,6 +75,7 @@ Accept: application/json
 | `keyCurveName` | For EC | `P-256`, `P-384`, `P-521`, or `P-256K`. |
 | `reuseKey` | No | Whether Key Vault should reuse the certificate key. |
 | `dnsAlias` | No | Alternate ASCII/punycode domain used for DNS-01 validation. Acmebot writes TXT records at `_acme-challenge.<dnsAlias>`, so omit the `_acme-challenge` prefix and trailing dot from this value. |
+| `profile` | No | ACME profile to request for this certificate. When omitted, Acmebot uses `Acmebot__PreferredProfile` if configured. |
 | `tags` | No | Custom Key Vault certificate tags. `Acmebot` is reserved. |
 
 For delegated DNS-01 validation, set `dnsNames` to the certificate names and set `dnsAlias` to a unique record in a zone Acmebot can update. For each DNS name, create a CNAME from `_acme-challenge.<dnsName>` to `_acme-challenge.<dnsAlias>` in the authoritative DNS provider for the certificate domain.
@@ -159,7 +161,7 @@ POST /api/certificates/wildcard-example-com/renew
 Accept: application/json
 ```
 
-Returns `202 Accepted` with a `Location` header for operation polling.
+Returns `202 Accepted` with a `Location` header for operation polling. Renewal restores the per-certificate ACME profile saved in Acmebot metadata; certificates without one use the deployment-level `Acmebot__PreferredProfile` setting when configured.
 
 ## Revocation
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -146,6 +146,7 @@ acmebot certificate issue --dns-name "*.example.com" --dns-provider "Azure DNS"
 | `--key-curve <curve>` | EC key curve. Valid values are `P-256`, `P-384`, `P-521`, and `P-256K`. Defaults to `P-256`. Valid only with `--key-type EC`. |
 | `--reuse-key` | Reuse the existing Key Vault certificate key. |
 | `--dns-alias <value>` | DNS-01 validation alias. Omit the `_acme-challenge` prefix. |
+| `--profile <value>` | ACME profile to request for this certificate. If omitted, Acmebot uses the deployment-level preferred profile when configured. |
 | `--tag <name=value>` | Key Vault certificate tag. Repeatable. The `Acmebot` tag name is reserved. |
 | `--no-wait` | Return after the operation is accepted instead of polling until completion. |
 

--- a/src/Acmebot.App/Acmebot.App.csproj
+++ b/src/Acmebot.App/Acmebot.App.csproj
@@ -41,6 +41,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Acmebot.App.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="wwwroot\**">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Acmebot.App/ClientApp/src/api/mockData.ts
+++ b/src/Acmebot.App/ClientApp/src/api/mockData.ts
@@ -114,6 +114,7 @@ let mockCertificates: CertificateItem[] = [
     isSameEndpoint: true,
     acmeEndpoint: 'https://acme-v02.api.letsencrypt.org/directory',
     dnsAlias: 'dns-alias.fabrikam.net',
+    profile: 'tlsserver',
   },
   {
     id: 'https://mock.vault/certificates/portal-example-org',

--- a/src/Acmebot.App/ClientApp/src/api/types.ts
+++ b/src/Acmebot.App/ClientApp/src/api/types.ts
@@ -20,6 +20,7 @@ export interface CertificateItem {
   isSameEndpoint: boolean;
   acmeEndpoint?: string | null;
   dnsAlias?: string | null;
+  profile?: string | null;
   tags?: Record<string, string> | null;
 }
 
@@ -45,6 +46,7 @@ export interface CertificatePolicyItem {
   keyCurveName?: KeyCurveName;
   reuseKey?: boolean;
   dnsAlias?: string;
+  profile?: string;
   tags?: Record<string, string>;
 }
 

--- a/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
@@ -71,6 +71,7 @@ const form = reactive({
   keySize: 2048,
   keyCurveName: 'P-256' as KeyCurveName,
   reuseKey: false,
+  profile: '',
   tags: [] as CertificateTagInput[],
 });
 
@@ -161,6 +162,7 @@ watch(
       form.keySize = 2048;
       form.keyCurveName = 'P-256';
       form.reuseKey = false;
+      form.profile = '';
       form.tags = [];
     }
   },
@@ -177,6 +179,7 @@ function resetForm(): void {
   form.keySize = 2048;
   form.keyCurveName = 'P-256';
   form.reuseKey = false;
+  form.profile = '';
   form.tags = [];
 }
 
@@ -284,6 +287,10 @@ function submit(): void {
 
   if (form.useAdvancedOptions && tagCount.value > 0) {
     policy.tags = tagValidation.value.tags;
+  }
+
+  if (form.useAdvancedOptions && form.profile.trim()) {
+    policy.profile = form.profile.trim();
   }
 
   emit('submit', policy);
@@ -457,6 +464,7 @@ function submit(): void {
               v-model:key-size="form.keySize"
               v-model:key-curve-name="form.keyCurveName"
               v-model:reuse-key="form.reuseKey"
+              v-model:profile="form.profile"
               v-model:tags="form.tags"
               :certificate-name-error="certificateNameError"
               :key-option-error="keyOptionError"

--- a/src/Acmebot.App/ClientApp/src/components/AdvancedCertificateOptions.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AdvancedCertificateOptions.vue
@@ -17,6 +17,7 @@ const props = defineProps<{
   keySize: number;
   keyCurveName: KeyCurveName;
   reuseKey: boolean;
+  profile: string;
   tags: CertificateTagInput[];
   tagError: string;
 }>();
@@ -27,6 +28,7 @@ const emit = defineEmits<{
   'update:keySize': [value: number];
   'update:keyCurveName': [value: KeyCurveName];
   'update:reuseKey': [value: boolean];
+  'update:profile': [value: string];
   'update:tags': [value: CertificateTagInput[]];
 }>();
 
@@ -163,6 +165,16 @@ function updateReuseKey(event: Event): void {
         <option value="false">No</option>
         <option value="true">Yes</option>
       </select>
+    </label>
+
+    <label class="form-field">
+      <span class="form-label">ACME Profile</span>
+      <input
+        :value="profile"
+        type="text"
+        placeholder="Deployment default"
+        @input="emit('update:profile', readFieldValue($event))"
+      >
     </label>
 
     <div class="tag-editor advanced-grid__wide">

--- a/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
+++ b/src/Acmebot.App/ClientApp/src/components/DetailsDrawer.vue
@@ -69,6 +69,14 @@ const metadataRows = computed<MetadataRow[]>(() => {
     });
   }
 
+  if (certificate.profile) {
+    rows.push({
+      key: 'profile',
+      label: 'ACME profile',
+      value: certificate.profile,
+    });
+  }
+
   return rows;
 });
 

--- a/src/Acmebot.App/Extensions/CertificateExtensions.cs
+++ b/src/Acmebot.App/Extensions/CertificateExtensions.cs
@@ -48,6 +48,7 @@ internal static class CertificateExtensions
             Enabled = certificate.Properties.Enabled != false,
             AcmeEndpoint = !string.IsNullOrEmpty(metadata?.Endpoint) ? NormalizeEndpoint(metadata.Endpoint) : "",
             DnsAlias = metadata?.DnsAlias ?? "",
+            Profile = metadata?.Profile,
             Tags = certificate.Properties.Tags.GetCustomCertificateTags()
         };
     }
@@ -67,6 +68,7 @@ internal static class CertificateExtensions
             KeyCurveName = certificate.Policy.KeyCurveName?.ToString(),
             ReuseKey = certificate.Policy.ReuseKey,
             DnsAlias = metadata?.DnsAlias ?? "",
+            Profile = metadata?.Profile,
             CertificateId = metadata?.CertificateId,
             Tags = certificate.Properties.Tags.GetCustomCertificateTags()
         };
@@ -93,7 +95,8 @@ internal static class CertificateExtensions
         {
             Endpoint = endpoint.Host,
             DnsProvider = certificatePolicyItem.DnsProviderName,
-            DnsAlias = string.IsNullOrEmpty(certificatePolicyItem.DnsAlias) ? null : certificatePolicyItem.DnsAlias
+            DnsAlias = string.IsNullOrEmpty(certificatePolicyItem.DnsAlias) ? null : certificatePolicyItem.DnsAlias,
+            Profile = string.IsNullOrWhiteSpace(certificatePolicyItem.Profile) ? null : certificatePolicyItem.Profile.Trim()
         };
 
         tags[AcmebotTagKey] = JsonSerializer.Serialize(metadata, s_jsonOptions);
@@ -191,6 +194,9 @@ internal static class CertificateExtensions
 
         [JsonPropertyName("dnsAlias")]
         public string? DnsAlias { get; init; }
+
+        [JsonPropertyName("profile")]
+        public string? Profile { get; init; }
 
         [JsonPropertyName("certificateId")]
         public string? CertificateId { get; set; }

--- a/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
@@ -26,12 +26,13 @@ public partial class AcmeOrderActivities(
     private readonly AcmebotOptions _options = options.Value;
 
     [Function(nameof(Order))]
-    public async Task<OrderDetails> Order([ActivityTrigger] (IReadOnlyList<string>, string?) input)
+    public async Task<OrderDetails> Order([ActivityTrigger] (IReadOnlyList<string>, string?, string?) input)
     {
-        var (dnsNames, requestedReplaces) = input;
+        var (dnsNames, requestedReplaces, requestedProfile) = input;
 
         var acmeContext = await acmeClientFactory.CreateClientAsync();
         var replaces = acmeContext.Directory.RenewalInfo is not null ? requestedReplaces : null;
+        var profile = NormalizeProfile(requestedProfile) ?? NormalizeProfile(_options.PreferredProfile);
 
         var result = await acmeContext.Client.CreateOrderAsync(
             acmeContext.Account,
@@ -40,7 +41,7 @@ public partial class AcmeOrderActivities(
                 Type = AcmeIdentifierTypes.Dns,
                 Value = x
             }).ToArray(),
-            profile: _options.PreferredProfile,
+            profile: profile,
             replaces: replaces);
 
         return OrderDetails.FromResult(result);
@@ -189,4 +190,6 @@ public partial class AcmeOrderActivities(
 
     [LoggerMessage(LogLevel.Error, "ACME domain validation failed. ProblemDetails: {ProblemDetailsJson}")]
     private static partial void LogAcmeDomainValidationError(ILogger logger, string problemDetailsJson);
+
+    private static string? NormalizeProfile(string? profile) => string.IsNullOrWhiteSpace(profile) ? null : profile.Trim();
 }

--- a/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
@@ -22,7 +22,7 @@ public partial class CertificateIssuanceOrchestrator
             certificatePolicyItem.DnsProviderName = await context.CallDns01PreconditionAsync(certificatePolicyItem);
 
             // 新しく ACME Order を作成する (ARI で更新扱いにする場合は既存証明書の Certificate ID を replaces に指定)
-            var orderDetails = await context.CallOrderAsync((certificatePolicyItem.DnsNames, certificatePolicyItem.CertificateId));
+            var orderDetails = await context.CallOrderAsync((certificatePolicyItem.DnsNames, certificatePolicyItem.CertificateId, certificatePolicyItem.Profile));
 
             // 既に確認済みの場合は Challenge をスキップする
             if (orderDetails.Payload.Status != AcmeOrderStatuses.Ready)

--- a/src/Acmebot.App/Models/CertificateItem.cs
+++ b/src/Acmebot.App/Models/CertificateItem.cs
@@ -52,6 +52,9 @@ public class CertificateItem
     [JsonPropertyName("dnsAlias")]
     public string? DnsAlias { get; set; }
 
+    [JsonPropertyName("profile")]
+    public string? Profile { get; set; }
+
     [JsonPropertyName("tags")]
     public IReadOnlyDictionary<string, string>? Tags { get; set; }
 }

--- a/src/Acmebot.App/Models/CertificatePolicyItem.cs
+++ b/src/Acmebot.App/Models/CertificatePolicyItem.cs
@@ -32,6 +32,9 @@ public partial class CertificatePolicyItem : IValidatableObject
     [JsonPropertyName("dnsAlias")]
     public string? DnsAlias { get; set; }
 
+    [JsonPropertyName("profile")]
+    public string? Profile { get; set; }
+
     [JsonPropertyName("tags")]
     public IDictionary<string, string>? Tags { get; set; }
 

--- a/src/Acmebot.Cli/CertificatePolicyFactory.cs
+++ b/src/Acmebot.Cli/CertificatePolicyFactory.cs
@@ -93,6 +93,7 @@ internal static partial class CertificatePolicyFactory
             KeyCurveName = keyCurveName,
             ReuseKey = commandLine.HasOption("reuse-key") ? commandLine.GetFlag("reuse-key") : null,
             DnsAlias = NormalizeDnsNameOption(commandLine.GetOption("dns-alias"), "--dns-alias", allowWildcard: false),
+            Profile = NormalizeOptionalValue(commandLine.GetOption("profile")),
             Tags = ParseTags(commandLine.GetOptions("tag"))
         };
     }

--- a/src/Acmebot.Cli/CliOptionNames.cs
+++ b/src/Acmebot.Cli/CliOptionNames.cs
@@ -23,6 +23,7 @@ internal static class CliOptionNames
         "key-size",
         "key-curve",
         "dns-alias",
+        "profile",
         "tag"
     };
 

--- a/src/Acmebot.Cli/HelpText.cs
+++ b/src/Acmebot.Cli/HelpText.cs
@@ -41,6 +41,7 @@ internal static class HelpText
         await writer.WriteLineAsync("  --key-curve <P-256|P-384|P-521|P-256K> EC key curve. Default: P-256.");
         await writer.WriteLineAsync("  --reuse-key                            Reuse the Key Vault certificate key.");
         await writer.WriteLineAsync("  --dns-alias <value>                    DNS-01 validation alias.");
+        await writer.WriteLineAsync("  --profile <value>                      ACME certificate profile.");
         await writer.WriteLineAsync("  --tag <name=value>                     Certificate tag. Repeatable.");
         await writer.WriteLineAsync("  --no-wait                              Return after the operation is accepted.");
     }

--- a/src/Acmebot.Cli/Models.cs
+++ b/src/Acmebot.Cli/Models.cs
@@ -28,6 +28,9 @@ internal sealed class CertificatePolicyItem
     [JsonPropertyName("dnsAlias")]
     public string? DnsAlias { get; set; }
 
+    [JsonPropertyName("profile")]
+    public string? Profile { get; set; }
+
     [JsonPropertyName("tags")]
     public IDictionary<string, string>? Tags { get; set; }
 }

--- a/tests/Acmebot.App.Tests/CertificateExtensionsTests.cs
+++ b/tests/Acmebot.App.Tests/CertificateExtensionsTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 
 using Acmebot.App.Extensions;
 using Acmebot.App.Models;

--- a/tests/Acmebot.App.Tests/CertificateExtensionsTests.cs
+++ b/tests/Acmebot.App.Tests/CertificateExtensionsTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+
+using Acmebot.App.Extensions;
+using Acmebot.App.Models;
+
+using Azure.Security.KeyVault.Certificates;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class CertificateExtensionsTests
+{
+    [Fact]
+    public void ToCertificateTags_WithProfile_StoresProfileInMetadata()
+    {
+        var policy = CreatePolicy(profile: " tlsserver ");
+
+        var tags = policy.ToCertificateTags(new Uri("https://acme.example/directory"));
+
+        using var metadata = JsonDocument.Parse(tags["Acmebot"]);
+        Assert.Equal("tlsserver", metadata.RootElement.GetProperty("profile").GetString());
+    }
+
+    [Fact]
+    public void ToCertificateTags_WithoutProfile_OmitsProfileFromMetadata()
+    {
+        var policy = CreatePolicy(profile: null);
+
+        var tags = policy.ToCertificateTags(new Uri("https://acme.example/directory"));
+
+        using var metadata = JsonDocument.Parse(tags["Acmebot"]);
+        Assert.False(metadata.RootElement.TryGetProperty("profile", out _));
+    }
+
+    [Fact]
+    public void ToCertificatePolicyItem_WithProfileMetadata_RestoresProfile()
+    {
+        var tags = CreatePolicy(profile: "tlsserver").ToCertificateTags(new Uri("https://acme.example/directory"));
+        var certificate = CreateCertificate(tags);
+
+        var policy = certificate.ToCertificatePolicyItem();
+
+        Assert.Equal("tlsserver", policy.Profile);
+    }
+
+    [Fact]
+    public void SetCertificateId_PreservesProfileMetadata()
+    {
+        var tags = CreatePolicy(profile: "tlsserver").ToCertificateTags(new Uri("https://acme.example/directory"));
+
+        tags.SetCertificateId("certificate-id");
+
+        using var metadata = JsonDocument.Parse(tags["Acmebot"]);
+        Assert.Equal("tlsserver", metadata.RootElement.GetProperty("profile").GetString());
+        Assert.Equal("certificate-id", metadata.RootElement.GetProperty("certificateId").GetString());
+    }
+
+    private static CertificatePolicyItem CreatePolicy(string? profile)
+    {
+        return new CertificatePolicyItem
+        {
+            CertificateName = "example-com",
+            DnsNames = ["example.com"],
+            DnsProviderName = "Azure DNS",
+            KeyType = "RSA",
+            KeySize = 2048,
+            Profile = profile
+        };
+    }
+
+    private static KeyVaultCertificateWithPolicy CreateCertificate(IDictionary<string, string> tags)
+    {
+        var subjectAlternativeNames = new SubjectAlternativeNames();
+        subjectAlternativeNames.DnsNames.Add("example.com");
+
+        var policy = new CertificatePolicy(WellKnownIssuerNames.Unknown, "CN=example.com", subjectAlternativeNames)
+        {
+            KeyType = CertificateKeyType.Rsa,
+            KeySize = 2048
+        };
+
+        var properties = new CertificateProperties("example-com");
+
+        foreach (var tag in tags)
+        {
+            properties.Tags[tag.Key] = tag.Value;
+        }
+
+        return CertificateModelFactory.KeyVaultCertificateWithPolicy(
+            properties,
+            new Uri("https://vault.example/keys/example-com/version"),
+            new Uri("https://vault.example/secrets/example-com/version"),
+            [],
+            policy);
+    }
+}

--- a/tests/Acmebot.Cli.Tests/AcmebotApiClientTests.cs
+++ b/tests/Acmebot.Cli.Tests/AcmebotApiClientTests.cs
@@ -75,7 +75,8 @@ public sealed class AcmebotApiClientTests
             DnsNames = ["example.com"],
             DnsProviderName = "Azure DNS",
             KeyType = "RSA",
-            KeySize = 2048
+            KeySize = 2048,
+            Profile = "tlsserver"
         }, TestContext.Current.CancellationToken);
 
         Assert.Equal(new Uri("https://acmebot.example/api/operations/abc"), location);
@@ -89,6 +90,7 @@ public sealed class AcmebotApiClientTests
         Assert.Equal("example", document.RootElement.GetProperty("certificateName").GetString());
         Assert.Equal("example.com", document.RootElement.GetProperty("dnsNames")[0].GetString());
         Assert.Equal("Azure DNS", document.RootElement.GetProperty("dnsProviderName").GetString());
+        Assert.Equal("tlsserver", document.RootElement.GetProperty("profile").GetString());
     }
 
     [Fact]

--- a/tests/Acmebot.Cli.Tests/CertificatePolicyTests.cs
+++ b/tests/Acmebot.Cli.Tests/CertificatePolicyTests.cs
@@ -85,6 +85,24 @@ public sealed class CertificatePolicyTests
     }
 
     [Fact]
+    public void Create_WithProfile_SetsProfile()
+    {
+        var policy = CertificatePolicyFactory.Create(CommandLine.Parse(
+        [
+            "certificate",
+            "issue",
+            "--dns-name",
+            "example.com",
+            "--dns-provider",
+            "Azure DNS",
+            "--profile",
+            " tlsserver "
+        ]));
+
+        Assert.Equal("tlsserver", policy.Profile);
+    }
+
+    [Fact]
     public void Create_WithWildcardDnsAlias_Throws()
     {
         var ex = Assert.Throws<CliException>(() => CertificatePolicyFactory.Create(CommandLine.Parse(


### PR DESCRIPTION
This pull request adds support for specifying and persisting ACME certificate profiles in Acmebot. Users can now set a certificate profile at the deployment, API, CLI, and dashboard levels, with per-certificate profiles saved and reused during renewal. The changes span documentation, backend, and frontend code, ensuring profile information is handled end-to-end.

**User-facing features and documentation:**

* Added support for specifying an ACME profile per certificate via the dashboard, CLI (`--profile`), and API (`profile` field), with fallback to a deployment-level default (`Acmebot__PreferredProfile`). Per-certificate profiles are saved in metadata and reused during renewal. Documentation has been updated throughout to describe these behaviors. [[1]](diffhunk://#diff-e4baa4dead20cd48e24e966617f047386446eb986c81fc2011e45534acdbeaefL66-R74) [[2]](diffhunk://#diff-1420d33a49070045f1430da4e11d56ca3e7b1c4a43c2009ae833bc3efdffcb59R59-R62) [[3]](diffhunk://#diff-370381df31c8d799afe0208a3b1f1c161b3f48ad3c5b5813e481c42f46161797R59) [[4]](diffhunk://#diff-370381df31c8d799afe0208a3b1f1c161b3f48ad3c5b5813e481c42f46161797R78) [[5]](diffhunk://#diff-370381df31c8d799afe0208a3b1f1c161b3f48ad3c5b5813e481c42f46161797L162-R164) [[6]](diffhunk://#diff-975000db2bb150ebdc1a762c178c531c19747c5c75a8147bec4a31e69945e711R149)

**Frontend changes (dashboard):**

* Added `profile` field support to the Add Certificate dialog and Advanced Options, including form state, submission, and display in the certificate details drawer. Types and mock data updated accordingly. [[1]](diffhunk://#diff-74e5b0ab07db2f541474ba8ddccd8d416f1aed6ff35c1a25b4d75940b3aff394R74) [[2]](diffhunk://#diff-74e5b0ab07db2f541474ba8ddccd8d416f1aed6ff35c1a25b4d75940b3aff394R165) [[3]](diffhunk://#diff-74e5b0ab07db2f541474ba8ddccd8d416f1aed6ff35c1a25b4d75940b3aff394R182) [[4]](diffhunk://#diff-74e5b0ab07db2f541474ba8ddccd8d416f1aed6ff35c1a25b4d75940b3aff394R292-R295) [[5]](diffhunk://#diff-74e5b0ab07db2f541474ba8ddccd8d416f1aed6ff35c1a25b4d75940b3aff394R467) [[6]](diffhunk://#diff-b9ae86f01189d1fdfb21c50f4afb981e4c1b469f12d84f638df274d2c35aaba6R20) [[7]](diffhunk://#diff-b9ae86f01189d1fdfb21c50f4afb981e4c1b469f12d84f638df274d2c35aaba6R31) [[8]](diffhunk://#diff-b9ae86f01189d1fdfb21c50f4afb981e4c1b469f12d84f638df274d2c35aaba6R170-R179) [[9]](diffhunk://#diff-5119876c339ea28b1c4454991fa0e4d029e5f829f61616dd43e0afc61d8f9784R72-R79) [[10]](diffhunk://#diff-cdea3bb27af2a238de5655e0dc14553ed8b16d5d150abf944a09711d06256d52R117) [[11]](diffhunk://#diff-1dede859c5c0d96d41465cb9900058f86ebe3e95a60daa1e05e51ad7c642a254R23) [[12]](diffhunk://#diff-1dede859c5c0d96d41465cb9900058f86ebe3e95a60daa1e05e51ad7c642a254R49)

**Backend changes (API, orchestration, and models):**

* Extended `CertificateItem`, `CertificatePolicyItem`, and metadata to include the `profile` field. Persisted the profile in certificate metadata and ensured it is used in all relevant flows (issuance, renewal, and display). [[1]](diffhunk://#diff-7d078dcb7c00987ef2311f1bd66076a5dd4290d58d44d76694cb218a203212fbR51) [[2]](diffhunk://#diff-7d078dcb7c00987ef2311f1bd66076a5dd4290d58d44d76694cb218a203212fbR71) [[3]](diffhunk://#diff-7d078dcb7c00987ef2311f1bd66076a5dd4290d58d44d76694cb218a203212fbL96-R99) [[4]](diffhunk://#diff-7d078dcb7c00987ef2311f1bd66076a5dd4290d58d44d76694cb218a203212fbR198-R200) [[5]](diffhunk://#diff-a0b41dedb647cfa21f499888695d33550344639a0c98154d9008ccf3a2f6369aR55-R57) [[6]](diffhunk://#diff-efddb66898db821457a5a5989403528a099cd5dae5fd7bc6d92700455682638bR35-R37)
* Updated orchestration and activity functions to accept and normalize the profile parameter, passing it to the ACME client when creating orders. [[1]](diffhunk://#diff-0a0200960d0f736a08081a244b12e480cada2703660f7a167ac84c4ee52dcdecL29-R35) [[2]](diffhunk://#diff-0a0200960d0f736a08081a244b12e480cada2703660f7a167ac84c4ee52dcdecL43-R44) [[3]](diffhunk://#diff-0a0200960d0f736a08081a244b12e480cada2703660f7a167ac84c4ee52dcdecR193-R194) [[4]](diffhunk://#diff-35b98ac32d04b0cdc95744f3e4d99860b77f9161a53d148acb0706cdec814281L25-R25)

**CLI support:**

* Added `--profile` option to the CLI and ensured it is included in the policy sent to the backend. [[1]](diffhunk://#diff-ff49c179456d3ac6e18f9193bded21da8785dba5358e62b8264c4b10c264afe4R96) [[2]](diffhunk://#diff-b49d23ac3900322cfd238f0991555ee196486afab8da4c1fe23efeee43ca5d8bR26)

**Project configuration:**

* Enabled test project access to internals for improved testability.

Close #1153 