### PR TITLE
Fail with a clear error when a DNS provider is not configured

### DIFF
--- a/src/Acmebot.App/Services/DnsZoneQueryService.cs
+++ b/src/Acmebot.App/Services/DnsZoneQueryService.cs
@@ -2,9 +2,11 @@
 using Acmebot.App.Models;
 using Acmebot.App.Providers;
 
+using Microsoft.Extensions.Logging;
+
 namespace Acmebot.App.Services;
 
-public class DnsZoneQueryService(IEnumerable<IDnsProvider> dnsProviders)
+public partial class DnsZoneQueryService(IEnumerable<IDnsProvider> dnsProviders, ILogger<DnsZoneQueryService> logger)
 {
     public async Task<IReadOnlyList<DnsZoneGroup>> GetAllDnsZonesAsync(CancellationToken cancellationToken = default)
     {
@@ -26,8 +28,13 @@ public class DnsZoneQueryService(IEnumerable<IDnsProvider> dnsProviders)
                 {
                     throw;
                 }
-                catch
+                catch (Exception ex)
                 {
+                    // A provider outage must not hide the zones of the other providers, but the failure
+                    // still has to be recorded. Otherwise an expired credential is indistinguishable from
+                    // a provider that genuinely hosts no zones.
+                    LogDnsZoneListingFailed(logger, ex, dnsProvider.Name);
+
                     return new DnsZoneGroup
                     {
                         DnsProviderName = dnsProvider.Name,
@@ -42,8 +49,10 @@ public class DnsZoneQueryService(IEnumerable<IDnsProvider> dnsProviders)
         {
             throw;
         }
-        catch
+        catch (Exception ex)
         {
+            LogDnsZoneEnumerationFailed(logger, ex);
+
             return [];
         }
     }
@@ -52,13 +61,25 @@ public class DnsZoneQueryService(IEnumerable<IDnsProvider> dnsProviders)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(dnsProviderName);
 
-        var dnsProvider = dnsProviders.FirstOrDefault(x => x.Name == dnsProviderName);
-
-        if (dnsProvider is null)
-        {
-            return [];
-        }
+        // Returning an empty zone list for an unknown provider would surface downstream as a misleading
+        // "no DNS zone was found for <domain>" error, which sends operators looking at their DNS zones
+        // instead of at the provider configuration that was renamed or removed.
+        var dnsProvider = dnsProviders.FirstOrDefault(x => x.Name == dnsProviderName)
+            ?? throw new PreconditionException($"The DNS provider '{dnsProviderName}' is not configured. Configured DNS providers: {FormatConfiguredProviderNames()}.");
 
         return await dnsProvider.ListZonesAsync(cancellationToken);
     }
+
+    private string FormatConfiguredProviderNames()
+    {
+        var names = dnsProviders.Select(x => x.Name).Order(StringComparer.Ordinal).ToArray();
+
+        return names.Length > 0 ? string.Join(", ", names) : "(none)";
+    }
+
+    [LoggerMessage(LogLevel.Warning, "Listing DNS zones failed and the provider was reported as having no zones. DnsProviderName: {DnsProviderName}")]
+    private static partial void LogDnsZoneListingFailed(ILogger logger, Exception exception, string dnsProviderName);
+
+    [LoggerMessage(LogLevel.Error, "Enumerating the configured DNS providers failed. No DNS zones were returned.")]
+    private static partial void LogDnsZoneEnumerationFailed(ILogger logger, Exception exception);
 }

--- a/tests/Acmebot.App.Tests/DnsZoneQueryServiceTests.cs
+++ b/tests/Acmebot.App.Tests/DnsZoneQueryServiceTests.cs
@@ -1,6 +1,8 @@
 ﻿using Acmebot.App.Providers;
 using Acmebot.App.Services;
 
+using Microsoft.Extensions.Logging.Abstractions;
+
 using Xunit;
 
 namespace Acmebot.App.Tests;
@@ -16,7 +18,7 @@ public sealed class DnsZoneQueryServiceTests
                 CreateZone("b", "b.example.com"),
                 CreateZone("a", "a.example.com")
             ]);
-        var service = new DnsZoneQueryService([provider]);
+        var service = CreateService(provider);
 
         var groups = await service.GetAllDnsZonesAsync(TestContext.Current.CancellationToken);
 
@@ -30,7 +32,7 @@ public sealed class DnsZoneQueryServiceTests
     {
         var failingProvider = new TestDnsProvider("Broken DNS", exception: new InvalidOperationException("boom"));
         var workingProvider = new TestDnsProvider("Working DNS", [CreateZone("example", "example.com")]);
-        var service = new DnsZoneQueryService([failingProvider, workingProvider]);
+        var service = CreateService(failingProvider, workingProvider);
 
         var groups = await service.GetAllDnsZonesAsync(TestContext.Current.CancellationToken);
 
@@ -52,7 +54,7 @@ public sealed class DnsZoneQueryServiceTests
     public async Task GetAllDnsZonesAsync_WhenCancellationIsRequested_ThrowsOperationCanceledException()
     {
         var provider = new TestDnsProvider("Test DNS", [CreateZone("example", "example.com")]);
-        var service = new DnsZoneQueryService([provider]);
+        var service = CreateService(provider);
         using var cancellationTokenSource = new CancellationTokenSource();
 
         await cancellationTokenSource.CancelAsync();
@@ -61,21 +63,23 @@ public sealed class DnsZoneQueryServiceTests
     }
 
     [Fact]
-    public async Task ListZonesAsync_WithUnknownProvider_ReturnsEmpty()
+    public async Task ListZonesAsync_WithUnknownProvider_ThrowsPreconditionExceptionNamingConfiguredProviders()
     {
         var provider = new TestDnsProvider("Test DNS", [CreateZone("example", "example.com")]);
-        var service = new DnsZoneQueryService([provider]);
+        var service = CreateService(provider);
 
-        var zones = await service.ListZonesAsync("Other DNS", TestContext.Current.CancellationToken);
+        var exception = await Assert.ThrowsAsync<PreconditionException>(
+            () => service.ListZonesAsync("Other DNS", TestContext.Current.CancellationToken));
 
-        Assert.Empty(zones);
+        Assert.Contains("'Other DNS' is not configured", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Test DNS", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
     public async Task ListZonesAsync_WithKnownProvider_ReturnsProviderZones()
     {
         var provider = new TestDnsProvider("Test DNS", [CreateZone("example", "example.com")]);
-        var service = new DnsZoneQueryService([provider]);
+        var service = CreateService(provider);
 
         var zones = await service.ListZonesAsync("Test DNS", TestContext.Current.CancellationToken);
 
@@ -83,6 +87,9 @@ public sealed class DnsZoneQueryServiceTests
         Assert.Equal("example.com", zone.Name);
         Assert.Same(provider, zone.DnsProvider);
     }
+
+    private static DnsZoneQueryService CreateService(params IDnsProvider[] dnsProviders)
+        => new(dnsProviders, NullLogger<DnsZoneQueryService>.Instance);
 
     private static DnsZone CreateZone(string id, string name)
     {


### PR DESCRIPTION
## Problem

`DnsZoneQueryService.ListZonesAsync` returns an empty list when no configured provider matches the requested name:

```csharp
var dnsProvider = dnsProviders.FirstOrDefault(x => x.Name == dnsProviderName);

if (dnsProvider is null)
{
    return [];
}
```

A certificate stores its provider name in the Key Vault tag. If that provider is later renamed or removed from configuration, the empty list flows into `Dns01Precondition` and surfaces as:

> No DNS zone was found for the following domain name(s): example.com.

That points operators at their DNS zones when the actual cause is the provider configuration.

Separately, `GetAllDnsZonesAsync` swallows exceptions in two places with no logger injected, so a provider outage or an expired credential is indistinguishable from a provider that genuinely hosts no zones — the dashboard just shows zero zones.

## Change

- Throw `PreconditionException` naming the requested provider and listing the configured ones. `PreconditionException` is outside the orchestrator retry policy, so this fails fast rather than retrying a configuration error.
- Inject `ILogger` and record both swallowed exception paths (warning per provider, error for the enumeration itself).

## Note

The existing test `ListZonesAsync_WithUnknownProvider_ReturnsEmpty` pinned the old behavior and has been rewritten to assert the new exception and its message contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)