### PR TITLE
Grant contents:write to draft release validation job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Validate draft release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Check draft release
         env:


### PR DESCRIPTION
## Summary

- The `validate-draft-release` job in the Release workflow failed with `Draft release v5.1.0 does not exist`, blocking the entire release. The cause was insufficient token permission, not a missing draft.

## Related Issue

-

## What Changed

- Changed the `validate-draft-release` job permission from `contents: read` to `contents: write` in `.github/workflows/release.yml`.

## Notes

- Draft releases are only visible to a token with push (write) access. With `contents: read`, the workflow's `GITHUB_TOKEN` got a 404 from `gh release view "$TAG_NAME"`, so the validation step exited 1 even though the draft existed.
- The `upload-release-asset` and `publish-release` jobs already use `contents: write`; this aligns the validation job with them.
- This is a CI-only change — no application code, build, bicep, or docs are affected, so the standard build/format/bicep validation steps are not applicable.
- To take effect for `v5.1.0`, the `v5.1.0` tag needs to be moved to a commit that includes this fix (the workflow runs from the tagged commit's workflow file), then the Release workflow re-triggered.