### PR TITLE
Fix webhook content length for Logic Apps

### DIFF
--- a/src/Acmebot.App/Notifications/WebhookInvoker.cs
+++ b/src/Acmebot.App/Notifications/WebhookInvoker.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 
 using Acmebot.App.Options;
 
@@ -10,6 +11,8 @@ namespace Acmebot.App.Notifications;
 
 public partial class WebhookInvoker(IWebhookPayloadBuilder webhookPayloadBuilder, IHttpClientFactory httpClientFactory, IOptions<WebhookOptions> options, ILogger<WebhookInvoker> logger)
 {
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new(JsonSerializerDefaults.Web);
+
     private readonly WebhookOptions _options = options.Value;
 
     public Task SendCompletedEventAsync(string certificateName, DateTimeOffset? expirationDate, IEnumerable<string> dnsNames, string acmeEndpoint)
@@ -43,8 +46,10 @@ public partial class WebhookInvoker(IWebhookPayloadBuilder webhookPayloadBuilder
         {
             var payload = payloadFactory();
             var httpClient = httpClientFactory.CreateClient();
+            using var content = JsonContent.Create(payload, options: s_jsonSerializerOptions);
+            await content.LoadIntoBufferAsync();
 
-            using var response = await httpClient.PostAsJsonAsync(_options.Endpoint, payload);
+            using var response = await httpClient.PostAsync(_options.Endpoint, content);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/tests/Acmebot.App.Tests/WebhookInvokerTests.cs
+++ b/tests/Acmebot.App.Tests/WebhookInvokerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Text;
 using System.Text.Json;
 
 using Acmebot.App.Notifications;
@@ -65,6 +66,7 @@ public sealed class WebhookInvokerTests
 
         Assert.Equal("application/json", handler.ContentType);
         Assert.NotNull(handler.Body);
+        Assert.Equal(Encoding.UTF8.GetByteCount(handler.Body), handler.ContentLength);
 
         using var body = JsonDocument.Parse(handler.Body);
         Assert.Equal("example-com", body.RootElement.GetProperty("certificateName").GetString());
@@ -138,8 +140,11 @@ public sealed class WebhookInvokerTests
 
         public string? ContentType { get; private set; }
 
+        public long? ContentLength { get; private set; }
+
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            ContentLength = request.Content!.Headers.ContentLength;
             Body = await request.Content!.ReadAsStringAsync(cancellationToken);
             ContentType = request.Content.Headers.ContentType?.MediaType;
 


### PR DESCRIPTION
## Summary

- Buffer webhook `JsonContent` before sending so `Content-Length` is available
- Keep the existing JSON payload serialization path instead of switching content types
- Add test coverage that verifies the webhook request content length matches the UTF-8 body length

## Root Cause

`PostAsJsonAsync` sends `JsonContent` without pre-buffering the request body. For endpoints such as Azure Logic Apps HTTP triggers, that can result in chunked transfer encoding and an unreadable empty request body.

## Validation

- `dotnet test tests\Acmebot.App.Tests\Acmebot.App.Tests.csproj --no-restore --filter FullyQualifiedName~WebhookInvokerTests --nologo --verbosity minimal`
- `dotnet test tests\Acmebot.App.Tests\Acmebot.App.Tests.csproj --no-restore --nologo --verbosity minimal`

Fixes #1201