### PR TITLE
Enhance documentation to reflect ARI-aware renewal features

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Acmebot is designed for teams that need to:
 
 - Store SSL/TLS certificates securely in Azure Key Vault
 - Centralize certificates for multiple Azure services and domains
-- Automate issuance and renewal with predictable operational behavior
+- Automate certificate fleets with per-certificate renewal state and predictable operational behavior
 - Monitor certificate operations through Application Insights and webhooks
 - Keep DNS provider credentials and Azure access scoped to the resources Acmebot manages
 
@@ -35,7 +35,8 @@ Acmebot is designed for teams that need to:
 
 - Issue certificates for zone apex names, wildcards, and SANs (multiple domains)
 - Dedicated dashboard for certificate management
-- Automated certificate renewal
+- ARI-aware renewal scheduling for each managed certificate, with CA-provided renewal windows, `Retry-After` timing, and an expiry-based fallback
+- Independent renewal state and next-check timing per certificate, built for long-running certificate fleets
 - Support for ACME v2 compliant Certification Authorities
   - [Let's Encrypt](https://letsencrypt.org/)
   - [GlobalSign](https://www.globalsign.com/) (Requires EAB Credentials)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -50,7 +50,7 @@ const hostname = "https://acmebot.dev";
 export default defineConfig({
   lang: "en-US",
   title: "Acmebot",
-  description: "ACME SSL/TLS certificate automation for Microsoft Azure.",
+  description: "ACME SSL/TLS certificate automation for Microsoft Azure, built around DNS-01 validation, ARI-aware renewal, and Azure Key Vault.",
   lastUpdated: true,
   srcExclude: ["README.md"],
   cleanUrls: true,

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -63,7 +63,7 @@ export default defineConfig({
     ["link", { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" }],
     ["link", { rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" }],
     ["meta", { property: "og:title", content: "Acmebot — Automated TLS certificates for Microsoft Azure" }],
-    ["meta", { property: "og:description", content: "ACME SSL/TLS certificate automation for Microsoft Azure, built around DNS-01 validation and Azure Key Vault." }],
+    ["meta", { property: "og:description", content: "ACME SSL/TLS certificate automation for Microsoft Azure, built around DNS-01 validation, ARI-aware renewal, and Azure Key Vault." }],
     ["meta", { property: "og:image", content: "https://acmebot.dev/images/ogp.png" }],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }]

--- a/docs/.vitepress/theme/HomePage.vue
+++ b/docs/.vitepress/theme/HomePage.vue
@@ -15,7 +15,7 @@ function scrollToSection(event: MouseEvent, selector: string) {
       <div class="container">
         <div class="hero-badge">Acmebot v5 &mdash; Production Ready</div>
         <h1 class="hero-title">Automated TLS certificates<br>for <span class="hero-highlight">Microsoft Azure</span></h1>
-        <p class="hero-description">Acmebot issues and renews ACME certificates with DNS-01 validation, stores private keys in Azure Key Vault, and gives your team one dashboard, API, and CLI.</p>
+        <p class="hero-description">Acmebot issues and renews ACME certificates with DNS-01 validation, ARI-aware renewal scheduling, and Azure Key Vault private key storage.</p>
         <div class="hero-actions">
           <a href="#deploy" class="btn btn-primary" @click="scrollToSection($event, '#deploy')">Deploy to Azure</a>
           <a href="/guide/getting-started" class="btn btn-outline">Get Started</a>
@@ -53,8 +53,8 @@ function scrollToSection(event: MouseEvent, selector: string) {
             <div class="feature-icon">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83" /></svg>
             </div>
-            <h3>Make renewal predictable</h3>
-            <p>The daily renewal job finds managed certificates, respects ACME renewal windows when available, and renews before expiry.</p>
+            <h3>Operate certificate fleets</h3>
+            <p>Each managed certificate keeps its own renewal state, next check time, CA-guided timing when available, and fallback behavior.</p>
           </div>
           <div class="feature-card">
             <div class="feature-icon">
@@ -105,7 +105,7 @@ function scrollToSection(event: MouseEvent, selector: string) {
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 12h-4l-3 9L9 3l-3 9H2" /></svg>
             </div>
             <h3>Use one operation model</h3>
-            <p>Issue, renew, revoke, and track operations through the same model whether you use the dashboard, HTTP API, or CLI.</p>
+            <p>Issue, renew, revoke, and track operations through the same model whether you use the dashboard, HTTP API, CLI, or scheduled renewal.</p>
           </div>
           <div class="v5-card">
             <div class="v5-icon">
@@ -257,6 +257,7 @@ function scrollToSection(event: MouseEvent, selector: string) {
             <p>Provision the Function App, storage, monitoring resources, application settings, and optional Key Vault for a new Acmebot environment.</p>
             <ul class="deploy-features">
               <li>Scheduled renewals</li>
+              <li>ARI-aware timing</li>
               <li>Key Vault storage</li>
               <li>Private network support</li>
               <li>Azure Monitor telemetry</li>

--- a/docs/guide/certificate-authorities.md
+++ b/docs/guide/certificate-authorities.md
@@ -1,5 +1,5 @@
 ---
-description: "Use Let's Encrypt, ZeroSSL, Google Trust Services, GlobalSign, or SSL.com as the ACME certificate authority for Acmebot on Azure."
+description: "Use Let's Encrypt, ZeroSSL, Google Trust Services, GlobalSign, or SSL.com as the ACME certificate authority for Acmebot on Azure, including ARI-aware renewal behavior."
 ---
 
 # Certificate Authorities
@@ -91,7 +91,7 @@ Acmebot tags each certificate with the endpoint that issued it and renews only c
 
 ## Renewal Behavior
 
-During scheduled renewal, Acmebot checks each enabled managed certificate in Key Vault. When the ACME directory supports renewal information, it uses the server-provided `suggestedWindow` and `Retry-After` timing; otherwise it renews when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent. See [Operations](./operations) for the full renewal schedule.
+During scheduled renewal, Acmebot checks each enabled managed certificate in Key Vault. When the ACME directory supports ACME Renewal Information (ARI), each certificate follows the server-provided `suggestedWindow` and `Retry-After` timing. Renewal orders include the previous certificate identifier as `replaces` when the CA advertises ARI support. When ARI is unavailable for a certificate, Acmebot renews that certificate when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent. See [Operations](./operations) for the full renewal schedule.
 
 ## CA Selection Guidance
 

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -1,5 +1,5 @@
 ---
-description: "Manage Acmebot certificates from the built-in dashboard served by the Function App, backed by the same-origin HTTP API."
+description: "Manage Acmebot certificates and ARI-aware renewal status from the built-in dashboard served by the Function App."
 ---
 
 # Dashboard
@@ -18,7 +18,7 @@ The dashboard lists certificates from the configured Key Vault and marks each on
 - Managed by Acmebot but issued for another ACME endpoint.
 - Not managed by Acmebot.
 
-Only enabled certificates with Acmebot metadata for the current endpoint are selected for scheduled renewal.
+Only enabled certificates with Acmebot metadata for the current endpoint are selected for scheduled renewal. Renewal status is tracked per managed certificate, including its current state, next check time, and last check time.
 
 ## DNS Zone List
 
@@ -72,7 +72,7 @@ Custom tags are written to the Key Vault certificate. The `Acmebot` tag is reser
 
 Manual renewal reuses the existing Key Vault certificate policy and starts a new issuance orchestration. Use it to rotate a certificate before its scheduled renewal window.
 
-Scheduled renewals run daily. Certificates with ACME renewal information use the CA's suggested window and `Retry-After` timing; certificates without renewal information use the configured fallback threshold.
+Scheduled renewals run daily. Each managed certificate keeps its own renewal state and next check time. Certificates with ACME Renewal Information (ARI) use the CA's suggested window and `Retry-After` timing; certificates without renewal information use the configured fallback threshold.
 
 ## Revoke a Certificate
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -1,18 +1,24 @@
 ---
-description: "Frequently asked questions about Acmebot: automatic renewal, DNS-01 validation, Azure Key Vault storage, and certificate lifecycle."
+description: "Frequently asked questions about Acmebot: ARI-aware automatic renewal, DNS-01 validation, Azure Key Vault storage, and certificate lifecycle."
 ---
 
 # FAQ
 
 ## How does automatic renewal work?
 
-The `RenewCertificates` timer runs daily for enabled managed certificates. When ACME renewal information is available, Acmebot uses the CA's suggested renewal window and `Retry-After` timing to decide the next check, then renews after the suggested window has started. Otherwise, it renews when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent (default 30):
+The `RenewCertificates` timer runs daily for enabled managed certificates. Each managed certificate keeps its own renewal state and next check time.
+
+When ACME Renewal Information (ARI) is available, Acmebot uses the CA's suggested renewal window and `Retry-After` timing to decide the next check for that certificate, then renews after the suggested window has started. Otherwise, that certificate falls back to the configured lifetime threshold and renews when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent (default 30):
 
 ```text
 Acmebot__RenewBeforeExpiry=30
 ```
 
 Azure Functions timer schedules run in UTC unless the hosting plan supports `WEBSITE_TIME_ZONE`.
+
+## What makes Acmebot's ARI support useful for many certificates?
+
+Acmebot applies ARI per certificate. A certificate can wait for its CA-provided renewal window, retry after a temporary failure, or fall back to the configured threshold without changing the renewal state for other certificates.
 
 ## Can I use an existing Key Vault?
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,5 +1,5 @@
 ---
-description: "Step-by-step guide to deploy Acmebot and issue your first Let's Encrypt certificate into Azure Key Vault with DNS-01 validation."
+description: "Step-by-step guide to deploy Acmebot and issue your first certificate into Azure Key Vault with DNS-01 validation and ARI-aware renewal."
 ---
 
 # Getting Started
@@ -84,7 +84,7 @@ After the operation completes:
 
 ## 7. Let Renewals Run
 
-The `RenewCertificates` timer runs daily. When ACME renewal information is available for a certificate, Acmebot evaluates the certificate authority's suggested renewal window and `Retry-After` timing before renewing. Otherwise, it renews when the remaining certificate lifetime is no more than `Acmebot__RenewBeforeExpiry` percent (default 30).
+The `RenewCertificates` timer runs daily and maintains renewal state per managed certificate. When ACME Renewal Information (ARI) is available for a certificate, Acmebot evaluates the certificate authority's suggested renewal window and `Retry-After` timing before renewing. Otherwise, only that certificate falls back to the configured lifetime threshold, `Acmebot__RenewBeforeExpiry` percent (default 30).
 
 See [Operations](./operations) for monitoring and troubleshooting guidance.
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -4,7 +4,7 @@ description: "Overview of how Acmebot automates ACME SSL/TLS certificate issuanc
 
 # Guide
 
-Acmebot automates ACME SSL/TLS certificate issuance and renewal on Microsoft Azure. It runs as a Function App, proves domain ownership with DNS-01 challenges, and stores private keys and issued certificates in Azure Key Vault.
+Acmebot automates ACME SSL/TLS certificate issuance and ARI-aware renewal on Microsoft Azure. It runs as a Function App, proves domain ownership with DNS-01 challenges, and stores private keys and issued certificates in Azure Key Vault.
 
 Use this guide to deploy Acmebot, connect DNS providers, issue certificates from the dashboard, and operate certificate-level renewals over time.
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,12 +1,12 @@
 ---
-description: "Overview of how Acmebot automates ACME SSL/TLS certificate issuance and renewal on Microsoft Azure using DNS-01 validation and Azure Key Vault."
+description: "Overview of how Acmebot automates ACME SSL/TLS certificate issuance and ARI-aware renewal on Microsoft Azure using DNS-01 validation and Azure Key Vault."
 ---
 
 # Guide
 
 Acmebot automates ACME SSL/TLS certificate issuance and renewal on Microsoft Azure. It runs as a Function App, proves domain ownership with DNS-01 challenges, and stores private keys and issued certificates in Azure Key Vault.
 
-Use this guide to deploy Acmebot, connect DNS providers, issue certificates from the dashboard, and operate scheduled renewals over time.
+Use this guide to deploy Acmebot, connect DNS providers, issue certificates from the dashboard, and operate certificate-level renewals over time.
 
 ## What Acmebot Does
 
@@ -14,7 +14,8 @@ Use this guide to deploy Acmebot, connect DNS providers, issue certificates from
 - Creates ACME orders for zone apex, wildcard, and multi-domain certificates.
 - Adds and removes DNS-01 TXT records through one or more configured DNS providers.
 - Requests certificates in Key Vault and merges the issued chain back into the same Key Vault certificate.
-- Tags managed certificates so scheduled renewals can find them later.
+- Tags managed certificates so each certificate can keep its own renewal state, next check time, and fallback behavior.
+- Uses ACME Renewal Information (ARI) when the CA provides it, including suggested renewal windows and `Retry-After` timing.
 - Sends webhook notifications for successful and failed operations when a webhook is configured.
 
 ## Runtime Workflow
@@ -41,6 +42,10 @@ Acmebot uses DNS-01 validation only. This supports wildcard certificates and wor
 
 Acmebot works with ACME v2 directory endpoints. The deployment form offers common endpoints such as Let's Encrypt, GlobalSign, Google Trust Services, SSL.com, and ZeroSSL, and also accepts a custom ACME directory URL.
 
+### ARI-Aware Renewal
+
+Each managed certificate has its own renewal lifecycle. When the ACME CA provides renewal information, Acmebot follows that certificate's suggested renewal window and `Retry-After` timing. If renewal information is unavailable, only that certificate falls back to the configured expiry-based renewal threshold.
+
 ### Dashboard
 
 The dashboard is a same-origin web app served by the Function App. It calls the `/api/*` endpoints to list, issue, renew, and revoke certificates, and to list DNS zones.
@@ -55,7 +60,7 @@ The dashboard is a same-origin web app served by the Function App. It calls the 
 | Issue, renew, or revoke a certificate | [Dashboard](./dashboard) |
 | Configure Azure DNS, Cloudflare, Route 53, or another DNS provider | [DNS Providers](./dns-providers) |
 | Use EAB or a CA other than Let's Encrypt | [Certificate Authorities](./certificate-authorities) |
-| Monitor renewals and troubleshoot failures | [Operations](./operations) |
+| Monitor certificate-level renewals and troubleshoot failures | [Operations](./operations) |
 | Connect renewed certificates to Azure services | [Azure Service Integration](./service-integration) |
 | Diagnose failed issuance, renewal, or service sync | [Troubleshooting](./troubleshooting) |
 | Answer common deployment and operations questions | [FAQ](./faq) |

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -1,5 +1,5 @@
 ---
-description: "Day-to-day operation of Acmebot: issuing, renewing, and revoking ACME certificates in Azure Key Vault after deployment."
+description: "Day-to-day operation of Acmebot: issuing, ARI-aware renewal scheduling, and revoking ACME certificates in Azure Key Vault after deployment."
 ---
 
 # Operations
@@ -14,9 +14,11 @@ The `RenewCertificates` timer runs once per day. It lists Key Vault certificates
 - Are tagged as issued by Acmebot.
 - Match the currently configured ACME endpoint.
 
-When ACME renewal information is available, Acmebot follows the certificate authority's `suggestedWindow` when choosing the next check. It selects a random time inside that window, but checks renewal information again first when `Retry-After` is earlier. When a scheduler evaluation runs after the suggested window starts, Acmebot renews the certificate.
+Each managed certificate has its own renewal state, next check time, and retry behavior. A certificate that is waiting, retrying, or falling back to an expiry-based policy does not reset the renewal schedule for other certificates.
 
-When renewal information is unavailable for a certificate, Acmebot falls back to `Acmebot__RenewBeforeExpiry`.
+Acmebot supports ACME Renewal Information (ARI). When the CA provides renewal information for a certificate, Acmebot follows the certificate authority's `suggestedWindow` when choosing the next check. It selects a random time inside that window, but checks renewal information again first when `Retry-After` is earlier. When a renewal evaluation runs after the suggested window starts, Acmebot renews the certificate and marks the new order as replacing the previous certificate when the CA supports it.
+
+When renewal information is unavailable for a certificate, only that certificate falls back to `Acmebot__RenewBeforeExpiry`.
 
 The default fallback renewal threshold is 30% of the certificate lifetime:
 
@@ -28,7 +30,7 @@ For example, a 90-day certificate is renewed when about 27 days remain. Use a la
 
 No separate pre-processing delay is added before due certificates are renewed.
 
-If automatic renewal fails, the certificate scheduler records a retrying state and checks again after six hours.
+If automatic renewal fails, that certificate records a retrying state and checks again after six hours.
 
 ## Durable Functions History
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ pageClass: landing-shell
 footer: false
 title: Acmebot
 titleTemplate: Automated TLS certificates for Microsoft Azure
-description: ACME SSL/TLS certificate automation for Microsoft Azure, built around DNS-01 validation and Azure Key Vault.
+description: ACME SSL/TLS certificate automation for Microsoft Azure, built around DNS-01 validation, ARI-aware renewal, and Azure Key Vault.
 ---
 
 <HomePage />

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,5 +1,5 @@
 ---
-description: "Acmebot architecture: how the Function App coordinates ACME orders, DNS-01 validation, Key Vault operations, and scheduled renewal."
+description: "Acmebot architecture: how the Function App coordinates ACME orders, DNS-01 validation, Key Vault operations, and ARI-aware scheduled renewal."
 ---
 
 # Architecture
@@ -39,18 +39,19 @@ DNS records are always cleaned up after challenge processing, even when an opera
 
 ## Renewal Flow
 
-The scheduled renewal timer runs daily and starts the renewal orchestrator.
+The scheduled renewal timer runs daily and starts certificate-level renewal evaluation.
 
-The orchestrator:
+The renewal flow:
 
 1. Lists certificates in the configured Key Vault.
 2. Filters to enabled certificates tagged as Acmebot-managed.
 3. Filters to the current ACME endpoint.
-4. Uses ACME renewal information when available, selecting the next check from the CA's suggested window and `Retry-After` timing.
-5. Renews after the suggested window has started, or falls back to `RenewBeforeExpiry` lifetime-percentage renewal when renewal information is unavailable for the certificate.
-6. Reissues each due certificate with its stored Key Vault policy.
+4. Maintains independent renewal state and next check time for each certificate.
+5. Uses ACME Renewal Information (ARI) when available, selecting that certificate's next check from the CA's suggested window and `Retry-After` timing.
+6. Renews after the suggested window has started, or falls back to `RenewBeforeExpiry` lifetime-percentage renewal when renewal information is unavailable for the certificate.
+7. Reissues each due certificate with its stored Key Vault policy and sends the previous certificate identifier as `replaces` when ARI is available.
 
-Automatic renewal failures put the certificate scheduler into a retrying state. The scheduler waits six hours, then evaluates that certificate again.
+Automatic renewal failures put only that certificate into a retrying state. It waits six hours, then evaluates that certificate again.
 
 ## State Storage
 


### PR DESCRIPTION
This pull request updates Acmebot's documentation and UI to highlight and explain its new ARI-aware (ACME Renewal Information) certificate renewal features. The changes clarify that renewal scheduling and state are now managed per certificate, leveraging CA-provided renewal windows and retry timing when available, and falling back to expiry-based thresholds otherwise. The documentation and UI have been revised throughout to reflect these improvements and provide more accurate guidance for users.

**Major documentation and UI updates:**

**ARI-aware renewal and per-certificate state:**
* Updated the README, guides, FAQ, and operations documentation to describe ARI-aware renewal scheduling, per-certificate renewal state, next-check timing, and fallback behavior when ARI is unavailable. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R39) [[2]](diffhunk://#diff-a9f09e5fd39208124b216a0cac772b60ab660bf177b9ecd1ab87f18006cecdbcL2-R18) [[3]](diffhunk://#diff-a9f09e5fd39208124b216a0cac772b60ab660bf177b9ecd1ab87f18006cecdbcR45-R48) [[4]](diffhunk://#diff-81d40d524dd8ec0bdb25fc9fdad32b4df91123fec70d6268cb8b9cfc1f70323dL17-R21) [[5]](diffhunk://#diff-81d40d524dd8ec0bdb25fc9fdad32b4df91123fec70d6268cb8b9cfc1f70323dL31-R33) [[6]](diffhunk://#diff-e4baa4dead20cd48e24e966617f047386446eb986c81fc2011e45534acdbeaefL94-R94) [[7]](diffhunk://#diff-1420d33a49070045f1430da4e11d56ca3e7b1c4a43c2009ae833bc3efdffcb59L21-R21) [[8]](diffhunk://#diff-1420d33a49070045f1430da4e11d56ca3e7b1c4a43c2009ae833bc3efdffcb59L75-R75) [[9]](diffhunk://#diff-81d6451f5c342f49402333f82fc69d7592ace98b3c2018af39d68ceafa949cd8L2-R22) [[10]](diffhunk://#diff-d11497d93c4e9a068e9d45153a3b33747c860d802b11d3f7cd9e5286916e0857L87-R87)
* Added new explanations and FAQ entries about the value of ARI support for large certificate fleets and how renewal state is managed independently for each certificate.

**UI and feature descriptions:**
* Revised the home page, feature cards, and deploy section to highlight ARI-aware renewal, per-certificate state, and CA-guided timing. [[1]](diffhunk://#diff-cc36d3887a0f6968e895be83b5e3c05771c2b54b2bbd929e06cd84cb64deae26L18-R18) [[2]](diffhunk://#diff-cc36d3887a0f6968e895be83b5e3c05771c2b54b2bbd929e06cd84cb64deae26L56-R57) [[3]](diffhunk://#diff-cc36d3887a0f6968e895be83b5e3c05771c2b54b2bbd929e06cd84cb64deae26R260)
* Updated dashboard documentation to mention tracking of renewal status, state, and timing per managed certificate.

**Metadata and SEO improvements:**
* Updated meta descriptions and OpenGraph tags to mention ARI-aware renewal throughout the documentation and site. [[1]](diffhunk://#diff-3def678deb1b1d5a53948eb8491817dde4dc881e032e785fc61cc93d334eefcdL66-R66) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L7-R7) [[3]](diffhunk://#diff-e4baa4dead20cd48e24e966617f047386446eb986c81fc2011e45534acdbeaefL2-R2) [[4]](diffhunk://#diff-d11497d93c4e9a068e9d45153a3b33747c860d802b11d3f7cd9e5286916e0857L2-R2) [[5]](diffhunk://#diff-c46a10526e5eab5e6c9167b10e4f3dcb61b1c1a41a6f15babf601e5b06634a8fL2-R2) [[6]](diffhunk://#diff-1420d33a49070045f1430da4e11d56ca3e7b1c4a43c2009ae833bc3efdffcb59L2-R2) [[7]](diffhunk://#diff-a9f09e5fd39208124b216a0cac772b60ab660bf177b9ecd1ab87f18006cecdbcL2-R18) [[8]](diffhunk://#diff-81d40d524dd8ec0bdb25fc9fdad32b4df91123fec70d6268cb8b9cfc1f70323dL2-R2)

**Clarifications and terminology:**
* Improved language to clarify that renewal operations are certificate-level, not global, and that ARI is used when available with fallback only for certificates lacking CA renewal information. [[1]](diffhunk://#diff-a9f09e5fd39208124b216a0cac772b60ab660bf177b9ecd1ab87f18006cecdbcL58-R63) [[2]](diffhunk://#diff-81d40d524dd8ec0bdb25fc9fdad32b4df91123fec70d6268cb8b9cfc1f70323dL17-R21) [[3]](diffhunk://#diff-a9f09e5fd39208124b216a0cac772b60ab660bf177b9ecd1ab87f18006cecdbcL2-R18) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R39)

These changes ensure that users and teams understand the new ARI-aware renewal capabilities, how Acmebot manages certificate renewal state, and the operational benefits for managing large fleets of certificates.