### PR TITLE
Refactor certificate renewal orchestration and add error handling for evaluation failures

### DIFF
--- a/src/Acmebot.App/Functions/Orchestration/CertificateRenewalSchedulerOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateRenewalSchedulerOrchestrator.cs
@@ -21,7 +21,19 @@ public partial class CertificateRenewalSchedulerOrchestrator
 
         SetSchedulerStatus(context, certificateName, "Checking", null, "Automatic renewal status is being refreshed.");
 
-        var evaluation = await context.CallEvaluateCertificateRenewalAsync(certificateName);
+        CertificateRenewalEvaluation evaluation;
+
+        try
+        {
+            evaluation = await context.CallEvaluateCertificateRenewalAsync(certificateName);
+        }
+        catch (Exception ex)
+        {
+            // Evaluation touches Key Vault, ACME account state, and the ACME directory. Treat those
+            // failures as transient so a single outage does not stop the per-certificate scheduler.
+            await ScheduleRenewalRetryAsync(context, certificateName, logger, ex);
+            return;
+        }
 
         if (!evaluation.IsActive)
         {

--- a/src/Acmebot.App/Functions/Timer/PurgeInstanceHistory.cs
+++ b/src/Acmebot.App/Functions/Timer/PurgeInstanceHistory.cs
@@ -2,7 +2,7 @@
 using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 
-namespace Acmebot.App.Functions.Orchestration;
+namespace Acmebot.App.Functions.Timer;
 
 public partial class PurgeInstanceHistory(ILogger<PurgeInstanceHistory> logger)
 {

--- a/src/Acmebot.App/Functions/Timer/RenewCertificates.cs
+++ b/src/Acmebot.App/Functions/Timer/RenewCertificates.cs
@@ -1,11 +1,12 @@
-﻿using Acmebot.App.Services;
+﻿using Acmebot.App.Functions.Orchestration;
+using Acmebot.App.Services;
 
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 
-namespace Acmebot.App.Functions.Orchestration;
+namespace Acmebot.App.Functions.Timer;
 
 public partial class RenewCertificates(
     CertificateQueryService certificateQueryService,


### PR DESCRIPTION
This pull request primarily refactors the timer-triggered functions by moving them from the `Orchestration` namespace to a new `Timer` namespace, and adds improved error handling to the certificate renewal scheduling logic. The changes help clarify the separation of orchestration and timer-based responsibilities, and make the renewal scheduler more resilient to transient errors.

**Namespace and File Organization Improvements:**

* Renamed `PurgeInstanceHistory.cs` and `RenewCertificates.cs` from the `Orchestration` folder/namespace to the new `Timer` folder/namespace to better reflect their timer-triggered nature. [[1]](diffhunk://#diff-947a16ae03bd5872e0a132dc10005b1f5887c65841a67fa002b627849fd2c6dcL5-R5) [[2]](diffhunk://#diff-3dd2c6420ea1b9274107b20ce6e933d5ac51b7854676079f34a6c5e71dc6d6fdL1-R9)
* Updated the `namespace` declarations in the renamed files to `Acmebot.App.Functions.Timer`. [[1]](diffhunk://#diff-947a16ae03bd5872e0a132dc10005b1f5887c65841a67fa002b627849fd2c6dcL5-R5) [[2]](diffhunk://#diff-3dd2c6420ea1b9274107b20ce6e933d5ac51b7854676079f34a6c5e71dc6d6fdL1-R9)
* Fixed using directives in `RenewCertificates.cs` to reference the correct orchestration types after the move.

**Error Handling Enhancements:**

* Improved error handling in `ScheduleCertificateRenewal` by catching exceptions during certificate renewal evaluation and scheduling a retry, preventing transient outages from halting the scheduler.