### PR TITLE
Enhance ARI retry handling and improve webhook exception management

### DIFF
--- a/src/Acmebot.Acme/AcmeProtocolException.cs
+++ b/src/Acmebot.Acme/AcmeProtocolException.cs
@@ -28,4 +28,6 @@ public sealed class AcmeProtocolException(
     public IReadOnlyList<AcmeLinkHeader> Links { get; } = links ?? [];
 
     public bool IsBadNonce => Problem?.Type == AcmeProblemTypes.BadNonce;
+
+    public bool IsAlreadyReplaced => Problem?.Type == AcmeProblemTypes.AlreadyReplaced;
 }

--- a/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
@@ -34,17 +34,7 @@ public partial class AcmeOrderActivities(
         var replaces = acmeContext.Directory.RenewalInfo is not null ? requestedReplaces : null;
         var profile = NormalizeProfile(requestedProfile) ?? NormalizeProfile(_options.PreferredProfile);
 
-        var result = await acmeContext.Client.CreateOrderAsync(
-            acmeContext.Account,
-            dnsNames.Select(x => new AcmeIdentifier
-            {
-                Type = AcmeIdentifierTypes.Dns,
-                Value = x
-            }).ToArray(),
-            profile: profile,
-            replaces: replaces);
-
-        return OrderDetails.FromResult(result);
+        return await CreateOrderAsync(acmeContext, dnsNames, profile, replaces, logger);
     }
 
     [Function(nameof(AnswerChallenges))]
@@ -190,6 +180,41 @@ public partial class AcmeOrderActivities(
 
     [LoggerMessage(LogLevel.Error, "ACME domain validation failed. ProblemDetails: {ProblemDetailsJson}")]
     private static partial void LogAcmeDomainValidationError(ILogger logger, string problemDetailsJson);
+
+    [LoggerMessage(LogLevel.Warning, "ACME order replacement was already consumed by another order. Retrying without ARI replaces hint. CertificateId: {CertificateId}")]
+    private static partial void LogAlreadyReplacedRetry(ILogger logger, string certificateId);
+
+    internal static async Task<OrderDetails> CreateOrderAsync(AcmeClientContext acmeContext, IReadOnlyList<string> dnsNames, string? profile, string? replaces, ILogger logger)
+    {
+        var identifiers = dnsNames.Select(x => new AcmeIdentifier
+        {
+            Type = AcmeIdentifierTypes.Dns,
+            Value = x
+        }).ToArray();
+
+        try
+        {
+            var result = await acmeContext.Client.CreateOrderAsync(
+                acmeContext.Account,
+                identifiers,
+                profile: profile,
+                replaces: replaces);
+
+            return OrderDetails.FromResult(result);
+        }
+        catch (AcmeProtocolException ex) when (!string.IsNullOrEmpty(replaces) && ex.IsAlreadyReplaced)
+        {
+            LogAlreadyReplacedRetry(logger, replaces);
+
+            var result = await acmeContext.Client.CreateOrderAsync(
+                acmeContext.Account,
+                identifiers,
+                profile: profile,
+                replaces: null);
+
+            return OrderDetails.FromResult(result);
+        }
+    }
 
     private static string? NormalizeProfile(string? profile) => string.IsNullOrWhiteSpace(profile) ? null : profile.Trim();
 }

--- a/src/Acmebot.App/Notifications/WebhookInvoker.cs
+++ b/src/Acmebot.App/Notifications/WebhookInvoker.cs
@@ -14,37 +14,44 @@ public partial class WebhookInvoker(IWebhookPayloadBuilder webhookPayloadBuilder
 
     public Task SendCompletedEventAsync(string certificateName, DateTimeOffset? expirationDate, IEnumerable<string> dnsNames, string acmeEndpoint)
     {
-        var payload = webhookPayloadBuilder.BuildCompleted(certificateName, expirationDate, dnsNames, acmeEndpoint);
-
-        return SendEventAsync(payload);
+        return SendEventAsync(() => webhookPayloadBuilder.BuildCompleted(certificateName, expirationDate, dnsNames, acmeEndpoint));
     }
 
     public Task SendFailedEventAsync(string certificateName, IEnumerable<string> dnsNames)
     {
-        var payload = webhookPayloadBuilder.BuildFailed(certificateName, dnsNames);
-
-        return SendEventAsync(payload);
+        return SendEventAsync(() => webhookPayloadBuilder.BuildFailed(certificateName, dnsNames));
     }
 
-    private async Task SendEventAsync(object payload)
+    private async Task SendEventAsync(Func<object> payloadFactory)
     {
         if (_options.Webhook is null)
         {
             return;
         }
 
-        var httpClient = httpClientFactory.CreateClient();
-
-        var response = await httpClient.PostAsJsonAsync(_options.Webhook, payload);
-
-        if (!response.IsSuccessStatusCode)
+        try
         {
-            var reason = await response.Content.ReadAsStringAsync();
+            var payload = payloadFactory();
+            var httpClient = httpClientFactory.CreateClient();
 
-            LogFailedInvokeWebhook(logger, response.StatusCode, reason);
+            using var response = await httpClient.PostAsJsonAsync(_options.Webhook, payload);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var reason = await response.Content.ReadAsStringAsync();
+
+                LogFailedInvokeWebhook(logger, response.StatusCode, reason);
+            }
+        }
+        catch (Exception ex)
+        {
+            LogWebhookDeliveryException(logger, ex);
         }
     }
 
     [LoggerMessage(LogLevel.Warning, "Webhook delivery failed. StatusCode: {ResponseStatusCode}. ResponseBody: {Reason}")]
     private static partial void LogFailedInvokeWebhook(ILogger logger, HttpStatusCode responseStatusCode, string reason);
+
+    [LoggerMessage(LogLevel.Warning, "Webhook delivery threw an exception and was ignored.")]
+    private static partial void LogWebhookDeliveryException(ILogger logger, Exception exception);
 }

--- a/tests/Acmebot.App.Tests/AcmeOrderActivitiesTests.cs
+++ b/tests/Acmebot.App.Tests/AcmeOrderActivitiesTests.cs
@@ -1,4 +1,4 @@
-using System.Buffers.Text;
+﻿using System.Buffers.Text;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;

--- a/tests/Acmebot.App.Tests/AcmeOrderActivitiesTests.cs
+++ b/tests/Acmebot.App.Tests/AcmeOrderActivitiesTests.cs
@@ -1,0 +1,162 @@
+using System.Buffers.Text;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+using Acmebot.Acme;
+using Acmebot.Acme.Models;
+using Acmebot.App.Acme;
+using Acmebot.App.Functions.Orchestration;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class AcmeOrderActivitiesTests
+{
+    [Fact]
+    public async Task CreateOrderAsync_WithAlreadyReplacedProblem_RetriesWithoutReplaces()
+    {
+        var directoryUrl = new Uri("https://example.com/acme/directory");
+        var newNonceUrl = new Uri("https://example.com/acme/new-nonce");
+        var newOrderUrl = new Uri("https://example.com/acme/new-order");
+        var orderUrl = new Uri("https://example.com/acme/order/1");
+        using var signer = AcmeSigner.CreateP256();
+        using var handler = new RecordingHandler();
+        using var httpClient = new HttpClient(handler);
+        using var client = new AcmeClient(httpClient, directoryUrl);
+
+        handler.Enqueue(_ => CreateJsonResponse(HttpStatusCode.OK, new
+        {
+            newNonce = newNonceUrl,
+            newAccount = new Uri("https://example.com/acme/new-account"),
+            newOrder = newOrderUrl,
+            renewalInfo = new Uri("https://example.com/acme/renewal-info")
+        }));
+        var directory = await client.GetDirectoryAsync(TestContext.Current.CancellationToken);
+        handler.Enqueue(_ => CreateResponse(HttpStatusCode.OK, string.Empty, contentType: null, replayNonce: "bm9uY2Ux"));
+        handler.Enqueue(_ => CreateJsonResponse(
+            HttpStatusCode.BadRequest,
+            new
+            {
+                type = AcmeProblemTypes.AlreadyReplaced.Value,
+                detail = "already replaced"
+            },
+            replayNonce: "bm9uY2Uy",
+            contentType: "application/problem+json"));
+        handler.Enqueue(_ => CreateJsonResponse(
+            HttpStatusCode.Created,
+            new
+            {
+                status = "pending",
+                authorizations = new[] { "https://example.com/acme/authz/1" },
+                finalize = "https://example.com/acme/finalize/1"
+            },
+            replayNonce: "bm9uY2Uz",
+            location: orderUrl));
+        var context = new AcmeClientContext
+        {
+            Client = client,
+            Directory = directory,
+            Signer = signer,
+            Account = CreateAccountHandle(signer)
+        };
+
+        var result = await AcmeOrderActivities.CreateOrderAsync(
+            context,
+            ["example.com"],
+            profile: "tlsserver",
+            replaces: "old-cert-id",
+            NullLogger<AcmeOrderActivities>.Instance);
+
+        var postRequests = handler.Requests.Where(x => x.Method == HttpMethod.Post).ToArray();
+        Assert.Equal(2, postRequests.Length);
+        Assert.Equal(orderUrl, result.OrderUrl);
+        Assert.Equal(AcmeOrderStatuses.Pending, result.Payload.Status);
+
+        using var firstPayload = postRequests[0].GetPayloadJson();
+        using var secondPayload = postRequests[1].GetPayloadJson();
+        Assert.Equal("old-cert-id", firstPayload.RootElement.GetProperty("replaces").GetString());
+        Assert.Equal("tlsserver", firstPayload.RootElement.GetProperty("profile").GetString());
+        Assert.False(secondPayload.RootElement.TryGetProperty("replaces", out _));
+        Assert.Equal("tlsserver", secondPayload.RootElement.GetProperty("profile").GetString());
+    }
+
+    private static AcmeAccountHandle CreateAccountHandle(AcmeSigner signer)
+    {
+        return new AcmeAccountHandle
+        {
+            AccountUrl = new Uri("https://example.com/acme/account/1"),
+            Signer = signer,
+            Account = new AcmeAccountResource
+            {
+                Status = AcmeAccountStatuses.Valid
+            }
+        };
+    }
+
+    private static HttpResponseMessage CreateJsonResponse<T>(HttpStatusCode statusCode, T payload, string? replayNonce = null, Uri? location = null, string contentType = "application/json")
+    {
+        return CreateResponse(statusCode, JsonSerializer.Serialize(payload), contentType, replayNonce, location);
+    }
+
+    private static HttpResponseMessage CreateResponse(HttpStatusCode statusCode, string content, string? contentType, string? replayNonce = null, Uri? location = null)
+    {
+        var response = new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(content, Encoding.ASCII)
+        };
+
+        response.Content.Headers.ContentType = contentType is null ? null : new MediaTypeHeaderValue(contentType);
+        response.Headers.Location = location;
+
+        if (replayNonce is not null)
+        {
+            response.Headers.TryAddWithoutValidation("Replay-Nonce", replayNonce);
+        }
+
+        return response;
+    }
+
+    private static string DecodeBase64UrlUtf8(string value) => Encoding.UTF8.GetString(Base64Url.DecodeFromChars(value));
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> _responses = new();
+
+        public List<RecordedRequest> Requests { get; } = [];
+
+        public void Enqueue(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) => _responses.Enqueue(responseFactory);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(await RecordedRequest.CreateAsync(request, cancellationToken));
+
+            return _responses.TryDequeue(out var responseFactory)
+                ? responseFactory(request)
+                : throw new InvalidOperationException("No response was configured for the HTTP request.");
+        }
+    }
+
+    private sealed record RecordedRequest(HttpMethod Method, Uri? RequestUri, string? Content)
+    {
+        public AcmeSignedMessage GetSignedMessage()
+        {
+            return JsonSerializer.Deserialize<AcmeSignedMessage>(Content!)
+                ?? throw new InvalidOperationException("The request body did not contain a signed ACME message.");
+        }
+
+        public JsonDocument GetPayloadJson() => JsonDocument.Parse(DecodeBase64UrlUtf8(GetSignedMessage().Payload));
+
+        public static async Task<RecordedRequest> CreateAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return new RecordedRequest(
+                request.Method,
+                request.RequestUri,
+                request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken));
+        }
+    }
+}

--- a/tests/Acmebot.App.Tests/WebhookInvokerTests.cs
+++ b/tests/Acmebot.App.Tests/WebhookInvokerTests.cs
@@ -4,7 +4,6 @@ using Acmebot.App.Notifications;
 using Acmebot.App.Options;
 
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 using Xunit;
 
@@ -55,7 +54,7 @@ public sealed class WebhookInvokerTests
         return new WebhookInvoker(
             payloadBuilder,
             new StubHttpClientFactory(httpClient),
-            Options.Create(new AcmebotOptions
+            Microsoft.Extensions.Options.Options.Create(new AcmebotOptions
             {
                 Contacts = "admin@example.com",
                 Endpoint = new Uri("https://acme.example/directory"),

--- a/tests/Acmebot.App.Tests/WebhookInvokerTests.cs
+++ b/tests/Acmebot.App.Tests/WebhookInvokerTests.cs
@@ -1,0 +1,116 @@
+using System.Net;
+
+using Acmebot.App.Notifications;
+using Acmebot.App.Options;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class WebhookInvokerTests
+{
+    [Fact]
+    public async Task SendCompletedEventAsync_WithFailureResponse_DoesNotThrow()
+    {
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.BadGateway)
+        {
+            Content = new StringContent("temporary failure")
+        }));
+        var invoker = CreateInvoker(httpClient, new StubWebhookPayloadBuilder());
+
+        await invoker.SendCompletedEventAsync(
+            "example-com",
+            DateTimeOffset.Parse("2026-07-01T00:00:00Z"),
+            ["example.com"],
+            "acme.example");
+    }
+
+    [Fact]
+    public async Task SendCompletedEventAsync_WhenPostThrows_DoesNotThrow()
+    {
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(_ => throw new HttpRequestException("network unavailable")));
+        var invoker = CreateInvoker(httpClient, new StubWebhookPayloadBuilder());
+
+        await invoker.SendCompletedEventAsync(
+            "example-com",
+            DateTimeOffset.Parse("2026-07-01T00:00:00Z"),
+            ["example.com"],
+            "acme.example");
+    }
+
+    [Fact]
+    public async Task SendFailedEventAsync_WhenPayloadBuilderThrows_DoesNotThrow()
+    {
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)));
+        var invoker = CreateInvoker(httpClient, new ThrowingWebhookPayloadBuilder());
+
+        await invoker.SendFailedEventAsync("example-com", ["example.com"]);
+    }
+
+    private static WebhookInvoker CreateInvoker(HttpClient httpClient, IWebhookPayloadBuilder payloadBuilder)
+    {
+        return new WebhookInvoker(
+            payloadBuilder,
+            new StubHttpClientFactory(httpClient),
+            Microsoft.Extensions.Options.Options.Create(new AcmebotOptions
+            {
+                Contacts = "admin@example.com",
+                Endpoint = new Uri("https://acme.example/directory"),
+                VaultBaseUrl = "https://vault.example/",
+                Webhook = new Uri("https://webhook.example/")
+            }),
+            NullLogger<WebhookInvoker>.Instance);
+    }
+
+    private sealed class StubHttpClientFactory(HttpClient httpClient) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => httpClient;
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(responseFactory(request));
+        }
+    }
+
+    private sealed class StubWebhookPayloadBuilder : IWebhookPayloadBuilder
+    {
+        public object BuildCompleted(string certificateName, DateTimeOffset? expirationDate, IEnumerable<string> dnsNames, string acmeEndpoint)
+        {
+            return new
+            {
+                certificateName,
+                expirationDate,
+                dnsNames,
+                acmeEndpoint
+            };
+        }
+
+        public object BuildFailed(string certificateName, IEnumerable<string> dnsNames)
+        {
+            return new
+            {
+                certificateName,
+                dnsNames
+            };
+        }
+    }
+
+    private sealed class ThrowingWebhookPayloadBuilder : IWebhookPayloadBuilder
+    {
+        public object BuildCompleted(string certificateName, DateTimeOffset? expirationDate, IEnumerable<string> dnsNames, string acmeEndpoint)
+        {
+            throw new InvalidOperationException("payload failed");
+        }
+
+        public object BuildFailed(string certificateName, IEnumerable<string> dnsNames)
+        {
+            throw new InvalidOperationException("payload failed");
+        }
+    }
+}

--- a/tests/Acmebot.App.Tests/WebhookInvokerTests.cs
+++ b/tests/Acmebot.App.Tests/WebhookInvokerTests.cs
@@ -55,7 +55,7 @@ public sealed class WebhookInvokerTests
         return new WebhookInvoker(
             payloadBuilder,
             new StubHttpClientFactory(httpClient),
-            Microsoft.Extensions.Options.Options.Create(new AcmebotOptions
+            Options.Create(new AcmebotOptions
             {
                 Contacts = "admin@example.com",
                 Endpoint = new Uri("https://acme.example/directory"),

--- a/tests/Acmebot.App.Tests/WebhookInvokerTests.cs
+++ b/tests/Acmebot.App.Tests/WebhookInvokerTests.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 
 using Acmebot.App.Notifications;
 using Acmebot.App.Options;


### PR DESCRIPTION
This pull request improves the robustness and reliability of ACME order handling and webhook delivery in the application. It introduces enhanced error handling for ACME order replacements, ensures webhook notifications do not throw on failure, and adds comprehensive tests for these scenarios.

**ACME order handling improvements:**

* Added logic in `CreateOrderAsync` to detect when an ACME order replacement has already been consumed (using the new `IsAlreadyReplaced` property on `AcmeProtocolException`). If this occurs, the order is retried without the `replaces` hint, and a warning is logged. (`src/Acmebot.Acme/AcmeProtocolException.cs` [[1]](diffhunk://#diff-550c94f41e6b162e34765222c0d6a22cb8861aaa9b1e434a426ad2bd51b5af6bR31-R32) `src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs` [[2]](diffhunk://#diff-0a0200960d0f736a08081a244b12e480cada2703660f7a167ac84c4ee52dcdecL37-R37) [[3]](diffhunk://#diff-0a0200960d0f736a08081a244b12e480cada2703660f7a167ac84c4ee52dcdecR184-R218)
* Added a unit test to verify that when an ACME order fails with "already replaced," the code retries without the `replaces` field. (`tests/Acmebot.App.Tests/AcmeOrderActivitiesTests.cs` [tests/Acmebot.App.Tests/AcmeOrderActivitiesTests.csR1-R162](diffhunk://#diff-08696d16ea1aa87970296a36b8397b8c365cab6e592f7672cb0cbdff8d984e8aR1-R162))

**Webhook notification reliability:**

* Refactored `WebhookInvoker` to use a payload factory and to catch and log any exceptions during webhook delivery, ensuring that failures or exceptions do not cause the orchestration to fail. (`src/Acmebot.App/Notifications/WebhookInvoker.cs` [[1]](diffhunk://#diff-5d3be4bf606fbbd9277926f6e5941c7de0eb7d2b1ec5a5ea0ff88cb45f148244L17-R37) [[2]](diffhunk://#diff-5d3be4bf606fbbd9277926f6e5941c7de0eb7d2b1ec5a5ea0ff88cb45f148244R46-R56)
* Added tests to ensure that webhook notification failures and payload builder exceptions are handled gracefully (do not throw). (`tests/Acmebot.App.Tests/WebhookInvokerTests.cs` [tests/Acmebot.App.Tests/WebhookInvokerTests.csR1-R116](diffhunk://#diff-6c9dd83976526a057edd49e6132906df3fcff059d2bbb00cd51e673c3c28c652R1-R116))

Fixes #1183 