### PR TITLE
Add per-page meta descriptions to docs pages

### DIFF
--- a/docs/guide/certificate-authorities.md
+++ b/docs/guide/certificate-authorities.md
@@ -1,3 +1,7 @@
+---
+description: "Use Let's Encrypt, ZeroSSL, Google Trust Services, GlobalSign, or SSL.com as the ACME certificate authority for Acmebot on Azure."
+---
+
 # Certificate Authorities
 
 Acmebot works with ACME v2 certificate authorities (CAs). Configure the ACME directory endpoint with `Acmebot__Endpoint`.

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -1,3 +1,7 @@
+---
+description: "Manage Acmebot certificates from the built-in dashboard served by the Function App, backed by the same-origin HTTP API."
+---
+
 # Dashboard
 
 The dashboard is the primary interface for Acmebot. The Function App serves the dashboard, and the dashboard calls the same-origin `/api/*` endpoints.

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -1,3 +1,7 @@
+---
+description: "Deploy Acmebot v5 to Azure Functions Flex Consumption, storing ACME state in Azure Storage and certificates in Azure Key Vault."
+---
+
 # Deployment
 
 Acmebot v5 is generally available and is the current release for new deployments. It runs on Azure Functions Flex Consumption with the .NET isolated worker and stores ACME state in Azure Storage. The standard deployment template targets the Azure public cloud.

--- a/docs/guide/dns-providers.md
+++ b/docs/guide/dns-providers.md
@@ -1,3 +1,7 @@
+---
+description: "Configure ACME DNS-01 validation for Acmebot with Azure DNS, Cloudflare, Route 53, Google Cloud DNS, and 15+ supported DNS providers."
+---
+
 # DNS Providers
 
 Acmebot uses ACME DNS-01 validation. Every certificate operation creates one or more `_acme-challenge` TXT records, waits for propagation, asks the ACME server to validate them, and then deletes the records.

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -1,3 +1,7 @@
+---
+description: "Frequently asked questions about Acmebot: automatic renewal, DNS-01 validation, Azure Key Vault storage, and certificate lifecycle."
+---
+
 # FAQ
 
 ## How does automatic renewal work?

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,3 +1,7 @@
+---
+description: "Step-by-step guide to deploy Acmebot and issue your first Let's Encrypt certificate into Azure Key Vault with DNS-01 validation."
+---
+
 # Getting Started
 
 This walkthrough deploys a new Acmebot v5 environment and issues a certificate into Azure Key Vault.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,3 +1,7 @@
+---
+description: "Overview of how Acmebot automates ACME SSL/TLS certificate issuance and renewal on Microsoft Azure using DNS-01 validation and Azure Key Vault."
+---
+
 # Guide
 
 Acmebot automates ACME SSL/TLS certificate issuance and renewal on Microsoft Azure. It runs as a Function App, proves domain ownership with DNS-01 challenges, and stores private keys and issued certificates in Azure Key Vault.

--- a/docs/guide/migration-v5.md
+++ b/docs/guide/migration-v5.md
@@ -1,3 +1,7 @@
+---
+description: "Migrate Acmebot from v4 to v5, moving to the .NET isolated worker while keeping existing certificates, Key Vault, and DNS settings in place."
+---
+
 # Migrating from v4 to v5
 
 Acmebot v5 moves the application from the .NET in-process worker to the .NET isolated worker. Existing certificates, Key Vault, DNS provider settings, managed identity, and monitoring resources can stay in place.

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -1,3 +1,7 @@
+---
+description: "Day-to-day operation of Acmebot: issuing, renewing, and revoking ACME certificates in Azure Key Vault after deployment."
+---
+
 # Operations
 
 This page covers day-to-day operation after Acmebot has been deployed.

--- a/docs/guide/service-integration.md
+++ b/docs/guide/service-integration.md
@@ -1,3 +1,7 @@
+---
+description: "Use Acmebot certificates from Azure Key Vault with App Service, Application Gateway, Azure Front Door, CDN, and API Management."
+---
+
 # Azure Service Integration
 
 Acmebot stores issued certificates in Azure Key Vault. Each consuming Azure service is responsible for importing, referencing, or syncing the current certificate version into its own TLS configuration.

--- a/docs/guide/support.md
+++ b/docs/guide/support.md
@@ -1,3 +1,7 @@
+---
+description: "Support options for Acmebot: community support via GitHub and optional commercial support for Acmebot v5 from Polymind Inc."
+---
+
 # Support
 
 Acmebot is an open source project released under the Apache License 2.0. Community support remains available through GitHub, and optional commercial support for Acmebot v5 is available from Polymind Inc.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,3 +1,7 @@
+---
+description: "Troubleshoot Acmebot issuance, renewal, revocation, authentication, DNS-01 validation, and Azure service integration issues."
+---
+
 # Troubleshooting
 
 Use this page when issuance, renewal, revocation, authentication, DNS validation, or downstream Azure service integration does not behave as expected.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,3 +1,7 @@
+---
+description: "Acmebot HTTP API reference: the same-origin endpoints behind the dashboard for issuing, renewing, and managing certificates."
+---
+
 # HTTP API
 
 The dashboard uses these same-origin HTTP endpoints. They define the integration surface and operation lifecycle.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,3 +1,7 @@
+---
+description: "Acmebot architecture: how the Function App coordinates ACME orders, DNS-01 validation, Key Vault operations, and scheduled renewal."
+---
+
 # Architecture
 
 Acmebot is a Function App that coordinates ACME certificate orders, DNS-01 validation, Key Vault certificate operations, scheduled renewal, and optional notifications.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,3 +1,7 @@
+---
+description: "Acmebot CLI reference: the acmebot .NET tool that wraps the HTTP API for scriptable certificate automation in CI and runbooks."
+---
+
 # CLI Reference
 
 The Acmebot CLI is a .NET tool named `acmebot` that wraps the authenticated HTTP API for automation. Use it from local shells, CI jobs, or runbooks when you want scriptable certificate operations without calling the API directly.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,3 +1,7 @@
+---
+description: "Acmebot configuration reference: required and optional app settings for ACME endpoints, DNS providers, Key Vault, and renewal."
+---
+
 # Configuration
 
 Acmebot reads its settings from the `Acmebot` configuration section. In Azure App Service and Azure Functions app settings, nested settings are expressed with double underscores.

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -1,3 +1,7 @@
+---
+description: "Acmebot security model: Azure identity, Key Vault access, DNS provider credentials, and dashboard authentication boundaries."
+---
+
 # Security
 
 Acmebot relies on Azure identity, Key Vault, DNS provider credentials, and dashboard authentication. This page summarizes the security model and recommended operational boundaries.


### PR DESCRIPTION
## Summary

All `guide/` and `reference/` pages had no frontmatter, so every page inherited the site-wide `description` — resulting in **duplicate meta descriptions across all 17 docs pages**. This adds a unique, content-specific `description` to each page.

## Why

- Fixes duplicate meta descriptions (weak SEO signal / poor SERP snippets).
- Targets non-branded keywords people actually search (Let's Encrypt, Azure Key Vault, DNS-01, Front Door / App Gateway, ZeroSSL, etc.) via the snippet rather than cluttering the visible `<title>`.
- Complements the recently shipped sitemap + clean URLs work.

## Scope

- Adds only a `description` frontmatter field to 17 pages.
- **Page titles and H1 headings are unchanged** (titles stay clean).

Verified locally: `vitepress build` succeeds and each page emits its own unique `<meta name="description">`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)