### PR TITLE
Stop renewal scheduler immediately when certificate is deleted

### DIFF
--- a/src/Acmebot.App/Functions/Orchestration/CertificateActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateActivities.cs
@@ -112,7 +112,19 @@ public class CertificateActivities(
     }
 
     [Function(nameof(GetCertificatePolicy))]
-    public Task<CertificatePolicyItem> GetCertificatePolicy([ActivityTrigger] string certificateName) => certificateOperationService.GetCertificatePolicyAsync(certificateName);
+    public async Task<CertificatePolicyItem> GetCertificatePolicy([ActivityTrigger] string certificateName)
+    {
+        try
+        {
+            return await certificateOperationService.GetCertificatePolicyAsync(certificateName);
+        }
+        catch (Azure.RequestFailedException ex) when (ex.Status == 404)
+        {
+            // The certificate was deleted after renewal evaluation. Surface this as a precondition failure
+            // so the scheduler can stop instead of treating it as a retriable renewal error.
+            throw new PreconditionException("Certificate was not found.", ex);
+        }
+    }
 
     private static DateTimeOffset SelectNextCheck(DateTimeOffset now, DateTimeOffset suggestedWindowStart, DateTimeOffset suggestedWindowEnd, TimeSpan? retryAfter)
     {

--- a/src/Acmebot.App/Functions/Orchestration/CertificateRenewalSchedulerOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateRenewalSchedulerOrchestrator.cs
@@ -34,11 +34,24 @@ public partial class CertificateRenewalSchedulerOrchestrator
         {
             SetSchedulerStatus(context, certificateName, "Renewing", null, "Automatic renewal is in progress.");
 
+            CertificatePolicyItem certificatePolicyItem;
+
+            try
+            {
+                certificatePolicyItem = await context.CallGetCertificatePolicyAsync(certificateName);
+            }
+            catch (TaskFailedException ex) when (ex.FailureDetails.IsCausedBy<PreconditionException>())
+            {
+                // The certificate was deleted between evaluation and policy retrieval, so stop the scheduler
+                // immediately instead of entering the retry loop.
+                SetSchedulerStatus(context, certificateName, "Stopped", null, "Certificate was not found.");
+                LogCertificateRenewalSchedulerStopped(logger, certificateName, "Certificate was not found.");
+                return;
+            }
+
             try
             {
                 LogCertificateRenewalStarted(logger, certificateName, evaluation.Reason);
-
-                var certificatePolicyItem = await context.CallGetCertificatePolicyAsync(certificateName);
 
                 await context.CallSubOrchestratorAsync(
                     nameof(CertificateIssuanceOrchestrator.IssueCertificate),

--- a/src/Acmebot.App/Functions/Orchestration/CertificateRenewalSchedulerOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateRenewalSchedulerOrchestrator.cs
@@ -48,6 +48,13 @@ public partial class CertificateRenewalSchedulerOrchestrator
                 LogCertificateRenewalSchedulerStopped(logger, certificateName, "Certificate was not found.");
                 return;
             }
+            catch (Exception ex)
+            {
+                // Any other policy retrieval failure (e.g. transient Key Vault or network errors) should fall back
+                // to the same retry path as a failed renewal rather than failing the orchestration outright.
+                await ScheduleRenewalRetryAsync(context, certificateName, logger, ex);
+                return;
+            }
 
             try
             {
@@ -60,14 +67,7 @@ public partial class CertificateRenewalSchedulerOrchestrator
             }
             catch (Exception ex)
             {
-                LogCertificateRenewalFailed(logger, ex, certificateName);
-
-                var nextCheck = context.CurrentUtcDateTime.Add(s_failedRenewalRetryInterval);
-                SetSchedulerStatus(context, certificateName, "Retrying", nextCheck, "Automatic renewal failed. Retrying later.");
-
-                await context.CreateTimer(nextCheck, CancellationToken.None);
-                context.ContinueAsNew(certificateName);
-
+                await ScheduleRenewalRetryAsync(context, certificateName, logger, ex);
                 return;
             }
 
@@ -91,6 +91,17 @@ public partial class CertificateRenewalSchedulerOrchestrator
     {
         HandleFailure = taskFailureDetails => taskFailureDetails.IsCausedBy<RetriableOrchestratorException>()
     };
+
+    private async Task ScheduleRenewalRetryAsync(TaskOrchestrationContext context, string certificateName, ILogger logger, Exception exception)
+    {
+        LogCertificateRenewalFailed(logger, exception, certificateName);
+
+        var nextCheck = context.CurrentUtcDateTime.Add(s_failedRenewalRetryInterval);
+        SetSchedulerStatus(context, certificateName, "Retrying", nextCheck, "Automatic renewal failed. Retrying later.");
+
+        await context.CreateTimer(nextCheck, CancellationToken.None);
+        context.ContinueAsNew(certificateName);
+    }
 
     private static void SetSchedulerStatus(TaskOrchestrationContext context, string certificateName, string state, DateTimeOffset? nextCheck, string reason)
     {


### PR DESCRIPTION
## Summary

- Make the per-certificate renewal scheduler stop right away when the certificate has been deleted from Key Vault, instead of logging a misleading error and parking in a 6-hour retry loop.

## Related Issue

- Closes #

## What Changed

- `EvaluateCertificateRenewal` already detects a deleted certificate (404 → `IsActive=false` → `Stopped`), but the scheduler then makes a **separate** `GetCertificatePolicy` Key Vault round-trip before issuance. If the certificate is deleted in that window, the 404 fell into the generic `catch` and put the scheduler into a 6-hour `Retrying` loop, emitting a renewal-failed error, until the next evaluation finally detected the deletion.
- `CertificateActivities.GetCertificatePolicy` now translates a Key Vault 404 into a `PreconditionException`.
- `CertificateRenewalSchedulerOrchestrator` fetches the policy in its own `try/catch` and, on a `PreconditionException`, transitions straight to `Stopped` and ends the orchestration — no spurious error, no 6-hour wait.

## Validation

- [x] `dotnet build -c Release ./Acmebot.slnx`
- [x] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx`
- [ ] `az bicep build -f ./deploy/azuredeploy.bicep` (no infra changes)
- [ ] Documentation updated if needed (no doc changes)

Existing `Acmebot.App.Tests` suite passes (87/87).

## Notes

- This came out of a review of the Durable Functions renewal flow for add/delete correctness. The eternal scheduler re-evaluates Key Vault existence on every `ContinueAsNew`, so deleted certificates are always eventually cleaned up; this change removes the remaining 6-hour latency + misleading error for the delete-during-evaluation race.
- Out of scope (assessed as low-impact or architecturally awkward, left as-is): certificate "resurrection" during an active renewal (mitigated by Key Vault soft-delete), the up-to-24h delay before a newly added certificate gets a scheduler (daily reconciliation by design), and singleton-izing `IssueCertificate` to guard manual+scheduled concurrency.