### PR TITLE
Dispose the ACME client and signer when context creation fails

### DIFF
--- a/src/Acmebot.App/Acme/AcmeClientFactory.cs
+++ b/src/Acmebot.App/Acme/AcmeClientFactory.cs
@@ -63,53 +63,70 @@ public sealed class AcmeClientFactory(IOptions<AcmebotOptions> options, IAcmeSta
         }
 
         var signer = accountKey.GenerateSigner();
-        var client = new AcmeClient(
-            _options.Endpoint,
-            new AcmeClientOptions
-            {
-                UserAgent = $"Acmebot/{Constants.ApplicationVersion}"
-            });
-        var directory = await client.GetDirectoryAsync();
-        AcmeAccountHandle accountHandle;
+        AcmeClient? client = null;
 
-        if (account is null)
+        // The client owns an HttpClient, and both it and the signer are only handed to the caller once
+        // the context has been fully built. Anything that fails in between (a directory fetch against an
+        // unreachable ACME endpoint, missing EAB credentials, a state store write) would otherwise leak
+        // them on every retry.
+        try
         {
-            var externalAccountBinding = CreateExternalAccountBinding();
-
-            if (externalAccountBinding is null && (directory.Metadata?.ExternalAccountRequired ?? false))
-            {
-                throw new PreconditionException("This ACME endpoint requires External Account Binding (EAB). Configure EAB credentials and try again.");
-            }
-
-            accountHandle = await client.CreateAccountAsync(
-                signer,
-                new AcmeNewAccountRequest
+            client = new AcmeClient(
+                _options.Endpoint,
+                new AcmeClientOptions
                 {
-                    Contact = contacts,
-                    TermsOfServiceAgreed = true
-                },
-                externalAccountBinding);
-            account = AccountDetails.FromAccountHandle(accountHandle, directory.Metadata?.TermsOfService);
+                    UserAgent = $"Acmebot/{Constants.ApplicationVersion}"
+                });
 
-            if (isNewAccountKey)
+            var directory = await client.GetDirectoryAsync();
+            AcmeAccountHandle accountHandle;
+
+            if (account is null)
             {
-                await stateStore.SaveAsync(accountKey, "account_key.json");
+                var externalAccountBinding = CreateExternalAccountBinding();
+
+                if (externalAccountBinding is null && (directory.Metadata?.ExternalAccountRequired ?? false))
+                {
+                    throw new PreconditionException("This ACME endpoint requires External Account Binding (EAB). Configure EAB credentials and try again.");
+                }
+
+                accountHandle = await client.CreateAccountAsync(
+                    signer,
+                    new AcmeNewAccountRequest
+                    {
+                        Contact = contacts,
+                        TermsOfServiceAgreed = true
+                    },
+                    externalAccountBinding);
+                account = AccountDetails.FromAccountHandle(accountHandle, directory.Metadata?.TermsOfService);
+
+                if (isNewAccountKey)
+                {
+                    await stateStore.SaveAsync(accountKey, "account_key.json");
+                }
+
+                await stateStore.SaveAsync(account, "account.json");
+            }
+            else
+            {
+                accountHandle = account.ToAccountHandle(signer);
             }
 
-            await stateStore.SaveAsync(account, "account.json");
+            return new AcmeClientContext
+            {
+                Client = client,
+                Directory = directory,
+                Signer = signer,
+                Account = accountHandle
+            };
         }
-        else
+        catch
         {
-            accountHandle = account.ToAccountHandle(signer);
-        }
+            client?.Dispose();
+            signer.Dispose();
 
-        return new AcmeClientContext
-        {
-            Client = client,
-            Directory = directory,
-            Signer = signer,
-            Account = accountHandle
-        };
+            throw;
+        }
     }
 
     private AcmeExternalAccountBindingOptions? CreateExternalAccountBinding()

--- a/src/Acmebot.App/Acme/AcmeClientFactory.cs
+++ b/src/Acmebot.App/Acme/AcmeClientFactory.cs
@@ -122,8 +122,9 @@ public sealed class AcmeClientFactory(IOptions<AcmebotOptions> options, IAcmeSta
         }
         catch
         {
-            client?.Dispose();
+            // Same order as AcmeClientContext.Dispose(), which owns these once the context exists.
             signer.Dispose();
+            client?.Dispose();
 
             throw;
         }


### PR DESCRIPTION
## Problem

`AcmeClientFactory.CreateClientCoreAsync` constructs an `AcmeClient` — which owns an `HttpClient` and its handler — and only afterwards fetches the directory and creates or loads the account. The result is assigned to the cached field via `_clientContext ??= await CreateClientCoreAsync()`, so it is only reachable on success.

Any failure in between leaves the client and the signer unreachable and undisposed:

- the directory fetch against an unreachable or misbehaving ACME endpoint
- the `PreconditionException` thrown when the endpoint requires EAB and none is configured
- an account creation failure or a state store write failure

Because `CreateClientAsync` is called from every activity, a persistently failing ACME endpoint accumulates one `HttpClient` and one `SocketsHttpHandler` per attempt for the lifetime of the worker.

## Change

Wrap the construction in `try`/`catch` and dispose both the client and the signer on the failure path. `AcmeClientContext.Dispose()` disposes both, so the failure path is symmetric with the success path. The client is declared nullable so a throw from the `AcmeClient` constructor itself is covered too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)