### PR TITLE
Centralize license metadata and copyright

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
   <PropertyGroup>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <Copyright>Copyright 2018-2025 Polymind Inc.</Copyright>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <Copyright>Copyright 2018-2025 Polymind Inc.</Copyright>
+    <Copyright>Copyright 2018-2026 Polymind Inc.</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 </Project>

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2026 Tatsuro Shibamura
+   Copyright 2018-2026 Polymind Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "acmebot-docs",
+      "license": "Apache-2.0",
       "devDependencies": {
         "vitepress": "2.0.0-alpha.17"
       }

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "acmebot-docs",
   "private": true,
+  "license": "Apache-2.0",
   "type": "module",
   "scripts": {
     "dev": "vitepress dev --host 127.0.0.1",

--- a/src/Acmebot.App/ClientApp/package-lock.json
+++ b/src/Acmebot.App/ClientApp/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "acmebot",
       "version": "1.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/vue-table": "8.21.3",
         "lucide-vue-next": "1.0.0",

--- a/src/Acmebot.App/ClientApp/package.json
+++ b/src/Acmebot.App/ClientApp/package.json
@@ -2,6 +2,7 @@
   "name": "acmebot",
   "private": true,
   "version": "1.0.0",
+  "license": "Apache-2.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",

--- a/src/Acmebot.Cli/Acmebot.Cli.csproj
+++ b/src/Acmebot.Cli/Acmebot.Cli.csproj
@@ -16,7 +16,6 @@
     <PackageId>Acmebot.Cli</PackageId>
     <Title>Acmebot CLI</Title>
     <Description>Command-line client for Acmebot HTTP API automation.</Description>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>acme;azure;key-vault;certificates;cli</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
Move shared NuGet license metadata into Directory.Build.props and remove the duplicate setting from Acmebot.Cli.csproj. Update project metadata to declare Apache-2.0 in npm manifests and align copyright ownership with Polymind Inc. in LICENSE and build properties.