### PR TITLE
Support sovereign cloud endpoints and audiences

### DIFF
--- a/src/Acmebot.App/Infrastructure/AzureEnvironment.cs
+++ b/src/Acmebot.App/Infrastructure/AzureEnvironment.cs
@@ -7,6 +7,7 @@ public class AzureEnvironment
 {
     public required Uri AuthorityHost { get; init; }
     public required ArmEnvironment ResourceManager { get; init; }
+    public required string StorageEndpointSuffix { get; init; }
 
     public static AzureEnvironment Get(string name) => s_environments[name];
 
@@ -17,7 +18,8 @@ public class AzureEnvironment
             new AzureEnvironment
             {
                 AuthorityHost = AzureAuthorityHosts.AzurePublicCloud,
-                ResourceManager = ArmEnvironment.AzurePublicCloud
+                ResourceManager = ArmEnvironment.AzurePublicCloud,
+                StorageEndpointSuffix = "core.windows.net"
             }
         },
         {
@@ -25,7 +27,8 @@ public class AzureEnvironment
             new AzureEnvironment
             {
                 AuthorityHost = AzureAuthorityHosts.AzureChina,
-                ResourceManager = ArmEnvironment.AzureChina
+                ResourceManager = ArmEnvironment.AzureChina,
+                StorageEndpointSuffix = "core.chinacloudapi.cn"
             }
         },
         {
@@ -33,7 +36,8 @@ public class AzureEnvironment
             new AzureEnvironment
             {
                 AuthorityHost = AzureAuthorityHosts.AzureGovernment,
-                ResourceManager = ArmEnvironment.AzureGovernment
+                ResourceManager = ArmEnvironment.AzureGovernment,
+                StorageEndpointSuffix = "core.usgovcloudapi.net"
             }
         }
     };

--- a/src/Acmebot.App/Infrastructure/AzureWebJobsStorageSettings.cs
+++ b/src/Acmebot.App/Infrastructure/AzureWebJobsStorageSettings.cs
@@ -15,7 +15,7 @@ public sealed record AzureWebJobsStorageSettings(string? ConnectionString, strin
             GetConnectionProperty(configuration, "clientId"));
     }
 
-    public string GetBlobServiceUri()
+    public string GetBlobServiceUri(string storageEndpointSuffix)
     {
         if (!string.IsNullOrWhiteSpace(BlobServiceUri))
         {
@@ -24,7 +24,7 @@ public sealed record AzureWebJobsStorageSettings(string? ConnectionString, strin
 
         if (!string.IsNullOrWhiteSpace(AccountName))
         {
-            return $"https://{AccountName}.blob.core.windows.net";
+            return $"https://{AccountName}.blob.{storageEndpointSuffix}";
         }
 
         throw new InvalidOperationException("AzureWebJobsStorage, AzureWebJobsStorage__blobServiceUri, or AzureWebJobsStorage__accountName is required.");

--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -113,7 +113,7 @@ builder.Services.AddSingleton(provider =>
         return new BlobContainerClient(connectionString, acmeStateContainerName);
     }
 
-    var blobServiceUri = storageSettings.GetBlobServiceUri();
+    var blobServiceUri = storageSettings.GetBlobServiceUri(environment.StorageEndpointSuffix);
     var clientId = storageSettings.ClientId;
 
     var managedIdentityId = string.IsNullOrWhiteSpace(clientId) ? ManagedIdentityId.SystemAssigned : ManagedIdentityId.FromUserAssignedClientId(clientId);
@@ -159,23 +159,29 @@ builder.Services.AddSingleton<IEnumerable<IDnsProvider>>(provider =>
     dnsProviders.TryAdd(options.Akamai, o => new AkamaiEdgeDnsProvider(o));
     dnsProviders.TryAdd(options.AzureDns, o => new AzureDnsProvider(
         o,
-        environment,
+        environment.ResourceManager,
         ResolveCredential(environment, tokenCredential, o.ManagedIdentityClientId)));
     dnsProviders.TryAdd(options.AzurePrivateDns, o => new AzurePrivateDnsProvider(
         o,
-        environment,
+        environment.ResourceManager,
         ResolveCredential(environment, tokenCredential, o.ManagedIdentityClientId)));
     dnsProviders.TryAdd(options.Cloudflare, o => new CloudflareProvider(o));
     dnsProviders.TryAdd(options.CustomDns, o => new CustomDnsProvider(o));
     dnsProviders.TryAdd(options.DnsMadeEasy, o => new DnsMadeEasyProvider(o));
     dnsProviders.TryAdd(options.GandiLiveDns, o => new GandiLiveDnsProvider(o));
     dnsProviders.TryAdd(options.GoDaddy, o => new GoDaddyProvider(o));
-    dnsProviders.TryAdd(options.GoogleDns, o => new GoogleDnsProvider(o, ResolveCredential(environment, tokenCredential, o.ManagedIdentityClientId)));
+    dnsProviders.TryAdd(options.GoogleDns, o => new GoogleDnsProvider(
+        o,
+        environment.ResourceManager.Audience,
+        ResolveCredential(environment, tokenCredential, o.ManagedIdentityClientId)));
     dnsProviders.TryAdd(options.IonosDns, o => new IonosDnsProvider(o));
     dnsProviders.TryAdd(options.Ovh, o => new OvhProvider(o));
     dnsProviders.TryAdd(options.PowerDns, o => new PowerDnsProvider(o));
     dnsProviders.TryAdd(options.Regfish, o => new RegfishProvider(o));
-    dnsProviders.TryAdd(options.Route53, o => new Route53Provider(o, ResolveCredential(environment, tokenCredential, o.ManagedIdentityClientId)));
+    dnsProviders.TryAdd(options.Route53, o => new Route53Provider(
+        o,
+        environment.ResourceManager.Audience,
+        ResolveCredential(environment, tokenCredential, o.ManagedIdentityClientId)));
     dnsProviders.TryAdd(options.TransIp, o => new TransIpProvider(options, o, tokenCredential));
     dnsProviders.TryAdd(options.UnitedDomains, o => new UnitedDomainsProvider(o));
 

--- a/src/Acmebot.App/Providers/AzureDnsProvider.cs
+++ b/src/Acmebot.App/Providers/AzureDnsProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net;
 
-using Acmebot.App.Infrastructure;
 using Acmebot.App.Options;
 
 using Azure;
@@ -11,9 +10,9 @@ using Azure.ResourceManager.Dns.Models;
 
 namespace Acmebot.App.Providers;
 
-public class AzureDnsProvider(AzureDnsOptions options, AzureEnvironment environment, TokenCredential credential) : IDnsProvider
+public class AzureDnsProvider(AzureDnsOptions options, ArmEnvironment environment, TokenCredential credential) : IDnsProvider
 {
-    private readonly ArmClient _armClient = new(credential, options.SubscriptionId, new ArmClientOptions { Environment = environment.ResourceManager });
+    private readonly ArmClient _armClient = new(credential, options.SubscriptionId, new ArmClientOptions { Environment = environment });
 
     public string Name => "Azure DNS";
 

--- a/src/Acmebot.App/Providers/AzurePrivateDnsProvider.cs
+++ b/src/Acmebot.App/Providers/AzurePrivateDnsProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net;
 
-using Acmebot.App.Infrastructure;
 using Acmebot.App.Options;
 
 using Azure;
@@ -11,9 +10,9 @@ using Azure.ResourceManager.PrivateDns.Models;
 
 namespace Acmebot.App.Providers;
 
-public class AzurePrivateDnsProvider(AzurePrivateDnsOptions options, AzureEnvironment environment, TokenCredential credential) : IDnsProvider
+public class AzurePrivateDnsProvider(AzurePrivateDnsOptions options, ArmEnvironment environment, TokenCredential credential) : IDnsProvider
 {
-    private readonly ArmClient _armClient = new(credential, options.SubscriptionId, new ArmClientOptions { Environment = environment.ResourceManager });
+    private readonly ArmClient _armClient = new(credential, options.SubscriptionId, new ArmClientOptions { Environment = environment });
 
     public string Name => "Azure Private DNS";
 

--- a/src/Acmebot.App/Providers/GoogleDnsProvider.cs
+++ b/src/Acmebot.App/Providers/GoogleDnsProvider.cs
@@ -13,7 +13,7 @@ namespace Acmebot.App.Providers;
 
 public class GoogleDnsProvider : IDnsProvider
 {
-    public GoogleDnsProvider(GoogleDnsOptions options, TokenCredential tokenCredential)
+    public GoogleDnsProvider(GoogleDnsOptions options, string audience, TokenCredential tokenCredential)
     {
         GoogleCredential? credential;
 
@@ -29,7 +29,7 @@ public class GoogleDnsProvider : IDnsProvider
             var initializer = new ProgrammaticExternalAccountCredential.Initializer("https://sts.googleapis.com/v1/token",
                                                                                     $"//iam.googleapis.com/{options.PoolProvider}",
                                                                                     "urn:ietf:params:oauth:token-type:jwt",
-                                                                                    new ManagedIdentitySubjectTokenProvider(tokenCredential))
+                                                                                    new ManagedIdentitySubjectTokenProvider(audience, tokenCredential))
             {
                 ServiceAccountImpersonationUrl = $"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{options.ServiceAccount}:generateAccessToken"
             };
@@ -120,13 +120,11 @@ public class GoogleDnsProvider : IDnsProvider
         await _dnsService.Changes.Create(change, _projectId, zone.Id).ExecuteAsync(cancellationToken);
     }
 
-    private sealed class ManagedIdentitySubjectTokenProvider(TokenCredential tokenCredential) : ProgrammaticExternalAccountCredential.ISubjectTokenProvider
+    private sealed class ManagedIdentitySubjectTokenProvider(string audience, TokenCredential tokenCredential) : ProgrammaticExternalAccountCredential.ISubjectTokenProvider
     {
-        private const string Audience = "https://management.azure.com/";
-
         public async Task<string> GetSubjectTokenAsync(ProgrammaticExternalAccountCredential caller, CancellationToken cancellationToken)
         {
-            var token = await tokenCredential.GetTokenAsync(new TokenRequestContext([Audience]), cancellationToken);
+            var token = await tokenCredential.GetTokenAsync(new TokenRequestContext([audience]), cancellationToken);
 
             return token.Token;
         }

--- a/src/Acmebot.App/Providers/Route53Provider.cs
+++ b/src/Acmebot.App/Providers/Route53Provider.cs
@@ -11,9 +11,9 @@ using Azure.Core;
 
 namespace Acmebot.App.Providers;
 
-public class Route53Provider(Route53Options options, TokenCredential tokenCredential) : IDnsProvider
+public class Route53Provider(Route53Options options, string audience, TokenCredential tokenCredential) : IDnsProvider
 {
-    private readonly AmazonRoute53Client _amazonRoute53Client = CreateClient(options, tokenCredential);
+    private readonly AmazonRoute53Client _amazonRoute53Client = CreateClient(options, audience, tokenCredential);
 
     public string Name => "Amazon Route 53";
 
@@ -91,23 +91,21 @@ public class Route53Provider(Route53Options options, TokenCredential tokenCreden
         await _amazonRoute53Client.ChangeResourceRecordSetsAsync(request, cancellationToken);
     }
 
-    private static AmazonRoute53Client CreateClient(Route53Options options, TokenCredential tokenCredential)
+    private static AmazonRoute53Client CreateClient(Route53Options options, string audience, TokenCredential tokenCredential)
     {
         if (!string.IsNullOrWhiteSpace(options.RoleArn))
         {
-            return new AmazonRoute53Client(new ManagedIdentityWebIdentityCredentials(options.RoleArn, tokenCredential), RegionEndpoint.USEast1);
+            return new AmazonRoute53Client(new ManagedIdentityWebIdentityCredentials(options.RoleArn, audience, tokenCredential), RegionEndpoint.USEast1);
         }
 
         return new AmazonRoute53Client(new BasicAWSCredentials(options.AccessKey, options.SecretKey), RegionEndpoint.USEast1);
     }
 
-    private sealed class ManagedIdentityWebIdentityCredentials(string roleArn, TokenCredential tokenCredential) : RefreshingAWSCredentials
+    private sealed class ManagedIdentityWebIdentityCredentials(string roleArn, string audience, TokenCredential tokenCredential) : RefreshingAWSCredentials
     {
-        private const string Audience = "https://management.azure.com/";
-
         protected override async Task<CredentialsRefreshState> GenerateNewCredentialsAsync()
         {
-            var token = await tokenCredential.GetTokenAsync(new TokenRequestContext([Audience]), CancellationToken.None);
+            var token = await tokenCredential.GetTokenAsync(new TokenRequestContext([audience]), CancellationToken.None);
 
             using var securityTokenServiceClient = new AmazonSecurityTokenServiceClient(new AnonymousAWSCredentials(), RegionEndpoint.USEast1);
 

--- a/tests/Acmebot.App.Tests/AzureWebJobsStorageSettingsTests.cs
+++ b/tests/Acmebot.App.Tests/AzureWebJobsStorageSettingsTests.cs
@@ -34,16 +34,19 @@ public sealed class AzureWebJobsStorageSettingsTests
         var settings = AzureWebJobsStorageSettings.FromConfiguration(configuration);
 
         Assert.Equal("storageaccount", settings.AccountName);
-        Assert.Equal("https://custom.blob.core.windows.net", settings.GetBlobServiceUri());
+        Assert.Equal("https://custom.blob.core.windows.net", settings.GetBlobServiceUri("core.windows.net"));
         Assert.Equal("11111111-1111-1111-1111-111111111111", settings.ClientId);
     }
 
-    [Fact]
-    public void GetBlobServiceUri_WithAccountName_BuildsDefaultPublicAzureUri()
+    [Theory]
+    [InlineData("core.windows.net", "https://storageaccount.blob.core.windows.net")]
+    [InlineData("core.usgovcloudapi.net", "https://storageaccount.blob.core.usgovcloudapi.net")]
+    [InlineData("core.chinacloudapi.cn", "https://storageaccount.blob.core.chinacloudapi.cn")]
+    public void GetBlobServiceUri_WithAccountName_BuildsUriWithStorageEndpointSuffix(string storageEndpointSuffix, string expected)
     {
         var settings = new AzureWebJobsStorageSettings(null, null, "storageaccount", null);
 
-        Assert.Equal("https://storageaccount.blob.core.windows.net", settings.GetBlobServiceUri());
+        Assert.Equal(expected, settings.GetBlobServiceUri(storageEndpointSuffix));
     }
 
     [Fact]
@@ -51,7 +54,7 @@ public sealed class AzureWebJobsStorageSettingsTests
     {
         var settings = new AzureWebJobsStorageSettings(null, null, null, null);
 
-        var ex = Assert.Throws<InvalidOperationException>(settings.GetBlobServiceUri);
+        var ex = Assert.Throws<InvalidOperationException>(() => settings.GetBlobServiceUri("core.windows.net"));
 
         Assert.Equal("AzureWebJobsStorage, AzureWebJobsStorage__blobServiceUri, or AzureWebJobsStorage__accountName is required.", ex.Message);
     }


### PR DESCRIPTION
This pull request updates how Azure and other cloud environments are handled, especially regarding storage endpoint suffixes and audience values for identity-based authentication. The main changes ensure that the correct endpoints and audiences are used for different cloud environments, improving multi-cloud compatibility and security.

**Environment and Endpoint Handling Improvements:**

* Added a new `StorageEndpointSuffix` property to the `AzureEnvironment` class and set appropriate values for Azure Public, China, and US Government clouds. (`src/Acmebot.App/Infrastructure/AzureEnvironment.cs`) [[1]](diffhunk://#diff-e0c50f65edcf7d8c8eab0829957a63ecd97754be2557482127feb529416889c6R10) [[2]](diffhunk://#diff-e0c50f65edcf7d8c8eab0829957a63ecd97754be2557482127feb529416889c6L20-R40)
* Updated `AzureWebJobsStorageSettings.GetBlobServiceUri` to accept a `storageEndpointSuffix` parameter, allowing construction of the correct blob service URI for each environment. (`src/Acmebot.App/Infrastructure/AzureWebJobsStorageSettings.cs`, `src/Acmebot.App/Program.cs`) [[1]](diffhunk://#diff-afcc429a5e4cb409eb4bc0ff6fd34fccb31d666827e7feb0f1f0ba53b0680b83L18-R18) [[2]](diffhunk://#diff-afcc429a5e4cb409eb4bc0ff6fd34fccb31d666827e7feb0f1f0ba53b0680b83L27-R27) [[3]](diffhunk://#diff-898b4223d5da9ec708be296f37a67a4173aa000af76fab8bfc945d53aee13557L116-R116)

**Provider Authentication Refactoring:**

* Refactored DNS provider constructors to accept `ArmEnvironment` or audience parameters instead of the full `AzureEnvironment`, ensuring only relevant environment data is passed and used. (`src/Acmebot.App/Providers/AzureDnsProvider.cs`, `src/Acmebot.App/Providers/AzurePrivateDnsProvider.cs`, `src/Acmebot.App/Program.cs`) [[1]](diffhunk://#diff-e0e469c768ccf93090731c93cc38f7ccf32b6b8ab2eadc15de74594a7297e175L14-R15) [[2]](diffhunk://#diff-2409acfa068a7fa9ae3160621b77642ecb74ce9f229f38484d448f6cb821663eL14-R15) [[3]](diffhunk://#diff-898b4223d5da9ec708be296f37a67a4173aa000af76fab8bfc945d53aee13557L162-R184)
* Updated Google DNS and Route 53 providers to accept and use a configurable audience for managed identity authentication, rather than a hardcoded value. (`src/Acmebot.App/Providers/GoogleDnsProvider.cs`, `src/Acmebot.App/Providers/Route53Provider.cs`, `src/Acmebot.App/Program.cs`) [[1]](diffhunk://#diff-21ef31d91b5005a7aa869fd8fb4c00491cc541dabd4c107c1cf39699eb4c49ddL16-R16) [[2]](diffhunk://#diff-21ef31d91b5005a7aa869fd8fb4c00491cc541dabd4c107c1cf39699eb4c49ddL32-R32) [[3]](diffhunk://#diff-21ef31d91b5005a7aa869fd8fb4c00491cc541dabd4c107c1cf39699eb4c49ddL123-R127) [[4]](diffhunk://#diff-dbd8554eaa27ddc9b55c3b7954a30290c67803bf2a6321cd6297c58aa8b05984L14-R16) [[5]](diffhunk://#diff-dbd8554eaa27ddc9b55c3b7954a30290c67803bf2a6321cd6297c58aa8b05984L94-R108) [[6]](diffhunk://#diff-898b4223d5da9ec708be296f37a67a4173aa000af76fab8bfc945d53aee13557L162-R184)

**Testing Updates:**

* Improved unit tests to verify that `GetBlobServiceUri` correctly builds URIs for different storage endpoint suffixes, and updated exception handling tests accordingly. (`tests/Acmebot.App.Tests/AzureWebJobsStorageSettingsTests.cs`)

These changes enhance support for multiple Azure clouds and external DNS providers, making the application more robust and secure in multi-cloud scenarios.