### PR TITLE
Add validation on start for Acmebot options

### DIFF
--- a/src/Acmebot.App/Program.cs
+++ b/src/Acmebot.App/Program.cs
@@ -47,7 +47,8 @@ builder.Services.Configure<JsonSerializerOptions>(options =>
 // Add Options
 builder.Services.AddOptions<AcmebotOptions>()
        .Bind(builder.Configuration.GetSection("Acmebot"))
-       .ValidateDataAnnotations();
+       .ValidateDataAnnotations()
+       .ValidateOnStart();
 
 builder.Services.AddWebhookOptions(builder.Configuration.GetSection("Acmebot:Webhook"));
 


### PR DESCRIPTION
This pull request makes a minor improvement to the application startup configuration by ensuring that option validation occurs during application startup, not just at runtime.

- Configuration validation:
  * [`src/Acmebot.App/Program.cs`](diffhunk://#diff-898b4223d5da9ec708be296f37a67a4173aa000af76fab8bfc945d53aee13557L50-R51): Added `.ValidateOnStart()` to the `AddOptions<AcmebotOptions>()` configuration, so that invalid configuration is detected as soon as the application starts.