### PR TITLE
Fix certificate renewal process to handle account changes by resetting CertificateId

### DIFF
--- a/src/Acmebot.App/Functions/Http/RenewCertificate.cs
+++ b/src/Acmebot.App/Functions/Http/RenewCertificate.cs
@@ -34,6 +34,11 @@ public partial class RenewCertificate(
         }
 
         var certificatePolicyItem = await certificateOperationService.GetCertificatePolicyAsync(certificateName, req.HttpContext.RequestAborted);
+
+        // Manual renewal must also work after the Acmebot account has changed. In that case, the
+        // current account cannot use the ARI certificate identifier issued to the previous account.
+        certificatePolicyItem.CertificateId = null;
+
         var instanceId = await starter.ScheduleNewOrchestrationInstanceAsync(nameof(CertificateIssuanceOrchestrator.IssueCertificate), certificatePolicyItem);
 
         LogOrchestrationStarted(logger, certificateName, instanceId);


### PR DESCRIPTION
This pull request introduces an important fix to the certificate renewal process in `RenewCertificate.cs`. The change ensures that manual certificate renewals work correctly even if the Acmebot account has changed, by resetting the certificate identifier before starting the orchestration.

- Certificate Renewal Robustness:
  * In `RenewCertificate.cs`, the `CertificateId` property of `certificatePolicyItem` is now set to `null` before scheduling the certificate issuance orchestration. This prevents issues when the Acmebot account has changed and ensures the new account does not attempt to use a certificate identifier issued to the previous account.

Fixes #1196 