### PR TITLE
Run backend tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
           dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx
           dotnet build -c Release --no-restore ./Acmebot.slnx
 
+      - name: Test backend
+        run: dotnet test -c Release --no-build --no-restore ./Acmebot.slnx
+
   dashboard:
     name: Dashboard
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The `backend` job in `ci.yml` runs `dotnet restore`, `dotnet format --verify-no-changes`, and `dotnet build`, but never `dotnet test`. The repository has 209 tests across three projects and none of them execute on push or pull request, so there is currently no regression gate on the backend.

## Change

Add a `Test backend` step that reuses the Release build output:

```
dotnet test -c Release --no-build --no-restore ./Acmebot.slnx
```

Verified locally that this invocation discovers and runs all three test assemblies (Acme 58 / App 113 / Cli 38).

## Note

The dashboard has no test runner configured at all (`package.json` has no `test` script). Pure functions such as `utils/dnsNames.ts` mirror the backend `CertificatePolicyItem` validation rules, so a vitest setup would be worth adding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)