### PR TITLE
Add non-branded keywords to docs site descriptions and hero copy

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -50,7 +50,7 @@ const hostname = "https://acmebot.dev";
 export default defineConfig({
   lang: "en-US",
   title: "Acmebot",
-  description: "ACME SSL/TLS certificate automation for Microsoft Azure, built around DNS-01 validation, ARI-aware renewal, and Azure Key Vault.",
+  description: "Automate free SSL/TLS certificates on Microsoft Azure with Let's Encrypt and other ACME CAs. DNS-01 validation, wildcard certificates, ARI-aware renewal, and Azure Key Vault storage.",
   lastUpdated: true,
   srcExclude: ["README.md"],
   cleanUrls: true,
@@ -63,7 +63,7 @@ export default defineConfig({
     ["link", { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" }],
     ["link", { rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" }],
     ["meta", { property: "og:title", content: "Acmebot — Automated TLS certificates for Microsoft Azure" }],
-    ["meta", { property: "og:description", content: "ACME SSL/TLS certificate automation for Microsoft Azure, built around DNS-01 validation, ARI-aware renewal, and Azure Key Vault." }],
+    ["meta", { property: "og:description", content: "Automate free SSL/TLS certificates on Microsoft Azure with Let's Encrypt and other ACME CAs. DNS-01 validation, wildcard certificates, ARI-aware renewal, and Azure Key Vault storage." }],
     ["meta", { property: "og:image", content: "https://acmebot.dev/images/ogp.png" }],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }]

--- a/docs/.vitepress/theme/HomePage.vue
+++ b/docs/.vitepress/theme/HomePage.vue
@@ -15,7 +15,7 @@ function scrollToSection(event: MouseEvent, selector: string) {
       <div class="container">
         <div class="hero-badge">Acmebot v5 &mdash; Production Ready</div>
         <h1 class="hero-title">Automated TLS certificates<br>for <span class="hero-highlight">Microsoft Azure</span></h1>
-        <p class="hero-description">Acmebot issues and renews ACME certificates with DNS-01 validation, ARI-aware renewal scheduling, and Azure Key Vault private key storage.</p>
+        <p class="hero-description">Acmebot issues and renews free certificates from Let's Encrypt and other ACME CAs — DNS-01 validation, wildcard support, ARI-aware renewal scheduling, and Azure Key Vault private key storage.</p>
         <div class="hero-actions">
           <a href="#deploy" class="btn btn-primary" @click="scrollToSection($event, '#deploy')">Deploy to Azure</a>
           <a href="/guide/getting-started" class="btn btn-outline">Get Started</a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ pageClass: landing-shell
 footer: false
 title: Acmebot
 titleTemplate: Automated TLS certificates for Microsoft Azure
-description: ACME SSL/TLS certificate automation for Microsoft Azure, built around DNS-01 validation, ARI-aware renewal, and Azure Key Vault.
+description: Automate free SSL/TLS certificates on Microsoft Azure with Let's Encrypt and other ACME CAs. DNS-01 validation, wildcard certificates, ARI-aware renewal, and Azure Key Vault storage.
 ---
 
 <HomePage />


### PR DESCRIPTION
## Summary

- Weave non-branded search keywords (Let's Encrypt, free SSL/TLS, wildcard certificates) into acmebot.dev meta descriptions and landing hero copy, so the site can start matching generic problem-space queries instead of only branded ones.

## Related Issue

- N/A (follow-up to the docs SEO work in #1173)

## What Changed

- `docs/.vitepress/config.ts` — site `description` and `og:description` now mention Let's Encrypt, free SSL/TLS, wildcard certificates, DNS-01 validation, ARI-aware renewal, and Key Vault storage.
- `docs/index.md` — landing page `description` frontmatter updated to match.
- `docs/.vitepress/theme/HomePage.vue` — hero paragraph now reads "issues and renews free certificates from Let's Encrypt and other ACME CAs — DNS-01 validation, wildcard support, …".

## Validation

- [ ] `dotnet build -c Release ./Acmebot.slnx`
- [ ] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx`
- [ ] `az bicep build -f ./deploy/azuredeploy.bicep`
- [x] Documentation updated if needed

Docs-only change; verified with `npm run build` in `docs/` and inspected the rendered HTML — descriptions updated, all page `<title>`s unchanged.

## Notes

- Page titles, `titleTemplate`, and `og:title` are intentionally untouched.
- Deploy to GitHub Pages requires a `workflow_dispatch` run of `docs.yml` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)