### PR TITLE
Add configurable webhook payload and events

### DIFF
--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -50,13 +50,13 @@ Function execution logs, dependency telemetry, and exception telemetry are the m
 
 ## Webhook Notifications
 
-Set `Acmebot__Webhook` to receive notification events:
+Set `Acmebot__Webhook__Endpoint` to receive notification events:
 
 ```text
-Acmebot__Webhook=https://example.com/webhook
+Acmebot__Webhook__Endpoint=https://example.com/webhook
 ```
 
-The payload format is selected from the webhook host:
+By default, the payload format is selected from the webhook host:
 
 | Host | Payload |
 | --- | --- |
@@ -64,6 +64,19 @@ The payload format is selected from the webhook host:
 | `.logic.azure.com` | Teams-style Adaptive Card payload. |
 | `.environment.api.powerplatform.com` | Teams-style Adaptive Card payload. |
 | Other hosts | Generic JSON payload. |
+
+Set `Acmebot__Webhook__PayloadType` to `Generic`, `Teams`, or `Slack` to override automatic detection. Explicitly select `Generic` when sending to a custom Logic App because Teams Workflows and custom Logic Apps can both use `.logic.azure.com` endpoints.
+
+Use `Acmebot__Webhook__Events` to select which certificate operation events send notifications. The default is `All`.
+
+```text
+# Send only failure notifications with a generic JSON payload.
+Acmebot__Webhook__Endpoint=https://example.com/webhook
+Acmebot__Webhook__PayloadType=Generic
+Acmebot__Webhook__Events=Failed
+```
+
+Supported event values are `Completed`, `Failed`, `All`, and `None`. Combine `Completed` and `Failed` with a comma when listing them explicitly. The legacy `Acmebot__Webhook=https://example.com/webhook` setting remains supported with automatic payload detection and all events enabled.
 
 Webhook failures are logged as warnings and never roll back certificate issuance.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -25,7 +25,9 @@ Acmebot__Endpoint=https://acme-v02.api.letsencrypt.org/directory
 
 | Setting | Default | Description |
 | --- | --- | --- |
-| `Acmebot__Webhook` | Empty | Webhook URL for certificate operation notifications. |
+| `Acmebot__Webhook__Endpoint` | Empty | Webhook URL for certificate operation notifications. |
+| `Acmebot__Webhook__Events` | `All` | Events that send webhook notifications. Supported values are `Completed`, `Failed`, `All`, and `None`. Combine individual values with a comma. |
+| `Acmebot__Webhook__PayloadType` | `Auto` | Webhook payload format. Supported values are `Auto`, `Generic`, `Teams`, and `Slack`. |
 | `Acmebot__PreferredChain` | Empty | Preferred issuer chain name when the ACME CA offers alternate chains. |
 | `Acmebot__PreferredProfile` | Empty | Preferred ACME profile when the CA advertises profiles. |
 | `Acmebot__RenewBeforeExpiry` | `30` | Percentage of certificate lifetime remaining at which scheduled renewal runs, used when ACME renewal information is unavailable for the certificate. Valid range is 0 to 100. |
@@ -219,5 +221,9 @@ Acmebot__Environment=AzureCloud
 Acmebot__AzureDns__SubscriptionId=00000000-0000-0000-0000-000000000000
 Acmebot__AzureDns__ManagedIdentityClientId=
 Acmebot__RenewBeforeExpiry=30
-Acmebot__Webhook=https://example.com/webhook
+Acmebot__Webhook__Endpoint=https://example.com/webhook
+Acmebot__Webhook__PayloadType=Generic
+Acmebot__Webhook__Events=Failed
 ```
+
+The legacy scalar setting `Acmebot__Webhook=https://example.com/webhook` remains supported. It is equivalent to configuring `Webhook__Endpoint` with the default `Auto` payload type and `All` events.

--- a/src/Acmebot.App/Notifications/WebhookInvoker.cs
+++ b/src/Acmebot.App/Notifications/WebhookInvoker.cs
@@ -8,23 +8,33 @@ using Microsoft.Extensions.Options;
 
 namespace Acmebot.App.Notifications;
 
-public partial class WebhookInvoker(IWebhookPayloadBuilder webhookPayloadBuilder, IHttpClientFactory httpClientFactory, IOptions<AcmebotOptions> options, ILogger<WebhookInvoker> logger)
+public partial class WebhookInvoker(IWebhookPayloadBuilder webhookPayloadBuilder, IHttpClientFactory httpClientFactory, IOptions<WebhookOptions> options, ILogger<WebhookInvoker> logger)
 {
-    private readonly AcmebotOptions _options = options.Value;
+    private readonly WebhookOptions _options = options.Value;
 
     public Task SendCompletedEventAsync(string certificateName, DateTimeOffset? expirationDate, IEnumerable<string> dnsNames, string acmeEndpoint)
     {
+        if ((_options.Events & WebhookEvents.Completed) == 0)
+        {
+            return Task.CompletedTask;
+        }
+
         return SendEventAsync(() => webhookPayloadBuilder.BuildCompleted(certificateName, expirationDate, dnsNames, acmeEndpoint));
     }
 
     public Task SendFailedEventAsync(string certificateName, IEnumerable<string> dnsNames)
     {
+        if ((_options.Events & WebhookEvents.Failed) == 0)
+        {
+            return Task.CompletedTask;
+        }
+
         return SendEventAsync(() => webhookPayloadBuilder.BuildFailed(certificateName, dnsNames));
     }
 
     private async Task SendEventAsync(Func<object> payloadFactory)
     {
-        if (_options.Webhook is null)
+        if (_options.Endpoint is null)
         {
             return;
         }
@@ -34,7 +44,7 @@ public partial class WebhookInvoker(IWebhookPayloadBuilder webhookPayloadBuilder
             var payload = payloadFactory();
             var httpClient = httpClientFactory.CreateClient();
 
-            using var response = await httpClient.PostAsJsonAsync(_options.Webhook, payload);
+            using var response = await httpClient.PostAsJsonAsync(_options.Endpoint, payload);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/src/Acmebot.App/Notifications/WebhookPayloadBuilderFactory.cs
+++ b/src/Acmebot.App/Notifications/WebhookPayloadBuilderFactory.cs
@@ -1,0 +1,45 @@
+﻿using Acmebot.App.Options;
+
+namespace Acmebot.App.Notifications;
+
+internal static class WebhookPayloadBuilderFactory
+{
+    public static IWebhookPayloadBuilder Create(AcmebotOptions acmebotOptions, WebhookOptions webhookOptions)
+    {
+        var payloadType = webhookOptions.PayloadType;
+
+        if (payloadType == WebhookPayloadType.Auto)
+        {
+            payloadType = DetectPayloadType(webhookOptions.Endpoint);
+        }
+
+        return payloadType switch
+        {
+            WebhookPayloadType.Slack => new SlackPayloadBuilder(),
+            WebhookPayloadType.Teams => new TeamsPayloadBuilder(),
+            _ => new GenericPayloadBuilder(acmebotOptions)
+        };
+    }
+
+    private static WebhookPayloadType DetectPayloadType(Uri? endpoint)
+    {
+        if (endpoint is null)
+        {
+            return WebhookPayloadType.Generic;
+        }
+
+        var host = endpoint.Host;
+
+        if (host.EndsWith("hooks.slack.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return WebhookPayloadType.Slack;
+        }
+
+        if (host.EndsWith(".logic.azure.com", StringComparison.OrdinalIgnoreCase) || host.EndsWith(".environment.api.powerplatform.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return WebhookPayloadType.Teams;
+        }
+
+        return WebhookPayloadType.Generic;
+    }
+}

--- a/src/Acmebot.App/Options/AcmebotOptions.cs
+++ b/src/Acmebot.App/Options/AcmebotOptions.cs
@@ -18,8 +18,6 @@ public class AcmebotOptions
     [Required]
     public required string VaultBaseUrl { get; set; }
 
-    public Uri? Webhook { get; set; }
-
     // ACME CA settings
     [Required]
     public required string Contacts { get; set; }

--- a/src/Acmebot.App/Options/WebhookOptions.cs
+++ b/src/Acmebot.App/Options/WebhookOptions.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Acmebot.App.Options;
+
+public class WebhookOptions
+{
+    public Uri? Endpoint { get; set; }
+
+    public WebhookEvents Events { get; set; } = WebhookEvents.All;
+
+    public WebhookPayloadType PayloadType { get; set; } = WebhookPayloadType.Auto;
+}
+
+[Flags]
+public enum WebhookEvents
+{
+    None = 0,
+    Completed = 1,
+    Failed = 2,
+    All = Completed | Failed
+}
+
+public enum WebhookPayloadType
+{
+    Auto,
+    Generic,
+    Teams,
+    Slack
+}
+
+internal static class WebhookOptionsExtensions
+{
+    public static IServiceCollection AddWebhookOptions(this IServiceCollection services, IConfigurationSection section)
+    {
+        services.AddOptions<WebhookOptions>()
+                .Bind(section)
+                .PostConfigure(options =>
+                {
+                    // Acmebot__Webhook was a scalar URL before structured webhook options were introduced.
+                    if (options.Endpoint is null && Uri.TryCreate(section.Value, UriKind.Absolute, out var endpoint))
+                    {
+                        options.Endpoint = endpoint;
+                    }
+                })
+                .Validate(options => options.Endpoint is not null || string.IsNullOrWhiteSpace(section.Value), "Legacy webhook endpoint must be an absolute URI.")
+                .Validate(options => options.Endpoint is null || options.Endpoint.IsAbsoluteUri, "Webhook endpoint must be an absolute URI.")
+                .Validate(options => Enum.IsDefined(options.PayloadType), "Webhook payload type is invalid.")
+                .Validate(options => (options.Events & ~WebhookEvents.All) == 0, "Webhook events contain an invalid value.");
+
+        return services;
+    }
+}

--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -49,6 +49,8 @@ builder.Services.AddOptions<AcmebotOptions>()
        .Bind(builder.Configuration.GetSection("Acmebot"))
        .ValidateDataAnnotations();
 
+builder.Services.AddWebhookOptions(builder.Configuration.GetSection("Acmebot:Webhook"));
+
 // Add Services
 builder.Services.AddHttpClient();
 builder.Services.AddSingleton<AppRoleService>();
@@ -139,26 +141,10 @@ builder.Services.AddSingleton<WebhookInvoker>();
 
 builder.Services.AddSingleton<IWebhookPayloadBuilder>(provider =>
 {
-    var options = provider.GetRequiredService<IOptions<AcmebotOptions>>().Value;
+    var acmebotOptions = provider.GetRequiredService<IOptions<AcmebotOptions>>().Value;
+    var webhookOptions = provider.GetRequiredService<IOptions<WebhookOptions>>().Value;
 
-    if (options.Webhook is null)
-    {
-        return new GenericPayloadBuilder(options);
-    }
-
-    var host = options.Webhook.Host;
-
-    if (host.EndsWith("hooks.slack.com", StringComparison.OrdinalIgnoreCase))
-    {
-        return new SlackPayloadBuilder();
-    }
-
-    if (host.EndsWith(".logic.azure.com", StringComparison.OrdinalIgnoreCase) || host.EndsWith(".environment.api.powerplatform.com", StringComparison.OrdinalIgnoreCase))
-    {
-        return new TeamsPayloadBuilder();
-    }
-
-    return new GenericPayloadBuilder(options);
+    return WebhookPayloadBuilderFactory.Create(acmebotOptions, webhookOptions);
 });
 
 // Add DNS Providers

--- a/tests/Acmebot.App.Tests/WebhookInvokerTests.cs
+++ b/tests/Acmebot.App.Tests/WebhookInvokerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Text.Json;
 
 using Acmebot.App.Notifications;
 using Acmebot.App.Options;
@@ -49,17 +50,71 @@ public sealed class WebhookInvokerTests
         await invoker.SendFailedEventAsync("example-com", ["example.com"]);
     }
 
-    private static WebhookInvoker CreateInvoker(HttpClient httpClient, IWebhookPayloadBuilder payloadBuilder)
+    [Fact]
+    public async Task SendCompletedEventAsync_PostsJsonBody()
+    {
+        using var handler = new CapturingHttpMessageHandler();
+        using var httpClient = new HttpClient(handler);
+        var invoker = CreateInvoker(httpClient, new StubWebhookPayloadBuilder());
+
+        await invoker.SendCompletedEventAsync(
+            "example-com",
+            DateTimeOffset.Parse("2026-07-01T00:00:00Z"),
+            ["example.com"],
+            "acme.example");
+
+        Assert.Equal("application/json", handler.ContentType);
+        Assert.NotNull(handler.Body);
+
+        using var body = JsonDocument.Parse(handler.Body);
+        Assert.Equal("example-com", body.RootElement.GetProperty("certificateName").GetString());
+    }
+
+    [Fact]
+    public async Task SendCompletedEventAsync_WhenCompletedEventDisabled_DoesNotPost()
+    {
+        var requestCount = 0;
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(_ =>
+        {
+            requestCount++;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }));
+        var invoker = CreateInvoker(httpClient, new ThrowingWebhookPayloadBuilder(), WebhookEvents.Failed);
+
+        await invoker.SendCompletedEventAsync(
+            "example-com",
+            DateTimeOffset.Parse("2026-07-01T00:00:00Z"),
+            ["example.com"],
+            "acme.example");
+
+        Assert.Equal(0, requestCount);
+    }
+
+    [Fact]
+    public async Task SendFailedEventAsync_WhenOnlyFailedEventEnabled_Posts()
+    {
+        var requestCount = 0;
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(_ =>
+        {
+            requestCount++;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }));
+        var invoker = CreateInvoker(httpClient, new StubWebhookPayloadBuilder(), WebhookEvents.Failed);
+
+        await invoker.SendFailedEventAsync("example-com", ["example.com"]);
+
+        Assert.Equal(1, requestCount);
+    }
+
+    private static WebhookInvoker CreateInvoker(HttpClient httpClient, IWebhookPayloadBuilder payloadBuilder, WebhookEvents events = WebhookEvents.All)
     {
         return new WebhookInvoker(
             payloadBuilder,
             new StubHttpClientFactory(httpClient),
-            Microsoft.Extensions.Options.Options.Create(new AcmebotOptions
+            Microsoft.Extensions.Options.Options.Create(new WebhookOptions
             {
-                Contacts = "admin@example.com",
-                Endpoint = new Uri("https://acme.example/directory"),
-                VaultBaseUrl = "https://vault.example/",
-                Webhook = new Uri("https://webhook.example/")
+                Endpoint = new Uri("https://webhook.example/"),
+                Events = events
             }),
             NullLogger<WebhookInvoker>.Instance);
     }
@@ -74,6 +129,21 @@ public sealed class WebhookInvokerTests
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return Task.FromResult(responseFactory(request));
+        }
+    }
+
+    private sealed class CapturingHttpMessageHandler : HttpMessageHandler
+    {
+        public string? Body { get; private set; }
+
+        public string? ContentType { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Body = await request.Content!.ReadAsStringAsync(cancellationToken);
+            ContentType = request.Content.Headers.ContentType?.MediaType;
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
         }
     }
 

--- a/tests/Acmebot.App.Tests/WebhookOptionsTests.cs
+++ b/tests/Acmebot.App.Tests/WebhookOptionsTests.cs
@@ -1,0 +1,74 @@
+﻿using Acmebot.App.Options;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class WebhookOptionsTests
+{
+    [Fact]
+    public void AddWebhookOptions_WithStructuredSettings_BindsValues()
+    {
+        var options = BindOptions(new Dictionary<string, string?>
+        {
+            ["Acmebot:Webhook:Endpoint"] = "https://webhook.example/",
+            ["Acmebot:Webhook:Events"] = "Failed",
+            ["Acmebot:Webhook:PayloadType"] = "Generic"
+        });
+
+        Assert.Equal(new Uri("https://webhook.example/"), options.Endpoint);
+        Assert.Equal(WebhookEvents.Failed, options.Events);
+        Assert.Equal(WebhookPayloadType.Generic, options.PayloadType);
+    }
+
+    [Fact]
+    public void AddWebhookOptions_WithLegacyScalarSetting_UsesItAsEndpoint()
+    {
+        var options = BindOptions(new Dictionary<string, string?>
+        {
+            ["Acmebot:Webhook"] = "https://legacy-webhook.example/"
+        });
+
+        Assert.Equal(new Uri("https://legacy-webhook.example/"), options.Endpoint);
+        Assert.Equal(WebhookEvents.All, options.Events);
+        Assert.Equal(WebhookPayloadType.Auto, options.PayloadType);
+    }
+
+    [Fact]
+    public void AddWebhookOptions_WithStructuredAndLegacySettings_PrefersStructuredEndpoint()
+    {
+        var options = BindOptions(new Dictionary<string, string?>
+        {
+            ["Acmebot:Webhook"] = "https://legacy-webhook.example/",
+            ["Acmebot:Webhook:Endpoint"] = "https://webhook.example/"
+        });
+
+        Assert.Equal(new Uri("https://webhook.example/"), options.Endpoint);
+    }
+
+    [Fact]
+    public void AddWebhookOptions_WithInvalidLegacyScalarSetting_FailsValidation()
+    {
+        Assert.Throws<OptionsValidationException>(() => BindOptions(new Dictionary<string, string?>
+        {
+            ["Acmebot:Webhook"] = "not-a-url"
+        }));
+    }
+
+    private static WebhookOptions BindOptions(Dictionary<string, string?> values)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+        var services = new ServiceCollection();
+
+        services.AddWebhookOptions(configuration.GetSection("Acmebot:Webhook"));
+
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IOptions<WebhookOptions>>().Value;
+    }
+}

--- a/tests/Acmebot.App.Tests/WebhookPayloadBuilderFactoryTests.cs
+++ b/tests/Acmebot.App.Tests/WebhookPayloadBuilderFactoryTests.cs
@@ -1,0 +1,58 @@
+﻿using Acmebot.App.Notifications;
+using Acmebot.App.Options;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class WebhookPayloadBuilderFactoryTests
+{
+    [Theory]
+    [InlineData("https://hooks.slack.com/services/example", typeof(SlackPayloadBuilder))]
+    [InlineData("https://prod-00.japaneast.logic.azure.com/workflows/example", typeof(TeamsPayloadBuilder))]
+    [InlineData("https://example.environment.api.powerplatform.com/powerautomate/automations/direct/workflows/example", typeof(TeamsPayloadBuilder))]
+    [InlineData("https://webhook.example/", typeof(GenericPayloadBuilder))]
+    public void Create_WithAutomaticPayloadType_DetectsEndpoint(string endpoint, Type expectedType)
+    {
+        var builder = WebhookPayloadBuilderFactory.Create(CreateAcmebotOptions(), new WebhookOptions
+        {
+            Endpoint = new Uri(endpoint)
+        });
+
+        Assert.IsType(expectedType, builder);
+    }
+
+    [Fact]
+    public void Create_WithExplicitGenericPayloadType_OverridesLogicAppsEndpoint()
+    {
+        var builder = WebhookPayloadBuilderFactory.Create(CreateAcmebotOptions(), new WebhookOptions
+        {
+            Endpoint = new Uri("https://prod-00.japaneast.logic.azure.com/workflows/example"),
+            PayloadType = WebhookPayloadType.Generic
+        });
+
+        Assert.IsType<GenericPayloadBuilder>(builder);
+    }
+
+    [Fact]
+    public void Create_WithExplicitTeamsPayloadType_OverridesEndpointDetection()
+    {
+        var builder = WebhookPayloadBuilderFactory.Create(CreateAcmebotOptions(), new WebhookOptions
+        {
+            Endpoint = new Uri("https://webhook.example/"),
+            PayloadType = WebhookPayloadType.Teams
+        });
+
+        Assert.IsType<TeamsPayloadBuilder>(builder);
+    }
+
+    private static AcmebotOptions CreateAcmebotOptions()
+    {
+        return new AcmebotOptions
+        {
+            Contacts = "admin@example.com",
+            Endpoint = new Uri("https://acme.example/directory"),
+            VaultBaseUrl = "https://vault.example/"
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- add structured webhook settings for endpoint, payload type, and notification events
- allow custom Logic Apps to explicitly select the generic JSON payload
- support completed-only, failed-only, all, or disabled webhook notifications
- preserve compatibility with the legacy scalar `Acmebot__Webhook` setting
- document the new configuration and add regression coverage

## Root cause

Webhook payload selection was based only on the endpoint host. Both Teams Workflows and custom Logic Apps can use `.logic.azure.com`, so custom Logic Apps were incorrectly sent a Teams Adaptive Card payload.

## Impact

Existing configurations continue to use automatic payload detection and send all events. Users can opt into a generic payload and failure-only notifications with:

```text
Acmebot__Webhook__Endpoint=https://...
Acmebot__Webhook__PayloadType=Generic
Acmebot__Webhook__Events=Failed
```

## Validation

- `dotnet test Acmebot.slnx --no-restore` (200 tests passed)
- `dotnet format Acmebot.slnx --verify-no-changes --no-restore`
- `npm run build` in `docs`

Fixes #1197