### PR TITLE
Enable clean URLs in VitePress configuration

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
   description: "ACME SSL/TLS certificate automation for Microsoft Azure.",
   lastUpdated: true,
   srcExclude: ["README.md"],
+  cleanUrls: true,
   sitemap: {
     hostname
   },

--- a/docs/.vitepress/theme/HomePage.vue
+++ b/docs/.vitepress/theme/HomePage.vue
@@ -18,7 +18,7 @@ function scrollToSection(event: MouseEvent, selector: string) {
         <p class="hero-description">Acmebot issues and renews ACME certificates with DNS-01 validation, stores private keys in Azure Key Vault, and gives your team one dashboard, API, and CLI.</p>
         <div class="hero-actions">
           <a href="#deploy" class="btn btn-primary" @click="scrollToSection($event, '#deploy')">Deploy to Azure</a>
-          <a href="/guide/getting-started.html" class="btn btn-outline">Get Started</a>
+          <a href="/guide/getting-started" class="btn btn-outline">Get Started</a>
         </div>
         <div class="hero-stats">
           <div class="hero-stat">
@@ -294,7 +294,7 @@ function scrollToSection(event: MouseEvent, selector: string) {
           </div>
         </div>
         <div class="steps-cta">
-          <a href="/guide/getting-started.html" class="btn btn-primary">Read the Documentation</a>
+          <a href="/guide/getting-started" class="btn btn-primary">Read the Documentation</a>
         </div>
       </div>
     </section>
@@ -356,7 +356,7 @@ function scrollToSection(event: MouseEvent, selector: string) {
             <div class="footer-col">
               <h4>Resources</h4>
               <a href="/guide/">Documentation</a>
-              <a href="/guide/getting-started.html">Getting Started</a>
+              <a href="/guide/getting-started">Getting Started</a>
               <a href="https://github.com/polymind-inc/acmebot/discussions">Discussions</a>
             </div>
             <div class="footer-col">


### PR DESCRIPTION
This pull request introduces a configuration change to the VitePress documentation site. The most important update is the enabling of clean URLs, which will result in more user-friendly and readable URLs for the documentation pages.

Documentation site configuration:

* Enabled the `cleanUrls` option in the VitePress config (`docs/.vitepress/config.ts`) to generate cleaner, extension-free URLs for documentation pages.