### PR TITLE
Tune durable task settings and blob init flow

### DIFF
--- a/src/Acmebot.App/Acme/BlobAcmeStateStore.cs
+++ b/src/Acmebot.App/Acme/BlobAcmeStateStore.cs
@@ -33,14 +33,17 @@ internal sealed class BlobAcmeStateStore(BlobContainerClient containerClient, IO
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
         {
+            if (ex.ErrorCode == BlobErrorCode.ContainerNotFound)
+            {
+                await containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+            }
+
             return default;
         }
     }
 
     public async Task SaveAsync<TState>(TState value, string path, CancellationToken cancellationToken = default)
     {
-        await containerClient.CreateIfNotExistsAsync(PublicAccessType.None, cancellationToken: cancellationToken);
-
         var blobClient = containerClient.GetBlobClient(CreateBlobName(path));
         var content = BinaryData.FromObjectAsJson(value, s_jsonSerializerOptions);
 

--- a/src/Acmebot.App/host.json
+++ b/src/Acmebot.App/host.json
@@ -8,8 +8,13 @@
   },
   "extensions": {
     "durableTask": {
-      "useGracefulShutdown": true,
-      "useTablePartitionManagement": true
+      "storageProvider": {
+        "maxQueuePollingInterval": "00:00:30"
+      },
+      "tracing": {
+        "distributedTracingEnabled": true,
+        "version": "V2"
+      }
     },
     "http": {
       "routePrefix": "",


### PR DESCRIPTION
This pull request updates how the application handles Azure Blob container creation and refines the configuration for Durable Task in the `host.json`. The main improvements are better error handling for missing blob containers and enhanced tracing and polling configurations for Durable Task.

**Blob Storage Error Handling:**

* In `BlobAcmeStateStore`, the code now checks specifically for the `ContainerNotFound` error when accessing blobs. If the container is missing, it is created before proceeding, ensuring smoother operation when containers do not exist yet.
* The unconditional container creation in `SaveAsync` was removed, so the container is only created when necessary, reducing redundant operations.

**Durable Task Configuration:**

* In `host.json`, the Durable Task extension is updated to use a `storageProvider` section with a `maxQueuePollingInterval`, allowing for more control over polling behavior.
* Distributed tracing is enabled with version V2, improving observability and diagnostics for Durable Task orchestrations.