### PR TITLE
Require exact versions in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,14 +13,24 @@ body:
 
         Please fill out the details below so the issue can be reproduced and investigated efficiently.
 
+        Before submitting, review the [latest release](https://github.com/polymind-inc/acmebot/releases/latest), update Acmebot, and confirm that the issue still occurs. If you cannot update, explain why in **Additional context**.
+
   - type: input
     id: acmebot-version
     attributes:
       label: Acmebot version
-      description: The version of Acmebot you are using.
-      placeholder: e.g. v5.x.x
+      description: Enter the exact version matching an Acmebot release or tag. Values such as "v5" or "latest" are not accepted.
+      placeholder: e.g. v5.1.2
     validations:
       required: true
+
+  - type: checkboxes
+    id: latest-version-confirmation
+    attributes:
+      label: Latest version confirmation
+      options:
+        - label: I reviewed the latest release and updated to it, or explained in Additional context why I cannot update.
+          required: true
 
   - type: dropdown
     id: dns-provider


### PR DESCRIPTION
## Summary

- require reporters to enter an exact Acmebot release or tag version
- clarify that values such as `v5` and `latest` are not accepted
- ask reporters to review and update to the latest release before submitting
- require confirmation that the latest release was reviewed, with an explanation when an update is not possible

## Why

Ambiguous version values make it difficult to determine whether a reported problem is already addressed by a published release. The updated form captures an actionable version and encourages reproduction against the latest available release.

## Impact

Bug reports should contain enough version information to map directly to a release or tag, reducing follow-up questions during triage.

## Validation

- `git diff --cached --check`