### PR TITLE
Improve ARI renewal scheduling conformance with RFC 9773

### DIFF
--- a/src/Acmebot.App/Functions/Orchestration/CertificateActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateActivities.cs
@@ -69,6 +69,19 @@ public class CertificateActivities(
             };
         }
 
+        // RFC 9773 Section 4.3: renewal information must not be checked after the certificate
+        // has expired, so renew immediately without consulting the ARI endpoint.
+        if (properties.ExpiresOn is { } expiresOn && expiresOn <= now)
+        {
+            return new CertificateRenewalEvaluation
+            {
+                IsActive = true,
+                ShouldRenew = true,
+                NextCheck = now.Add(s_renewalInfoCheckInterval),
+                Reason = "Certificate has expired. Renewing immediately."
+            };
+        }
+
         if (properties.TryGetCertificateId(out var certificateId))
         {
             var acmeContext = await acmeClientFactory.CreateClientAsync();
@@ -79,12 +92,13 @@ public class CertificateActivities(
                 {
                     var renewalInfo = await acmeContext.Client.GetRenewalInfoAsync(certificateId);
                     var suggestedWindow = renewalInfo.Resource.SuggestedWindow;
+                    var renewalTime = CertificateRenewalScheduleEvaluator.SelectRenewalTime(certificateId, suggestedWindow.Start, suggestedWindow.End);
 
                     return new CertificateRenewalEvaluation
                     {
                         IsActive = true,
-                        ShouldRenew = suggestedWindow.Start <= now,
-                        NextCheck = SelectNextCheck(now, suggestedWindow.Start, suggestedWindow.End, renewalInfo.RetryAfter),
+                        ShouldRenew = renewalTime <= now,
+                        NextCheck = SelectNextCheck(now, renewalTime, renewalInfo.RetryAfter),
                         Reason = "Renewal is scheduled within the certificate authority's suggested renewal window."
                     };
                 }
@@ -126,8 +140,8 @@ public class CertificateActivities(
         }
     }
 
-    private static DateTimeOffset SelectNextCheck(DateTimeOffset now, DateTimeOffset suggestedWindowStart, DateTimeOffset suggestedWindowEnd, TimeSpan? retryAfter)
+    private static DateTimeOffset SelectNextCheck(DateTimeOffset now, DateTimeOffset renewalTime, TimeSpan? retryAfter)
     {
-        return CertificateRenewalScheduleEvaluator.SelectNextCheck(now, suggestedWindowStart, suggestedWindowEnd, retryAfter, s_renewalInfoCheckInterval);
+        return CertificateRenewalScheduleEvaluator.SelectNextCheck(now, renewalTime, retryAfter, s_renewalInfoCheckInterval);
     }
 }

--- a/src/Acmebot.App/Services/CertificateRenewalScheduleEvaluator.cs
+++ b/src/Acmebot.App/Services/CertificateRenewalScheduleEvaluator.cs
@@ -1,7 +1,17 @@
-﻿namespace Acmebot.App.Services;
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Acmebot.App.Services;
 
 internal static class CertificateRenewalScheduleEvaluator
 {
+    // RFC 9773 Section 4.3.2 requires reasonable limits on the renewalInfo checking interval.
+    // The bounds follow the example given in the RFC: under one minute is treated as one
+    // minute, over one day is treated as one day.
+    private static readonly TimeSpan s_minCheckInterval = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan s_maxCheckInterval = TimeSpan.FromDays(1);
+
     public static bool ShouldRenew(
         DateTimeOffset? notBefore,
         DateTimeOffset? createdOn,
@@ -33,19 +43,38 @@ internal static class CertificateRenewalScheduleEvaluator
         return suggestedWindowStart <= now;
     }
 
+    public static DateTimeOffset SelectRenewalTime(string certificateIdentifier, DateTimeOffset suggestedWindowStart, DateTimeOffset suggestedWindowEnd)
+    {
+        // RFC 9773 Section 4.2 requires selecting a uniform random time within the suggested
+        // window and renewing at exactly that moment. Deriving the offset from a hash of the
+        // certificate identifier and the window keeps the selection stable across evaluations
+        // without persisting state, while still spreading renewals across clients.
+        var seed = SHA256.HashData(Encoding.UTF8.GetBytes($"{certificateIdentifier}|{suggestedWindowStart.UtcTicks}|{suggestedWindowEnd.UtcTicks}"));
+        var windowTicks = (suggestedWindowEnd - suggestedWindowStart).Ticks;
+        var offsetTicks = (long)(BinaryPrimitives.ReadUInt64LittleEndian(seed) % (ulong)windowTicks);
+
+        return suggestedWindowStart.AddTicks(offsetTicks);
+    }
+
     public static DateTimeOffset SelectNextCheck(
         DateTimeOffset now,
-        DateTimeOffset suggestedWindowStart,
-        DateTimeOffset suggestedWindowEnd,
+        DateTimeOffset renewalTime,
         TimeSpan? retryAfter,
-        TimeSpan renewalInfoCheckInterval,
-        Func<long, long>? nextInt64 = null)
+        TimeSpan renewalInfoCheckInterval)
     {
-        var window = suggestedWindowEnd - suggestedWindowStart;
-        var randomOffsetTicks = nextInt64?.Invoke(window.Ticks) ?? Random.Shared.NextInt64(window.Ticks);
-        var randomRenewalTime = suggestedWindowStart.AddTicks(randomOffsetTicks);
-        var nextRenewalInfoCheck = now.Add(retryAfter ?? renewalInfoCheckInterval);
+        var interval = ClampCheckInterval(retryAfter ?? renewalInfoCheckInterval);
+        var nextRenewalInfoCheck = now.Add(interval);
 
-        return randomRenewalTime <= nextRenewalInfoCheck ? randomRenewalTime : nextRenewalInfoCheck;
+        return renewalTime > now && renewalTime < nextRenewalInfoCheck ? renewalTime : nextRenewalInfoCheck;
+    }
+
+    private static TimeSpan ClampCheckInterval(TimeSpan interval)
+    {
+        if (interval < s_minCheckInterval)
+        {
+            return s_minCheckInterval;
+        }
+
+        return interval > s_maxCheckInterval ? s_maxCheckInterval : interval;
     }
 }

--- a/src/Acmebot.App/Services/CertificateRenewalScheduleEvaluator.cs
+++ b/src/Acmebot.App/Services/CertificateRenewalScheduleEvaluator.cs
@@ -1,4 +1,4 @@
-using System.Buffers.Binary;
+﻿using System.Buffers.Binary;
 using System.Security.Cryptography;
 using System.Text;
 

--- a/src/Acmebot.App/Services/CertificateRenewalScheduleEvaluator.cs
+++ b/src/Acmebot.App/Services/CertificateRenewalScheduleEvaluator.cs
@@ -45,6 +45,11 @@ internal static class CertificateRenewalScheduleEvaluator
 
     public static DateTimeOffset SelectRenewalTime(string certificateIdentifier, DateTimeOffset suggestedWindowStart, DateTimeOffset suggestedWindowEnd)
     {
+        if (suggestedWindowEnd <= suggestedWindowStart)
+        {
+            throw new ArgumentException("The suggested renewal window end must be after its start.", nameof(suggestedWindowEnd));
+        }
+
         // RFC 9773 Section 4.2 requires selecting a uniform random time within the suggested
         // window and renewing at exactly that moment. Deriving the offset from a hash of the
         // certificate identifier and the window keeps the selection stable across evaluations

--- a/tests/Acmebot.App.Tests/CertificateRenewalScheduleEvaluatorTests.cs
+++ b/tests/Acmebot.App.Tests/CertificateRenewalScheduleEvaluatorTests.cs
@@ -150,6 +150,15 @@ public sealed class CertificateRenewalScheduleEvaluatorTests
     }
 
     [Fact]
+    public void SelectRenewalTime_ThrowsForInvalidWindow()
+    {
+        var suggestedWindowStart = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        Assert.Throws<ArgumentException>(() => CertificateRenewalScheduleEvaluator.SelectRenewalTime("aYhba4dGQEHhs3uEe6CuLN4ByNQ.AIdlQyE", suggestedWindowStart, suggestedWindowStart));
+        Assert.Throws<ArgumentException>(() => CertificateRenewalScheduleEvaluator.SelectRenewalTime("aYhba4dGQEHhs3uEe6CuLN4ByNQ.AIdlQyE", suggestedWindowStart, suggestedWindowStart.AddHours(-1)));
+    }
+
+    [Fact]
     public void SelectNextCheck_WhenRenewalTimeIsBeforeRetryCheck_ReturnsRenewalTime()
     {
         var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);

--- a/tests/Acmebot.App.Tests/CertificateRenewalScheduleEvaluatorTests.cs
+++ b/tests/Acmebot.App.Tests/CertificateRenewalScheduleEvaluatorTests.cs
@@ -115,37 +115,66 @@ public sealed class CertificateRenewalScheduleEvaluatorTests
     }
 
     [Fact]
-    public void SelectNextCheck_WhenRandomRenewalTimeIsBeforeRetryCheck_ReturnsRandomRenewalTime()
+    public void SelectRenewalTime_ReturnsTimeWithinSuggestedWindow()
     {
-        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        var suggestedWindowStart = now.AddHours(1);
-        var suggestedWindowEnd = now.AddHours(3);
+        var suggestedWindowStart = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var suggestedWindowEnd = suggestedWindowStart.AddDays(2);
 
-        var result = CertificateRenewalScheduleEvaluator.SelectNextCheck(
-            now,
-            suggestedWindowStart,
-            suggestedWindowEnd,
-            retryAfter: TimeSpan.FromHours(4),
-            renewalInfoCheckInterval: TimeSpan.FromHours(6),
-            nextInt64: _ => TimeSpan.FromHours(1).Ticks);
+        var result = CertificateRenewalScheduleEvaluator.SelectRenewalTime("aYhba4dGQEHhs3uEe6CuLN4ByNQ.AIdlQyE", suggestedWindowStart, suggestedWindowEnd);
 
-        Assert.Equal(now.AddHours(2), result);
+        Assert.InRange(result, suggestedWindowStart, suggestedWindowEnd.AddTicks(-1));
     }
 
     [Fact]
-    public void SelectNextCheck_WhenRetryCheckIsBeforeRandomRenewalTime_ReturnsRetryCheck()
+    public void SelectRenewalTime_IsDeterministicForSameCertificateAndWindow()
+    {
+        var suggestedWindowStart = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var suggestedWindowEnd = suggestedWindowStart.AddDays(2);
+
+        var first = CertificateRenewalScheduleEvaluator.SelectRenewalTime("aYhba4dGQEHhs3uEe6CuLN4ByNQ.AIdlQyE", suggestedWindowStart, suggestedWindowEnd);
+        var second = CertificateRenewalScheduleEvaluator.SelectRenewalTime("aYhba4dGQEHhs3uEe6CuLN4ByNQ.AIdlQyE", suggestedWindowStart, suggestedWindowEnd);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void SelectRenewalTime_VariesByCertificateIdentifier()
+    {
+        var suggestedWindowStart = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var suggestedWindowEnd = suggestedWindowStart.AddDays(2);
+
+        var first = CertificateRenewalScheduleEvaluator.SelectRenewalTime("aYhba4dGQEHhs3uEe6CuLN4ByNQ.AIdlQyE", suggestedWindowStart, suggestedWindowEnd);
+        var second = CertificateRenewalScheduleEvaluator.SelectRenewalTime("aYhba4dGQEHhs3uEe6CuLN4ByNQ.AQAB", suggestedWindowStart, suggestedWindowEnd);
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void SelectNextCheck_WhenRenewalTimeIsBeforeRetryCheck_ReturnsRenewalTime()
     {
         var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        var suggestedWindowStart = now.AddHours(2);
-        var suggestedWindowEnd = now.AddHours(5);
+        var renewalTime = now.AddHours(2);
 
         var result = CertificateRenewalScheduleEvaluator.SelectNextCheck(
             now,
-            suggestedWindowStart,
-            suggestedWindowEnd,
+            renewalTime,
+            retryAfter: TimeSpan.FromHours(4),
+            renewalInfoCheckInterval: TimeSpan.FromHours(6));
+
+        Assert.Equal(renewalTime, result);
+    }
+
+    [Fact]
+    public void SelectNextCheck_WhenRetryCheckIsBeforeRenewalTime_ReturnsRetryCheck()
+    {
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var renewalTime = now.AddHours(3);
+
+        var result = CertificateRenewalScheduleEvaluator.SelectNextCheck(
+            now,
+            renewalTime,
             retryAfter: TimeSpan.FromMinutes(30),
-            renewalInfoCheckInterval: TimeSpan.FromHours(6),
-            nextInt64: _ => TimeSpan.FromHours(1).Ticks);
+            renewalInfoCheckInterval: TimeSpan.FromHours(6));
 
         Assert.Equal(now.AddMinutes(30), result);
     }
@@ -154,17 +183,59 @@ public sealed class CertificateRenewalScheduleEvaluatorTests
     public void SelectNextCheck_WithoutRetryAfter_UsesDefaultRenewalInfoCheckInterval()
     {
         var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        var suggestedWindowStart = now.AddHours(2);
-        var suggestedWindowEnd = now.AddHours(5);
+        var renewalTime = now.AddHours(3);
 
         var result = CertificateRenewalScheduleEvaluator.SelectNextCheck(
             now,
-            suggestedWindowStart,
-            suggestedWindowEnd,
+            renewalTime,
             retryAfter: null,
-            renewalInfoCheckInterval: TimeSpan.FromHours(1),
-            nextInt64: _ => TimeSpan.FromHours(1).Ticks);
+            renewalInfoCheckInterval: TimeSpan.FromHours(1));
 
         Assert.Equal(now.AddHours(1), result);
+    }
+
+    [Fact]
+    public void SelectNextCheck_WhenRenewalTimeIsInPast_ReturnsRetryCheck()
+    {
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var renewalTime = now.AddHours(-1);
+
+        var result = CertificateRenewalScheduleEvaluator.SelectNextCheck(
+            now,
+            renewalTime,
+            retryAfter: null,
+            renewalInfoCheckInterval: TimeSpan.FromHours(6));
+
+        Assert.Equal(now.AddHours(6), result);
+    }
+
+    [Fact]
+    public void SelectNextCheck_ClampsRetryAfterBelowOneMinute()
+    {
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var renewalTime = now.AddDays(3);
+
+        var result = CertificateRenewalScheduleEvaluator.SelectNextCheck(
+            now,
+            renewalTime,
+            retryAfter: TimeSpan.Zero,
+            renewalInfoCheckInterval: TimeSpan.FromHours(6));
+
+        Assert.Equal(now.AddMinutes(1), result);
+    }
+
+    [Fact]
+    public void SelectNextCheck_ClampsRetryAfterAboveOneDay()
+    {
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var renewalTime = now.AddDays(30);
+
+        var result = CertificateRenewalScheduleEvaluator.SelectNextCheck(
+            now,
+            renewalTime,
+            retryAfter: TimeSpan.FromDays(14),
+            renewalInfoCheckInterval: TimeSpan.FromHours(6));
+
+        Assert.Equal(now.AddDays(1), result);
     }
 }


### PR DESCRIPTION
## Summary

A strict review of the ACME Renewal Information implementation against [RFC 9773](https://datatracker.ietf.org/doc/rfc9773/) found the core parts (certificate identifier construction, unauthenticated GET, `replaces` handling) fully conformant, but three deviations in the polling/scheduling logic. This PR fixes them in priority order.

## Changes

1. **Clamp the renewalInfo checking interval (Section 4.3.2, MUST)** — the interval derived from `Retry-After` (or the 6-hour default) is now clamped to 1 minute – 1 day, following the bounds suggested in the RFC. Previously a CA returning `Retry-After: 0` could drive the scheduler into a tight evaluate/fetch loop.

2. **Skip ARI for expired certificates (Section 4.3, MUST NOT)** — evaluation now short-circuits to an immediate renewal when the certificate has expired, instead of continuing to query the renewalInfo endpoint on every retry cycle.

3. **Renew at a uniform random time within the suggested window (Section 4.2, RECOMMENDED)** — `SelectRenewalTime` derives the renewal moment from a SHA-256 hash of the certificate identifier and the window bounds. The selection is uniform across clients but deterministic across evaluations, so the stateless evaluation activity implements "pick a random time in the window; renew when it passes" exactly, without persisting state. Previously renewal fired as soon as the window opened. If the CA moves the window, the selected time is recomputed, which matches the RFC's re-selection loop.

The remaining SHOULD (exponential backoff for temporary ARI errors, Section 4.3.3) is intentionally left as-is: the flat 6-hour fallback already satisfies the long-term error MUST and is more conservative than exponential backoff.

## Notes for reviewers

- `SelectNextCheck` changed signature: it now takes the pre-selected renewal time instead of the window bounds plus an injectable RNG; the RNG injection hook was removed since the selection is deterministic.
- Behavior change: renewals now happen at a point spread across the suggested window rather than at window start. With Let''s Encrypt''s typical windows this shifts renewals later by up to the window width.
- Tests: rewrote the `SelectNextCheck` tests for the new signature and added coverage for both clamp bounds, determinism, window containment, and past-time handling. All 208 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)