### PR TITLE
Report the ACME order problem when no challenge carries one

### DIFF
--- a/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
@@ -76,12 +76,16 @@ public partial class AcmeOrderActivities(
                 problems.Add(challenge.Error);
             }
 
-            if (problems.Count > 0 && problems.All(x => x.Type is { } type && type == AcmeProblemTypes.Dns))
+            // The certificate authority does not always attach the failure to a challenge, so fall back
+            // to the order-level problem before giving up on reporting a cause.
+            if (problems.Count == 0 && orderDetails.Payload.Error is { } orderError)
             {
-                throw new RetriableOrchestratorException("ACME validation failed because of a DNS-related error. The operation will be retried automatically.");
+                LogAcmeDomainValidationError(logger, JsonSerializer.Serialize(orderError));
+
+                problems.Add(orderError);
             }
 
-            throw new InvalidOperationException($"ACME validation failed and the order is now invalid. Review the reported problem and retry the operation.\nLast problem: {JsonSerializer.Serialize(problems.Last())}");
+            throw CreateOrderInvalidException(problems);
         }
 
         if (orderDetails.Payload.Status != AcmeOrderStatuses.Ready)
@@ -183,6 +187,21 @@ public partial class AcmeOrderActivities(
 
     [LoggerMessage(LogLevel.Warning, "ACME order replacement was already consumed by another order. Retrying without ARI replaces hint. CertificateId: {CertificateId}")]
     private static partial void LogAlreadyReplacedRetry(ILogger logger, string certificateId);
+
+    internal static Exception CreateOrderInvalidException(IReadOnlyList<AcmeProblemDetails> problems)
+    {
+        if (problems.Count == 0)
+        {
+            return new InvalidOperationException("ACME validation failed and the order is now invalid, but the certificate authority did not report a problem for the order or any of its challenges. Review the order on the certificate authority and retry the operation.");
+        }
+
+        if (problems.All(x => x.Type is { } type && type == AcmeProblemTypes.Dns))
+        {
+            return new RetriableOrchestratorException("ACME validation failed because of a DNS-related error. The operation will be retried automatically.");
+        }
+
+        return new InvalidOperationException($"ACME validation failed and the order is now invalid. Review the reported problem and retry the operation.\nLast problem: {JsonSerializer.Serialize(problems[^1])}");
+    }
 
     internal static async Task<OrderDetails> CreateOrderAsync(AcmeClientContext acmeContext, IReadOnlyList<string> dnsNames, string? profile, string? replaces, ILogger logger)
     {

--- a/tests/Acmebot.App.Tests/AcmeOrderActivitiesTests.cs
+++ b/tests/Acmebot.App.Tests/AcmeOrderActivitiesTests.cs
@@ -85,6 +85,40 @@ public sealed class AcmeOrderActivitiesTests
         Assert.Equal("tlsserver", secondPayload.RootElement.GetProperty("profile").GetString());
     }
 
+    [Fact]
+    public void CreateOrderInvalidException_WithoutProblems_ReportsMissingProblemInsteadOfThrowing()
+    {
+        var exception = AcmeOrderActivities.CreateOrderInvalidException([]);
+
+        var invalidOperationException = Assert.IsType<InvalidOperationException>(exception);
+        Assert.Contains("did not report a problem", invalidOperationException.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateOrderInvalidException_WithOnlyDnsProblems_IsRetriable()
+    {
+        var exception = AcmeOrderActivities.CreateOrderInvalidException(
+        [
+            new AcmeProblemDetails { Type = AcmeProblemTypes.Dns },
+            new AcmeProblemDetails { Type = AcmeProblemTypes.Dns }
+        ]);
+
+        Assert.IsType<RetriableOrchestratorException>(exception);
+    }
+
+    [Fact]
+    public void CreateOrderInvalidException_WithNonDnsProblem_ReportsLastProblem()
+    {
+        var exception = AcmeOrderActivities.CreateOrderInvalidException(
+        [
+            new AcmeProblemDetails { Type = AcmeProblemTypes.Dns },
+            new AcmeProblemDetails { Type = AcmeProblemTypes.Caa, Detail = "caa forbids issuance" }
+        ]);
+
+        var invalidOperationException = Assert.IsType<InvalidOperationException>(exception);
+        Assert.Contains("caa forbids issuance", invalidOperationException.Message, StringComparison.Ordinal);
+    }
+
     private static AcmeAccountHandle CreateAccountHandle(AcmeSigner signer)
     {
         return new AcmeAccountHandle


### PR DESCRIPTION
## Problem

In `AcmeOrderActivities.CheckIsReady`, when the order status is `invalid`, problems are collected only from challenges whose own status is `invalid` and whose `Error` is non-null. The final throw then unconditionally formats `problems.Last()`:

```csharp
throw new InvalidOperationException($"...\nLast problem: {JsonSerializer.Serialize(problems.Last())}");
```

If no challenge carries an error — for example when an authorization expires and the challenge stays `pending`, or when the failure is order-scoped rather than challenge-scoped — the list is empty and `Last()` throws `Sequence contains no elements`. The genuine cause is replaced by an unrelated LINQ failure in the operator-facing error.

## Change

- Fall back to `AcmeOrderResource.Error` when no challenge reported a problem. The order-level `error` field is what a CA populates for order-scoped failures, and it was not being read at all.
- Extract the three-way decision into `CreateOrderInvalidException`: no problem at all, DNS-only problems (retriable), anything else (report the last problem).
- Emit a clear message for the no-problem case instead of throwing from `Last()`.

## Tests

Three cases added for `CreateOrderInvalidException`: empty, DNS-only, and mixed with a non-DNS problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)