### PR TITLE
Set GH_REPO so release jobs can resolve the repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ env:
   DOTNET_VERSION: 10.0.x
   NODE_VERSION: 24.x
   RELEASE_ASSET_NAME: acmebot.zip
-  GH_REPO: ${{ github.repository }}
 
 permissions: {}
 
@@ -22,6 +21,7 @@ jobs:
       - name: Check draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
           if ! gh release view "$TAG_NAME" > /dev/null 2>&1; then
@@ -110,6 +110,7 @@ jobs:
       - name: Upload release asset
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
         run: gh release upload "$TAG_NAME" "${{ env.RELEASE_ASSET_NAME }}" --clobber
 
@@ -150,5 +151,6 @@ jobs:
       - name: Publish draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
         run: gh release edit "$TAG_NAME" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ env:
   DOTNET_VERSION: 10.0.x
   NODE_VERSION: 24.x
   RELEASE_ASSET_NAME: acmebot.zip
+  GH_REPO: ${{ github.repository }}
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

- The Release workflow still fails at `Validate draft release` with `Draft release v5.1.0 does not exist`, even though the draft exists and (after #1168) the job has `contents: write`. The real cause is missing repository context for the `gh` CLI.

## Related Issue

-

## What Changed

- Added `GH_REPO: ${{ github.repository }}` to the workflow-level `env` in `.github/workflows/release.yml`.

## Notes

- The refactored workflow (#1154 / #1163) splits work into jobs that do **not** run `actions/checkout`: `validate-draft-release`, `upload-release-asset`, and `publish-release`. The `gh` CLI determines the target repo from the local git remote; with no checkout, no `--repo`, and no `GH_REPO`, it fails with `not a git repository`.
- In the validation step that error is hidden by `gh release view "$TAG_NAME" > /dev/null 2>&1`, so the `if !` branch fires and reports the misleading `Draft release <tag> does not exist`.
- Reproduced locally: `gh release view v5.1.0` from a non-repo dir → `failed to run git: fatal: not a git repository` (exit 1); with `GH_REPO=polymind-inc/acmebot` set → returns the draft (`isDraft: true`, exit 0).
- The previous single-job `publish.yml` (v5.0.4) avoided this because it ran `actions/checkout` first, giving `gh` a git remote to resolve. Setting `GH_REPO` at the workflow level restores that for all three `gh`-using jobs without adding checkouts.
- `contents: write` from #1168 is still required (draft releases are only visible to a token with push access); this PR adds the missing second half of the fix.
- CI-only change — no application code, build, bicep, or docs affected.