### PR TITLE
Update copyright information in footer

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -92,7 +92,7 @@ export default defineConfig({
     },
     footer: {
       message: "Released under the Apache License 2.0.",
-      copyright: "Copyright (c) 2026 Acmebot Project"
+      copyright: "Copyright (c) 2026 Polymind Inc."
     }
   }
 });

--- a/docs/.vitepress/theme/HomePage.vue
+++ b/docs/.vitepress/theme/HomePage.vue
@@ -368,7 +368,7 @@ function scrollToSection(event: MouseEvent, selector: string) {
           </div>
         </div>
         <div class="footer-bottom">
-          <p>&copy; 2026 Acmebot Project. Licensed under Apache License 2.0.</p>
+          <p>&copy; 2026 Polymind Inc. Licensed under Apache License 2.0.</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
This pull request updates the project copyright information in the documentation. The changes ensure that the copyright holder is listed as "Polymind Inc." instead of "Acmebot Project".

Documentation updates:

* Updated the copyright notice in the VitePress configuration (`docs/.vitepress/config.ts`).
* Updated the copyright text in the homepage footer (`docs/.vitepress/theme/HomePage.vue`).