### PR TITLE
Refactor certificate renewal logic and introduce new models

### DIFF
--- a/src/Acmebot.App/Extensions/DnsZoneExtensions.cs
+++ b/src/Acmebot.App/Extensions/DnsZoneExtensions.cs
@@ -9,7 +9,37 @@ internal static class DnsZoneExtensions
 
     public static DnsZone? FindDnsZone(this IEnumerable<DnsZone> dnsZones, string dnsName)
     {
-        return dnsZones.Where(x => string.Equals(dnsName, x.Name, StringComparison.OrdinalIgnoreCase) || dnsName.EndsWith($".{x.Name}", StringComparison.OrdinalIgnoreCase))
-                       .MaxBy(x => x.Name.Length);
+        DnsZone? bestMatch = null;
+
+        foreach (var dnsZone in dnsZones)
+        {
+            if (!IsInZone(dnsName, dnsZone.Name))
+            {
+                continue;
+            }
+
+            if (bestMatch is null || dnsZone.Name.Length > bestMatch.Name.Length)
+            {
+                bestMatch = dnsZone;
+            }
+        }
+
+        return bestMatch;
+    }
+
+    private static bool IsInZone(string dnsName, string zoneName)
+    {
+        if (dnsName.Length < zoneName.Length)
+        {
+            return false;
+        }
+
+        if (!dnsName.EndsWith(zoneName, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return dnsName.Length == zoneName.Length ||
+               dnsName[dnsName.Length - zoneName.Length - 1] == '.';
     }
 }

--- a/src/Acmebot.App/Functions/Http/GetCertificateRenewals.cs
+++ b/src/Acmebot.App/Functions/Http/GetCertificateRenewals.cs
@@ -43,7 +43,7 @@ public partial class GetCertificateRenewals(
         return Ok(output);
     }
 
-    private static async Task<RenewalScheduleSnapshot?> GetRenewalSchedule(DurableTaskClient starter, string certificateName, CancellationToken cancellationToken)
+    private static async Task<CertificateRenewalScheduleSnapshot?> GetRenewalSchedule(DurableTaskClient starter, string certificateName, CancellationToken cancellationToken)
     {
         var instanceId = CertificateRenewalSchedulerOrchestrator.GetInstanceId(certificateName);
 
@@ -54,16 +54,16 @@ public partial class GetCertificateRenewals(
             return null;
         }
 
-        return new RenewalScheduleSnapshot(
+        return new CertificateRenewalScheduleSnapshot(
             ReadSchedulerStatus(metadata),
             metadata.RuntimeStatus,
             metadata.FailureDetails?.ErrorMessage,
             metadata.LastUpdatedAt);
     }
 
-    private static CertificateRenewalItem CreateRenewalItem(CertificateRenewalTarget certificate, RenewalScheduleSnapshot? schedule)
+    private static CertificateRenewalItem CreateRenewalItem(CertificateRenewalTarget certificate, CertificateRenewalScheduleSnapshot? schedule)
     {
-        var state = GetRenewalState(certificate, schedule);
+        var state = CertificateRenewalStateEvaluator.GetRenewalState(certificate, schedule);
 
         return new CertificateRenewalItem
         {
@@ -73,41 +73,6 @@ public partial class GetCertificateRenewals(
             Message = state.Message,
             NextCheck = state.NextCheck,
             LastCheckedAt = state.LastCheckedAt
-        };
-    }
-
-    private static RenewalState GetRenewalState(CertificateRenewalTarget certificate, RenewalScheduleSnapshot? schedule)
-    {
-        var lastCheckedAt = schedule?.Status?.UpdatedAt ?? schedule?.LastUpdatedAt;
-
-        if (!certificate.Enabled)
-        {
-            return new RenewalState("Disabled", "disabled", "Automatic renewal is paused because this certificate is disabled.", null, lastCheckedAt);
-        }
-
-        if (!certificate.IsIssuedByAcmebot || !certificate.IsSameEndpoint)
-        {
-            return new RenewalState("Not managed", "neutral", "This certificate is not managed by this Acmebot endpoint.", null, lastCheckedAt);
-        }
-
-        if (schedule is null)
-        {
-            return new RenewalState("Not scheduled", "pending", "Automatic renewal will start after the daily renewal check runs.", null, null);
-        }
-
-        if (schedule.RuntimeStatus is OrchestrationRuntimeStatus.Failed or OrchestrationRuntimeStatus.Terminated or OrchestrationRuntimeStatus.Suspended)
-        {
-            return new RenewalState("Needs attention", "attention", schedule.FailureMessage ?? "Automatic renewal is not running.", null, schedule.LastUpdatedAt);
-        }
-
-        return schedule.Status switch
-        {
-            { State: "Scheduled" } status => new RenewalState("Scheduled", "scheduled", status.Reason, status.NextCheck, status.UpdatedAt),
-            { State: "Renewing" } status => new RenewalState("Renewing", "active", status.Reason, null, status.UpdatedAt),
-            { State: "Retrying" } status => new RenewalState("Retrying", "attention", status.Reason, status.NextCheck, status.UpdatedAt),
-            { State: "Stopped" } status => new RenewalState("Stopped", "attention", status.Reason, null, status.UpdatedAt),
-            { State: "Checking" } status => new RenewalState("Checking", "pending", status.Reason, null, status.UpdatedAt),
-            _ => new RenewalState("Checking", "pending", "Automatic renewal status is being refreshed.", null, schedule.LastUpdatedAt)
         };
     }
 
@@ -127,19 +92,6 @@ public partial class GetCertificateRenewals(
             return null;
         }
     }
-
-    private sealed record RenewalScheduleSnapshot(
-        CertificateRenewalSchedulerStatus? Status,
-        OrchestrationRuntimeStatus RuntimeStatus,
-        string? FailureMessage,
-        DateTimeOffset LastUpdatedAt);
-
-    private sealed record RenewalState(
-        string Status,
-        string StatusKind,
-        string Message,
-        DateTimeOffset? NextCheck,
-        DateTimeOffset? LastCheckedAt);
 
     [LoggerMessage(LogLevel.Information, "Certificate renewals retrieved. Count: {Count}")]
     private static partial void LogCertificateRenewalsRetrieved(ILogger logger, int count);

--- a/src/Acmebot.App/Functions/Orchestration/CertificateActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateActivities.cs
@@ -94,7 +94,7 @@ public class CertificateActivities(
                     return new CertificateRenewalEvaluation
                     {
                         IsActive = true,
-                        ShouldRenew = CheckShouldRenew(properties, now),
+                        ShouldRenew = CertificateRenewalScheduleEvaluator.ShouldRenew(properties.NotBefore, properties.CreatedOn, properties.ExpiresOn, _options.RenewBeforeExpiry, now),
                         NextCheck = now.Add(s_renewalInfoCheckInterval),
                         Reason = "Renewal information is temporarily unavailable. Using the configured schedule and rechecking soon."
                     };
@@ -105,7 +105,7 @@ public class CertificateActivities(
         return new CertificateRenewalEvaluation
         {
             IsActive = true,
-            ShouldRenew = CheckShouldRenew(properties, now),
+            ShouldRenew = CertificateRenewalScheduleEvaluator.ShouldRenew(properties.NotBefore, properties.CreatedOn, properties.ExpiresOn, _options.RenewBeforeExpiry, now),
             NextCheck = now.AddDays(1),
             Reason = "Renewal is scheduled based on the configured renewal threshold."
         };
@@ -114,39 +114,8 @@ public class CertificateActivities(
     [Function(nameof(GetCertificatePolicy))]
     public Task<CertificatePolicyItem> GetCertificatePolicy([ActivityTrigger] string certificateName) => certificateOperationService.GetCertificatePolicyAsync(certificateName);
 
-    private bool CheckShouldRenew(CertificateProperties properties, DateTimeOffset now)
-    {
-        if (properties.ExpiresOn is not { } expiresOn)
-        {
-            return false;
-        }
-
-        var notBefore = properties.NotBefore ?? properties.CreatedOn;
-
-        if (expiresOn <= now)
-        {
-            return true;
-        }
-
-        if (notBefore is null || notBefore.Value > expiresOn)
-        {
-            return false;
-        }
-
-        var lifetime = expiresOn - notBefore.Value;
-        var renewalThreshold = TimeSpan.FromTicks((long)(lifetime.Ticks * (_options.RenewBeforeExpiry / 100d)));
-        var suggestedWindowStart = expiresOn - renewalThreshold;
-
-        return suggestedWindowStart <= now;
-    }
-
     private static DateTimeOffset SelectNextCheck(DateTimeOffset now, DateTimeOffset suggestedWindowStart, DateTimeOffset suggestedWindowEnd, TimeSpan? retryAfter)
     {
-        var window = suggestedWindowEnd - suggestedWindowStart;
-
-        var randomRenewalTime = suggestedWindowStart.AddTicks(Random.Shared.NextInt64(window.Ticks));
-        var nextRenewalInfoCheck = now.Add(retryAfter ?? s_renewalInfoCheckInterval);
-
-        return randomRenewalTime <= nextRenewalInfoCheck ? randomRenewalTime : nextRenewalInfoCheck;
+        return CertificateRenewalScheduleEvaluator.SelectNextCheck(now, suggestedWindowStart, suggestedWindowEnd, retryAfter, s_renewalInfoCheckInterval);
     }
 }

--- a/src/Acmebot.App/Functions/Orchestration/DnsChallengeActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/DnsChallengeActivities.cs
@@ -48,7 +48,7 @@ public class DnsChallengeActivities(
             var queryResult = await lookupClient.QueryAsync(zone.Name, QueryType.NS);
 
             var expectedNameServers = zone.NameServers
-                                          .Select<string, string>(x => x.TrimEnd('.'))
+                                          .Select(x => x.TrimEnd('.'))
                                           .ToArray();
 
             var actualNameServers = queryResult.Answers

--- a/src/Acmebot.App/Models/CertificateRenewalTarget.cs
+++ b/src/Acmebot.App/Models/CertificateRenewalTarget.cs
@@ -1,0 +1,6 @@
+﻿namespace Acmebot.App.Models;
+
+public sealed record CertificateRenewalTarget(string Name, bool Enabled, bool IsIssuedByAcmebot, bool IsSameEndpoint)
+{
+    public bool IsRenewable => Enabled && IsIssuedByAcmebot && IsSameEndpoint;
+}

--- a/src/Acmebot.App/Models/DnsZoneGroup.cs
+++ b/src/Acmebot.App/Models/DnsZoneGroup.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Acmebot.App.Models;
+
+public class DnsZoneGroup
+{
+    [JsonPropertyName("dnsProviderName")]
+    public required string DnsProviderName { get; set; }
+
+    [JsonPropertyName("dnsZones")]
+    public required IReadOnlyList<DnsZoneItem> DnsZones { get; set; }
+}

--- a/src/Acmebot.App/Models/DnsZoneItem.cs
+++ b/src/Acmebot.App/Models/DnsZoneItem.cs
@@ -7,12 +7,3 @@ public class DnsZoneItem
     [JsonPropertyName("name")]
     public required string Name { get; set; }
 }
-
-public class DnsZoneGroup
-{
-    [JsonPropertyName("dnsProviderName")]
-    public required string DnsProviderName { get; set; }
-
-    [JsonPropertyName("dnsZones")]
-    public required IReadOnlyList<DnsZoneItem> DnsZones { get; set; }
-}

--- a/src/Acmebot.App/Properties/AssemblyInfo.cs
+++ b/src/Acmebot.App/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Acmebot.App.Tests")]

--- a/src/Acmebot.App/Services/CertificateQueryService.cs
+++ b/src/Acmebot.App/Services/CertificateQueryService.cs
@@ -66,8 +66,3 @@ public class CertificateQueryService(
         return result;
     }
 }
-
-public sealed record CertificateRenewalTarget(string Name, bool Enabled, bool IsIssuedByAcmebot, bool IsSameEndpoint)
-{
-    public bool IsRenewable => Enabled && IsIssuedByAcmebot && IsSameEndpoint;
-}

--- a/src/Acmebot.App/Services/CertificateRenewalScheduleEvaluator.cs
+++ b/src/Acmebot.App/Services/CertificateRenewalScheduleEvaluator.cs
@@ -1,0 +1,51 @@
+﻿namespace Acmebot.App.Services;
+
+internal static class CertificateRenewalScheduleEvaluator
+{
+    public static bool ShouldRenew(
+        DateTimeOffset? notBefore,
+        DateTimeOffset? createdOn,
+        DateTimeOffset? expiresOn,
+        int renewBeforeExpiry,
+        DateTimeOffset now)
+    {
+        if (expiresOn is not { } expires)
+        {
+            return false;
+        }
+
+        var effectiveNotBefore = notBefore ?? createdOn;
+
+        if (expires <= now)
+        {
+            return true;
+        }
+
+        if (effectiveNotBefore is null || effectiveNotBefore.Value > expires)
+        {
+            return false;
+        }
+
+        var lifetime = expires - effectiveNotBefore.Value;
+        var renewalThreshold = TimeSpan.FromTicks((long)(lifetime.Ticks * (renewBeforeExpiry / 100d)));
+        var suggestedWindowStart = expires - renewalThreshold;
+
+        return suggestedWindowStart <= now;
+    }
+
+    public static DateTimeOffset SelectNextCheck(
+        DateTimeOffset now,
+        DateTimeOffset suggestedWindowStart,
+        DateTimeOffset suggestedWindowEnd,
+        TimeSpan? retryAfter,
+        TimeSpan renewalInfoCheckInterval,
+        Func<long, long>? nextInt64 = null)
+    {
+        var window = suggestedWindowEnd - suggestedWindowStart;
+        var randomOffsetTicks = nextInt64?.Invoke(window.Ticks) ?? Random.Shared.NextInt64(window.Ticks);
+        var randomRenewalTime = suggestedWindowStart.AddTicks(randomOffsetTicks);
+        var nextRenewalInfoCheck = now.Add(retryAfter ?? renewalInfoCheckInterval);
+
+        return randomRenewalTime <= nextRenewalInfoCheck ? randomRenewalTime : nextRenewalInfoCheck;
+    }
+}

--- a/src/Acmebot.App/Services/CertificateRenewalScheduleSnapshot.cs
+++ b/src/Acmebot.App/Services/CertificateRenewalScheduleSnapshot.cs
@@ -1,0 +1,11 @@
+﻿using Acmebot.App.Models;
+
+using Microsoft.DurableTask.Client;
+
+namespace Acmebot.App.Services;
+
+internal sealed record CertificateRenewalScheduleSnapshot(
+    CertificateRenewalSchedulerStatus? Status,
+    OrchestrationRuntimeStatus RuntimeStatus,
+    string? FailureMessage,
+    DateTimeOffset LastUpdatedAt);

--- a/src/Acmebot.App/Services/CertificateRenewalState.cs
+++ b/src/Acmebot.App/Services/CertificateRenewalState.cs
@@ -1,0 +1,8 @@
+﻿namespace Acmebot.App.Services;
+
+internal sealed record CertificateRenewalState(
+    string Status,
+    string StatusKind,
+    string Message,
+    DateTimeOffset? NextCheck,
+    DateTimeOffset? LastCheckedAt);

--- a/src/Acmebot.App/Services/CertificateRenewalStateEvaluator.cs
+++ b/src/Acmebot.App/Services/CertificateRenewalStateEvaluator.cs
@@ -1,0 +1,43 @@
+﻿using Acmebot.App.Models;
+
+using Microsoft.DurableTask.Client;
+
+namespace Acmebot.App.Services;
+
+internal static class CertificateRenewalStateEvaluator
+{
+    public static CertificateRenewalState GetRenewalState(CertificateRenewalTarget certificate, CertificateRenewalScheduleSnapshot? schedule)
+    {
+        var lastCheckedAt = schedule?.Status?.UpdatedAt ?? schedule?.LastUpdatedAt;
+
+        if (!certificate.Enabled)
+        {
+            return new CertificateRenewalState("Disabled", "disabled", "Automatic renewal is paused because this certificate is disabled.", null, lastCheckedAt);
+        }
+
+        if (!certificate.IsIssuedByAcmebot || !certificate.IsSameEndpoint)
+        {
+            return new CertificateRenewalState("Not managed", "neutral", "This certificate is not managed by this Acmebot endpoint.", null, lastCheckedAt);
+        }
+
+        if (schedule is null)
+        {
+            return new CertificateRenewalState("Not scheduled", "pending", "Automatic renewal will start after the daily renewal check runs.", null, null);
+        }
+
+        if (schedule.RuntimeStatus is OrchestrationRuntimeStatus.Failed or OrchestrationRuntimeStatus.Terminated or OrchestrationRuntimeStatus.Suspended)
+        {
+            return new CertificateRenewalState("Needs attention", "attention", schedule.FailureMessage ?? "Automatic renewal is not running.", null, schedule.LastUpdatedAt);
+        }
+
+        return schedule.Status switch
+        {
+            { State: "Scheduled" } status => new CertificateRenewalState("Scheduled", "scheduled", status.Reason, status.NextCheck, status.UpdatedAt),
+            { State: "Renewing" } status => new CertificateRenewalState("Renewing", "active", status.Reason, null, status.UpdatedAt),
+            { State: "Retrying" } status => new CertificateRenewalState("Retrying", "attention", status.Reason, status.NextCheck, status.UpdatedAt),
+            { State: "Stopped" } status => new CertificateRenewalState("Stopped", "attention", status.Reason, null, status.UpdatedAt),
+            { State: "Checking" } status => new CertificateRenewalState("Checking", "pending", status.Reason, null, status.UpdatedAt),
+            _ => new CertificateRenewalState("Checking", "pending", "Automatic renewal status is being refreshed.", null, schedule.LastUpdatedAt)
+        };
+    }
+}

--- a/tests/Acmebot.App.Tests/AppRoleServiceTests.cs
+++ b/tests/Acmebot.App.Tests/AppRoleServiceTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Security.Claims;
+
+using Acmebot.App.Options;
+using Acmebot.App.Services;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class AppRoleServiceTests
+{
+    [Fact]
+    public void HasRoles_WhenAppRolesAreNotRequired_ReturnsTrue()
+    {
+        var service = CreateService(requireAppRoles: false);
+        var principal = CreatePrincipal();
+
+        Assert.True(service.HasIssueCertificateRole(principal));
+        Assert.True(service.HasRevokeCertificateRole(principal));
+    }
+
+    [Fact]
+    public void HasIssueCertificateRole_WithIssueRole_ReturnsTrue()
+    {
+        var service = CreateService(requireAppRoles: true);
+        var principal = CreatePrincipal(new Claim("roles", "Acmebot.IssueCertificate"));
+
+        Assert.True(service.HasIssueCertificateRole(principal));
+        Assert.False(service.HasRevokeCertificateRole(principal));
+    }
+
+    [Fact]
+    public void HasRevokeCertificateRole_WithRevokeRole_ReturnsTrue()
+    {
+        var service = CreateService(requireAppRoles: true);
+        var principal = CreatePrincipal(new Claim("roles", "Acmebot.RevokeCertificate"));
+
+        Assert.False(service.HasIssueCertificateRole(principal));
+        Assert.True(service.HasRevokeCertificateRole(principal));
+    }
+
+    [Fact]
+    public void HasRoles_WithDifferentClaimType_ReturnsFalse()
+    {
+        var service = CreateService(requireAppRoles: true);
+        var principal = CreatePrincipal(new Claim(ClaimTypes.Role, "Acmebot.IssueCertificate"));
+
+        Assert.False(service.HasIssueCertificateRole(principal));
+    }
+
+    private static AppRoleService CreateService(bool requireAppRoles)
+    {
+        return new AppRoleService(Microsoft.Extensions.Options.Options.Create(new AcmebotOptions
+        {
+            RequireAppRoles = requireAppRoles,
+            VaultBaseUrl = "https://vault.example.net/",
+            Contacts = "admin@example.com",
+            Endpoint = new Uri("https://acme.example.net/directory")
+        }));
+    }
+
+    private static ClaimsPrincipal CreatePrincipal(params Claim[] claims)
+    {
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "Test"));
+    }
+}

--- a/tests/Acmebot.App.Tests/CertificateExtensionsTests.cs
+++ b/tests/Acmebot.App.Tests/CertificateExtensionsTests.cs
@@ -1,0 +1,122 @@
+﻿using Acmebot.App.Extensions;
+using Acmebot.App.Models;
+
+using Azure.Security.KeyVault.Certificates;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class CertificateExtensionsTests
+{
+    private static readonly Uri s_endpoint = new("https://acme-v02.api.letsencrypt.org/directory");
+
+    [Fact]
+    public void IsIssuedByAcmebot_WithMetadataTag_ReturnsTrue()
+    {
+        var properties = CreateCertificateProperties(("Acmebot", """{"endpoint":"acme-v02.api.letsencrypt.org"}"""));
+
+        Assert.True(properties.IsIssuedByAcmebot());
+    }
+
+    [Fact]
+    public void IsIssuedByAcmebot_WithLegacyIssuerTag_ReturnsTrue()
+    {
+        var properties = CreateCertificateProperties(("Issuer", "Acmebot"));
+
+        Assert.True(properties.IsIssuedByAcmebot());
+    }
+
+    [Fact]
+    public void IsIssuedByAcmebot_WithNonAcmebotLegacyIssuerTag_ReturnsFalse()
+    {
+        var properties = CreateCertificateProperties(("Issuer", "Other"));
+
+        Assert.False(properties.IsIssuedByAcmebot());
+    }
+
+    [Theory]
+    [InlineData("""{"endpoint":"acme-v02.api.letsencrypt.org"}""")]
+    [InlineData("""{"endpoint":"https://acme-v02.api.letsencrypt.org/directory"}""")]
+    public void IsSameEndpoint_WithMetadataEndpoint_ReturnsTrue(string metadata)
+    {
+        var properties = CreateCertificateProperties(("Acmebot", metadata));
+
+        Assert.True(properties.IsSameEndpoint(s_endpoint));
+    }
+
+    [Fact]
+    public void IsSameEndpoint_WithInvalidMetadataJson_FallsBackToLegacyEndpointTag()
+    {
+        var properties = CreateCertificateProperties(
+            ("Acmebot", "{"),
+            ("Issuer", "Acmebot"),
+            ("Endpoint", "https://acme-v02.api.letsencrypt.org/directory"));
+
+        Assert.True(properties.IsSameEndpoint(s_endpoint));
+    }
+
+    [Fact]
+    public void TryGetCertificateId_WithCertificateIdInMetadata_ReturnsTrue()
+    {
+        var properties = CreateCertificateProperties(("Acmebot", """{"certificateId":"abc123"}"""));
+
+        var result = properties.TryGetCertificateId(out var certificateId);
+
+        Assert.True(result);
+        Assert.Equal("abc123", certificateId);
+    }
+
+    [Fact]
+    public void SetCertificateId_WithExistingMetadata_PreservesEndpointAndDnsProvider()
+    {
+        var tags = new Dictionary<string, string>
+        {
+            ["Acmebot"] = """{"endpoint":"acme-v02.api.letsencrypt.org","dnsProvider":"Azure DNS"}"""
+        };
+
+        tags.SetCertificateId("cert-id");
+
+        var properties = CreateCertificateProperties(tags.Select(x => (x.Key, x.Value)).ToArray());
+
+        Assert.True(properties.TryGetCertificateId(out var certificateId));
+        Assert.Equal("cert-id", certificateId);
+        Assert.True(properties.IsSameEndpoint(s_endpoint));
+    }
+
+    [Fact]
+    public void ToCertificateTags_TrimsCustomTagsAndSkipsReservedAcmebotTag()
+    {
+        var policy = new CertificatePolicyItem
+        {
+            CertificateName = "example-com",
+            DnsNames = ["example.com"],
+            DnsProviderName = "Azure DNS",
+            KeyType = "RSA",
+            KeySize = 2048,
+            Tags = new Dictionary<string, string>
+            {
+                [" environment "] = " production ",
+                ["Acmebot"] = "user supplied"
+            }
+        };
+
+        var tags = policy.ToCertificateTags(s_endpoint);
+
+        Assert.Equal("production", tags["environment"]);
+        Assert.Contains("Acmebot", tags.Keys);
+        Assert.DoesNotContain("user supplied", tags.Values);
+    }
+
+    private static CertificateProperties CreateCertificateProperties(params (string Key, string Value)[] tags)
+    {
+        var properties = new CertificateProperties("example-com");
+
+        foreach (var (key, value) in tags)
+        {
+            properties.Tags[key] = value;
+        }
+
+        return properties;
+    }
+}

--- a/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
+++ b/tests/Acmebot.App.Tests/CertificatePolicyItemTests.cs
@@ -125,20 +125,103 @@ public sealed class CertificatePolicyItemTests
         Assert.Empty(Validate(policy));
     }
 
+    [Theory]
+    [InlineData(2048)]
+    [InlineData(3072)]
+    [InlineData(4096)]
+    public void Validate_WithValidRsaKeySize_ReturnsNoError(int keySize)
+    {
+        var policy = CreatePolicy(keySize: keySize);
+
+        Assert.Empty(Validate(policy));
+    }
+
+    [Fact]
+    public void Validate_WithInvalidRsaKeySize_ReturnsError()
+    {
+        var policy = CreatePolicy(keySize: 1024);
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal("The KeySize must be 2048, 3072, or 4096 when KeyType is RSA.", result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("P-256")]
+    [InlineData("P-384")]
+    [InlineData("P-521")]
+    [InlineData("P-256K")]
+    public void Validate_WithValidEcCurve_ReturnsNoError(string keyCurveName)
+    {
+        var policy = CreatePolicy(keyType: "EC", keySize: null, keyCurveName: keyCurveName);
+
+        Assert.Empty(Validate(policy));
+    }
+
+    [Fact]
+    public void Validate_WithEcKeyMissingCurve_ReturnsError()
+    {
+        var policy = CreatePolicy(keyType: "EC", keySize: null, keyCurveName: null);
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal("The KeyCurveName must be P-256, P-384, P-521, or P-256K when KeyType is EC.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_WithReservedAcmebotTag_ReturnsError()
+    {
+        var policy = CreatePolicy(tags: new Dictionary<string, string> { ["Acmebot"] = "metadata" });
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal("The Acmebot tag is reserved for internal metadata.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_WithEmptyTagName_ReturnsError()
+    {
+        var policy = CreatePolicy(tags: new Dictionary<string, string> { [" "] = "value" });
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal("The Tags contains an empty tag name.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_WithDuplicateTagNames_ReturnsError()
+    {
+        var policy = CreatePolicy(tags: new Dictionary<string, string>
+        {
+            ["Environment"] = "production",
+            [" environment "] = "staging"
+        });
+
+        var result = Assert.Single(Validate(policy));
+
+        Assert.Equal("The Tags contains duplicate tag names.", result.ErrorMessage);
+    }
+
     private static CertificatePolicyItem CreatePolicy(
         string certificateName = "example-com",
         string[]? dnsNames = null,
         string dnsProviderName = "Azure DNS",
-        string? dnsAlias = null)
+        string? dnsAlias = null,
+        string keyType = "RSA",
+        int? keySize = 2048,
+        string? keyCurveName = null,
+        IDictionary<string, string>? tags = null)
     {
         return new CertificatePolicyItem
         {
             CertificateName = certificateName,
             DnsNames = dnsNames ?? ["example.com"],
             DnsProviderName = dnsProviderName,
-            KeyType = "RSA",
-            KeySize = 2048,
-            DnsAlias = dnsAlias
+            KeyType = keyType,
+            KeySize = keySize,
+            KeyCurveName = keyCurveName,
+            DnsAlias = dnsAlias,
+            Tags = tags
         };
     }
 

--- a/tests/Acmebot.App.Tests/CertificateRenewalScheduleEvaluatorTests.cs
+++ b/tests/Acmebot.App.Tests/CertificateRenewalScheduleEvaluatorTests.cs
@@ -1,0 +1,170 @@
+﻿using Acmebot.App.Services;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class CertificateRenewalScheduleEvaluatorTests
+{
+    [Fact]
+    public void ShouldRenew_WithoutExpirationDate_ReturnsFalse()
+    {
+        var now = new DateTimeOffset(2026, 6, 24, 0, 0, 0, TimeSpan.Zero);
+
+        var result = CertificateRenewalScheduleEvaluator.ShouldRenew(
+            notBefore: now.AddDays(-10),
+            createdOn: now.AddDays(-10),
+            expiresOn: null,
+            renewBeforeExpiry: 30,
+            now);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldRenew_WithExpiredCertificate_ReturnsTrue()
+    {
+        var now = new DateTimeOffset(2026, 6, 24, 0, 0, 0, TimeSpan.Zero);
+
+        var result = CertificateRenewalScheduleEvaluator.ShouldRenew(
+            notBefore: now.AddDays(-90),
+            createdOn: null,
+            expiresOn: now,
+            renewBeforeExpiry: 30,
+            now);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldRenew_WithoutValidStartDate_ReturnsFalse()
+    {
+        var now = new DateTimeOffset(2026, 6, 24, 0, 0, 0, TimeSpan.Zero);
+
+        var result = CertificateRenewalScheduleEvaluator.ShouldRenew(
+            notBefore: null,
+            createdOn: null,
+            expiresOn: now.AddDays(10),
+            renewBeforeExpiry: 30,
+            now);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldRenew_WithStartDateAfterExpiration_ReturnsFalse()
+    {
+        var now = new DateTimeOffset(2026, 6, 24, 0, 0, 0, TimeSpan.Zero);
+
+        var result = CertificateRenewalScheduleEvaluator.ShouldRenew(
+            notBefore: now.AddDays(20),
+            createdOn: null,
+            expiresOn: now.AddDays(10),
+            renewBeforeExpiry: 30,
+            now);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldRenew_BeforeRenewalThreshold_ReturnsFalse()
+    {
+        var notBefore = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var expiresOn = notBefore.AddDays(10);
+
+        var result = CertificateRenewalScheduleEvaluator.ShouldRenew(
+            notBefore,
+            createdOn: null,
+            expiresOn,
+            renewBeforeExpiry: 30,
+            now: expiresOn.AddDays(-3).AddTicks(-1));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldRenew_AtRenewalThreshold_ReturnsTrue()
+    {
+        var notBefore = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var expiresOn = notBefore.AddDays(10);
+
+        var result = CertificateRenewalScheduleEvaluator.ShouldRenew(
+            notBefore,
+            createdOn: null,
+            expiresOn,
+            renewBeforeExpiry: 30,
+            now: expiresOn.AddDays(-3));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldRenew_UsesCreatedOnWhenNotBeforeIsMissing()
+    {
+        var createdOn = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var expiresOn = createdOn.AddDays(10);
+
+        var result = CertificateRenewalScheduleEvaluator.ShouldRenew(
+            notBefore: null,
+            createdOn,
+            expiresOn,
+            renewBeforeExpiry: 30,
+            now: expiresOn.AddDays(-3));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void SelectNextCheck_WhenRandomRenewalTimeIsBeforeRetryCheck_ReturnsRandomRenewalTime()
+    {
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var suggestedWindowStart = now.AddHours(1);
+        var suggestedWindowEnd = now.AddHours(3);
+
+        var result = CertificateRenewalScheduleEvaluator.SelectNextCheck(
+            now,
+            suggestedWindowStart,
+            suggestedWindowEnd,
+            retryAfter: TimeSpan.FromHours(4),
+            renewalInfoCheckInterval: TimeSpan.FromHours(6),
+            nextInt64: _ => TimeSpan.FromHours(1).Ticks);
+
+        Assert.Equal(now.AddHours(2), result);
+    }
+
+    [Fact]
+    public void SelectNextCheck_WhenRetryCheckIsBeforeRandomRenewalTime_ReturnsRetryCheck()
+    {
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var suggestedWindowStart = now.AddHours(2);
+        var suggestedWindowEnd = now.AddHours(5);
+
+        var result = CertificateRenewalScheduleEvaluator.SelectNextCheck(
+            now,
+            suggestedWindowStart,
+            suggestedWindowEnd,
+            retryAfter: TimeSpan.FromMinutes(30),
+            renewalInfoCheckInterval: TimeSpan.FromHours(6),
+            nextInt64: _ => TimeSpan.FromHours(1).Ticks);
+
+        Assert.Equal(now.AddMinutes(30), result);
+    }
+
+    [Fact]
+    public void SelectNextCheck_WithoutRetryAfter_UsesDefaultRenewalInfoCheckInterval()
+    {
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var suggestedWindowStart = now.AddHours(2);
+        var suggestedWindowEnd = now.AddHours(5);
+
+        var result = CertificateRenewalScheduleEvaluator.SelectNextCheck(
+            now,
+            suggestedWindowStart,
+            suggestedWindowEnd,
+            retryAfter: null,
+            renewalInfoCheckInterval: TimeSpan.FromHours(1),
+            nextInt64: _ => TimeSpan.FromHours(1).Ticks);
+
+        Assert.Equal(now.AddHours(1), result);
+    }
+}

--- a/tests/Acmebot.App.Tests/CertificateRenewalStateEvaluatorTests.cs
+++ b/tests/Acmebot.App.Tests/CertificateRenewalStateEvaluatorTests.cs
@@ -1,0 +1,124 @@
+﻿using Acmebot.App.Models;
+using Acmebot.App.Services;
+
+using Microsoft.DurableTask.Client;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class CertificateRenewalStateEvaluatorTests
+{
+    private static readonly DateTimeOffset s_lastUpdatedAt = new(2026, 6, 24, 1, 2, 3, TimeSpan.Zero);
+    private static readonly DateTimeOffset s_statusUpdatedAt = new(2026, 6, 24, 2, 3, 4, TimeSpan.Zero);
+    private static readonly DateTimeOffset s_nextCheck = new(2026, 6, 25, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void GetRenewalState_WithDisabledCertificate_ReturnsDisabled()
+    {
+        var certificate = new CertificateRenewalTarget("example-com", Enabled: false, IsIssuedByAcmebot: true, IsSameEndpoint: true);
+        var schedule = CreateSchedule("Scheduled");
+
+        var state = CertificateRenewalStateEvaluator.GetRenewalState(certificate, schedule);
+
+        Assert.Equal("Disabled", state.Status);
+        Assert.Equal("disabled", state.StatusKind);
+        Assert.Null(state.NextCheck);
+        Assert.Equal(s_statusUpdatedAt, state.LastCheckedAt);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void GetRenewalState_WithCertificateNotManagedByThisEndpoint_ReturnsNotManaged(bool isIssuedByAcmebot, bool isSameEndpoint)
+    {
+        var certificate = new CertificateRenewalTarget("example-com", Enabled: true, isIssuedByAcmebot, isSameEndpoint);
+        var schedule = CreateSchedule("Scheduled");
+
+        var state = CertificateRenewalStateEvaluator.GetRenewalState(certificate, schedule);
+
+        Assert.Equal("Not managed", state.Status);
+        Assert.Equal("neutral", state.StatusKind);
+        Assert.Null(state.NextCheck);
+        Assert.Equal(s_statusUpdatedAt, state.LastCheckedAt);
+    }
+
+    [Fact]
+    public void GetRenewalState_WithoutSchedule_ReturnsNotScheduled()
+    {
+        var state = CertificateRenewalStateEvaluator.GetRenewalState(CreateManagedCertificate(), schedule: null);
+
+        Assert.Equal("Not scheduled", state.Status);
+        Assert.Equal("pending", state.StatusKind);
+        Assert.Null(state.NextCheck);
+        Assert.Null(state.LastCheckedAt);
+    }
+
+    [Theory]
+    [InlineData(OrchestrationRuntimeStatus.Failed)]
+    [InlineData(OrchestrationRuntimeStatus.Terminated)]
+    [InlineData(OrchestrationRuntimeStatus.Suspended)]
+    public void GetRenewalState_WithStoppedOrchestration_ReturnsNeedsAttention(OrchestrationRuntimeStatus runtimeStatus)
+    {
+        var schedule = new CertificateRenewalScheduleSnapshot(null, runtimeStatus, "scheduler failed", s_lastUpdatedAt);
+
+        var state = CertificateRenewalStateEvaluator.GetRenewalState(CreateManagedCertificate(), schedule);
+
+        Assert.Equal("Needs attention", state.Status);
+        Assert.Equal("attention", state.StatusKind);
+        Assert.Equal("scheduler failed", state.Message);
+        Assert.Null(state.NextCheck);
+        Assert.Equal(s_lastUpdatedAt, state.LastCheckedAt);
+    }
+
+    [Theory]
+    [InlineData("Scheduled", "scheduled", true)]
+    [InlineData("Renewing", "active", false)]
+    [InlineData("Retrying", "attention", true)]
+    [InlineData("Stopped", "attention", false)]
+    [InlineData("Checking", "pending", false)]
+    public void GetRenewalState_WithKnownSchedulerStatus_ReturnsMappedState(string schedulerState, string expectedKind, bool expectsNextCheck)
+    {
+        var schedule = CreateSchedule(schedulerState);
+
+        var state = CertificateRenewalStateEvaluator.GetRenewalState(CreateManagedCertificate(), schedule);
+
+        Assert.Equal(schedulerState, state.Status);
+        Assert.Equal(expectedKind, state.StatusKind);
+        Assert.Equal($"{schedulerState} reason", state.Message);
+        Assert.Equal(expectsNextCheck ? s_nextCheck : null, state.NextCheck);
+        Assert.Equal(s_statusUpdatedAt, state.LastCheckedAt);
+    }
+
+    [Fact]
+    public void GetRenewalState_WithUnknownSchedulerStatus_ReturnsChecking()
+    {
+        var schedule = CreateSchedule("Unexpected");
+
+        var state = CertificateRenewalStateEvaluator.GetRenewalState(CreateManagedCertificate(), schedule);
+
+        Assert.Equal("Checking", state.Status);
+        Assert.Equal("pending", state.StatusKind);
+        Assert.Equal("Automatic renewal status is being refreshed.", state.Message);
+        Assert.Null(state.NextCheck);
+        Assert.Equal(s_lastUpdatedAt, state.LastCheckedAt);
+    }
+
+    private static CertificateRenewalTarget CreateManagedCertificate() => new("example-com", Enabled: true, IsIssuedByAcmebot: true, IsSameEndpoint: true);
+
+    private static CertificateRenewalScheduleSnapshot CreateSchedule(string state)
+    {
+        return new CertificateRenewalScheduleSnapshot(
+            new CertificateRenewalSchedulerStatus
+            {
+                CertificateName = "example-com",
+                State = state,
+                NextCheck = s_nextCheck,
+                Reason = $"{state} reason",
+                UpdatedAt = s_statusUpdatedAt
+            },
+            OrchestrationRuntimeStatus.Running,
+            null,
+            s_lastUpdatedAt);
+    }
+}

--- a/tests/Acmebot.App.Tests/DnsZoneExtensionsTests.cs
+++ b/tests/Acmebot.App.Tests/DnsZoneExtensionsTests.cs
@@ -1,0 +1,54 @@
+﻿using Acmebot.App.Extensions;
+using Acmebot.App.Providers;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class DnsZoneExtensionsTests
+{
+    [Fact]
+    public void FindDnsZone_WithNestedZones_ReturnsLongestSuffixMatch()
+    {
+        var provider = new TestDnsProvider("Test DNS");
+        var zones = new[]
+        {
+            CreateZone(provider, "root", "example.com"),
+            CreateZone(provider, "sub", "api.example.com")
+        };
+
+        var zone = zones.FindDnsZone("www.api.example.com");
+
+        Assert.NotNull(zone);
+        Assert.Equal("api.example.com", zone.Name);
+    }
+
+    [Fact]
+    public void FindDnsZone_WithDifferentCasing_ReturnsMatchingZone()
+    {
+        var provider = new TestDnsProvider("Test DNS");
+        var zones = new[] { CreateZone(provider, "root", "example.com") };
+
+        var zone = zones.FindDnsZone("WWW.EXAMPLE.COM");
+
+        Assert.NotNull(zone);
+        Assert.Equal("example.com", zone.Name);
+    }
+
+    [Fact]
+    public void FindDnsZone_WithNonBoundarySuffix_ReturnsNull()
+    {
+        var provider = new TestDnsProvider("Test DNS");
+        var zones = new[] { CreateZone(provider, "root", "example.com") };
+
+        var zone = zones.FindDnsZone("badexample.com");
+
+        Assert.Null(zone);
+    }
+
+    private static DnsZone CreateZone(TestDnsProvider provider, string id, string name) => new(provider)
+    {
+        Id = id,
+        Name = name
+    };
+}

--- a/tests/Acmebot.App.Tests/DnsZoneExtensionsTests.cs
+++ b/tests/Acmebot.App.Tests/DnsZoneExtensionsTests.cs
@@ -7,20 +7,22 @@ namespace Acmebot.App.Tests;
 
 public sealed class DnsZoneExtensionsTests
 {
-    [Fact]
-    public void FindDnsZone_WithNestedZones_ReturnsLongestSuffixMatch()
+    [Theory]
+    [InlineData("staging.example.com")]
+    [InlineData("www.staging.example.com")]
+    public void FindDnsZone_WithParentAndChildZones_ReturnsMostSpecificZone(string dnsName)
     {
         var provider = new TestDnsProvider("Test DNS");
         var zones = new[]
         {
             CreateZone(provider, "root", "example.com"),
-            CreateZone(provider, "sub", "api.example.com")
+            CreateZone(provider, "staging", "staging.example.com")
         };
 
-        var zone = zones.FindDnsZone("www.api.example.com");
+        var zone = zones.FindDnsZone(dnsName);
 
         Assert.NotNull(zone);
-        Assert.Equal("api.example.com", zone.Name);
+        Assert.Equal("staging.example.com", zone.Name);
     }
 
     [Fact]

--- a/tests/Acmebot.App.Tests/DnsZoneQueryServiceTests.cs
+++ b/tests/Acmebot.App.Tests/DnsZoneQueryServiceTests.cs
@@ -1,0 +1,96 @@
+﻿using Acmebot.App.Providers;
+using Acmebot.App.Services;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class DnsZoneQueryServiceTests
+{
+    [Fact]
+    public async Task GetAllDnsZonesAsync_SortsZonesWithinProviderGroup()
+    {
+        var provider = new TestDnsProvider(
+            "Test DNS",
+            [
+                CreateZone("b", "b.example.com"),
+                CreateZone("a", "a.example.com")
+            ]);
+        var service = new DnsZoneQueryService([provider]);
+
+        var groups = await service.GetAllDnsZonesAsync(TestContext.Current.CancellationToken);
+
+        var group = Assert.Single(groups);
+        Assert.Equal("Test DNS", group.DnsProviderName);
+        Assert.Equal(["a.example.com", "b.example.com"], group.DnsZones.Select(x => x.Name));
+    }
+
+    [Fact]
+    public async Task GetAllDnsZonesAsync_WhenProviderThrows_ReturnsEmptyGroupForThatProvider()
+    {
+        var failingProvider = new TestDnsProvider("Broken DNS", exception: new InvalidOperationException("boom"));
+        var workingProvider = new TestDnsProvider("Working DNS", [CreateZone("example", "example.com")]);
+        var service = new DnsZoneQueryService([failingProvider, workingProvider]);
+
+        var groups = await service.GetAllDnsZonesAsync(TestContext.Current.CancellationToken);
+
+        Assert.Collection(
+            groups,
+            group =>
+            {
+                Assert.Equal("Broken DNS", group.DnsProviderName);
+                Assert.Empty(group.DnsZones);
+            },
+            group =>
+            {
+                Assert.Equal("Working DNS", group.DnsProviderName);
+                Assert.Equal(["example.com"], group.DnsZones.Select(x => x.Name));
+            });
+    }
+
+    [Fact]
+    public async Task GetAllDnsZonesAsync_WhenCancellationIsRequested_ThrowsOperationCanceledException()
+    {
+        var provider = new TestDnsProvider("Test DNS", [CreateZone("example", "example.com")]);
+        var service = new DnsZoneQueryService([provider]);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await cancellationTokenSource.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => service.GetAllDnsZonesAsync(cancellationTokenSource.Token));
+    }
+
+    [Fact]
+    public async Task ListZonesAsync_WithUnknownProvider_ReturnsEmpty()
+    {
+        var provider = new TestDnsProvider("Test DNS", [CreateZone("example", "example.com")]);
+        var service = new DnsZoneQueryService([provider]);
+
+        var zones = await service.ListZonesAsync("Other DNS", TestContext.Current.CancellationToken);
+
+        Assert.Empty(zones);
+    }
+
+    [Fact]
+    public async Task ListZonesAsync_WithKnownProvider_ReturnsProviderZones()
+    {
+        var provider = new TestDnsProvider("Test DNS", [CreateZone("example", "example.com")]);
+        var service = new DnsZoneQueryService([provider]);
+
+        var zones = await service.ListZonesAsync("Test DNS", TestContext.Current.CancellationToken);
+
+        var zone = Assert.Single(zones);
+        Assert.Equal("example.com", zone.Name);
+    }
+
+    private static DnsZone CreateZone(string id, string name)
+    {
+        var provider = new TestDnsProvider("Test DNS");
+
+        return new DnsZone(provider)
+        {
+            Id = id,
+            Name = name
+        };
+    }
+}

--- a/tests/Acmebot.App.Tests/DnsZoneQueryServiceTests.cs
+++ b/tests/Acmebot.App.Tests/DnsZoneQueryServiceTests.cs
@@ -81,6 +81,7 @@ public sealed class DnsZoneQueryServiceTests
 
         var zone = Assert.Single(zones);
         Assert.Equal("example.com", zone.Name);
+        Assert.Same(provider, zone.DnsProvider);
     }
 
     private static DnsZone CreateZone(string id, string name)

--- a/tests/Acmebot.App.Tests/TestDnsProvider.cs
+++ b/tests/Acmebot.App.Tests/TestDnsProvider.cs
@@ -2,7 +2,7 @@
 
 namespace Acmebot.App.Tests;
 
-internal sealed class TestDnsProvider(string name, IReadOnlyList<DnsZone>? zones = null, Exception? exception = null, TimeSpan? propagationDelay = null) : IDnsProvider
+internal sealed class TestDnsProvider(string name, IReadOnlyList<DnsZone>? zoneDefinitions = null, Exception? exception = null, TimeSpan? propagationDelay = null) : IDnsProvider
 {
     public string Name { get; } = name;
 
@@ -17,10 +17,20 @@ internal sealed class TestDnsProvider(string name, IReadOnlyList<DnsZone>? zones
             throw exception;
         }
 
-        return Task.FromResult(zones ?? []);
+        return Task.FromResult<IReadOnlyList<DnsZone>>(zoneDefinitions?.Select(CreateZone).ToArray() ?? []);
     }
 
     public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default) => Task.CompletedTask;
 
     public Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    private DnsZone CreateZone(DnsZone zoneDefinition)
+    {
+        return new DnsZone(this)
+        {
+            Id = zoneDefinition.Id,
+            Name = zoneDefinition.Name,
+            NameServers = zoneDefinition.NameServers
+        };
+    }
 }

--- a/tests/Acmebot.App.Tests/TestDnsProvider.cs
+++ b/tests/Acmebot.App.Tests/TestDnsProvider.cs
@@ -1,0 +1,26 @@
+﻿using Acmebot.App.Providers;
+
+namespace Acmebot.App.Tests;
+
+internal sealed class TestDnsProvider(string name, IReadOnlyList<DnsZone>? zones = null, Exception? exception = null, TimeSpan? propagationDelay = null) : IDnsProvider
+{
+    public string Name { get; } = name;
+
+    public TimeSpan PropagationDelay { get; } = propagationDelay ?? TimeSpan.Zero;
+
+    public Task<IReadOnlyList<DnsZone>> ListZonesAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (exception is not null)
+        {
+            throw exception;
+        }
+
+        return Task.FromResult(zones ?? []);
+    }
+
+    public Task CreateTxtRecordAsync(DnsZone zone, string relativeRecordName, string[] values, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public Task DeleteTxtRecordAsync(DnsZone zone, string relativeRecordName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+}


### PR DESCRIPTION
- Updated GetCertificateRenewals function to use CertificateRenewalScheduleSnapshot instead of RenewalScheduleSnapshot.
- Moved renewal state logic to CertificateRenewalStateEvaluator and removed redundant methods.
- Introduced CertificateRenewalTarget model to encapsulate certificate properties.
- Created CertificateRenewalScheduleEvaluator to handle renewal evaluation logic.
- Added unit tests for CertificateRenewalScheduleEvaluator and CertificateRenewalStateEvaluator.
- Refactored DnsZone related classes and tests for improved clarity and functionality.
- Added AppRoleServiceTests and CertificateExtensionsTests to enhance test coverage.
- Introduced TestDnsProvider for testing DNS-related functionalities.