### PR TITLE
Allow a custom DNS alias record in delegated DNS-01 mode

### DIFF
--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -58,7 +58,9 @@ Use the delegated DNS-01 issue mode when the DNS provider selected in Acmebot ma
 
 ### DNS Alias
 
-Set DNS Alias when the ACME challenge should be created under another domain. Acmebot then writes TXT records at `_acme-challenge.<dnsAlias>` with the selected DNS provider. The alias value must not include the `_acme-challenge` prefix. In delegated DNS-01 mode, the dashboard generates a unique alias record in the selected alias zone and shows the CNAME records to create in the certificate domain's DNS provider.
+Set DNS Alias when the ACME challenge should be created under another domain. Acmebot then writes TXT records at `_acme-challenge.<dnsAlias>` with the selected DNS provider. The alias value must not include the `_acme-challenge` prefix. In delegated DNS-01 mode, the dashboard suggests a unique alias record in the selected alias zone and shows the CNAME records to create in the certificate domain's DNS provider.
+
+The **DNS alias record** field accepts a custom record name for that alias. The `_acme-challenge.` prefix and the alias zone suffix are fixed, so only the record name in between is editable. Leave the field empty to keep the generated record name, which changes whenever the certificate's DNS names change. Set an explicit record name when the CNAME records are created manually and must stay stable across renewals and DNS name changes.
 
 ### ACME Profile
 

--- a/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AddCertificateDialog.vue
@@ -4,7 +4,7 @@ import { CirclePlus, KeyRound, ShieldPlus, Tag, X } from 'lucide-vue-next';
 
 import type { CertificatePolicyItem, DnsZoneGroup, KeyCurveName, KeyType, SelectableDnsZone } from '@/api/types';
 import { displayDnsName } from '@/utils/certificates';
-import { createCertificateName, createDelegatedDnsAlias } from '@/utils/dnsNames';
+import { createCertificateName } from '@/utils/dnsNames';
 
 import AdvancedCertificateOptions from './AdvancedCertificateOptions.vue';
 import DelegatedDnsNameEditor from './DelegatedDnsNameEditor.vue';
@@ -57,6 +57,7 @@ const issueModeOptions = {
 type IssueMode = keyof typeof issueModeOptions;
 
 const selectedZone = ref<SelectableDnsZone | null>(null);
+const delegatedAlias = reactive({ dnsAlias: '', message: '' });
 
 const validKeySizes = [2048, 3072, 4096];
 const validKeyCurves: KeyCurveName[] = ['P-256', 'P-384', 'P-521', 'P-256K'];
@@ -86,10 +87,13 @@ const tagValidation = computed(() => (form.useAdvancedOptions ? validateTags(for
 const tagError = computed(() => tagValidation.value.message);
 const zoneLabel = computed(() => activeIssueMode.value.zoneLabel);
 const zoneStepLabel = computed(() => activeIssueMode.value.zoneStepLabel);
-const delegatedDnsAlias = computed(() => (activeIssueMode.value.useGeneratedDnsAlias && selectedZone.value ? createDelegatedDnsAlias(form.dnsNames, selectedZone.value) : ''));
 const submitValidationMessage = computed(() => {
   if (form.dnsNames.length === 0) {
     return 'Add at least one DNS name.';
+  }
+
+  if (activeIssueMode.value.useGeneratedDnsAlias && !delegatedAlias.dnsAlias) {
+    return delegatedAlias.message || 'A DNS alias record is required.';
   }
 
   return certificateNameError.value || keyOptionError.value || tagError.value;
@@ -139,6 +143,7 @@ watch(
   () => {
     form.dnsNames = [];
     form.dnsProviderName = activeIssueMode.value.useSelectedZoneProvider && selectedZone.value ? selectedZone.value.dnsProviderName : '';
+    updateDelegatedAlias('', '');
   },
 );
 
@@ -168,8 +173,14 @@ watch(
   },
 );
 
+function updateDelegatedAlias(dnsAlias: string, message: string): void {
+  delegatedAlias.dnsAlias = dnsAlias;
+  delegatedAlias.message = message;
+}
+
 function resetForm(): void {
   selectedZone.value = null;
+  updateDelegatedAlias('', '');
   form.issueMode = 'managed';
   form.dnsNames = [];
   form.dnsProviderName = '';
@@ -268,7 +279,7 @@ function submit(): void {
     return;
   }
 
-  const dnsAlias = activeIssueMode.value.useGeneratedDnsAlias ? delegatedDnsAlias.value : '';
+  const dnsAlias = activeIssueMode.value.useGeneratedDnsAlias ? delegatedAlias.dnsAlias : '';
 
   const policy: CertificatePolicyItem = {
     dnsNames: form.dnsNames,
@@ -445,6 +456,7 @@ function submit(): void {
               :dns-provider-name="form.dnsProviderName"
               @add-dns-name="addDnsName"
               @remove-dns-name="removeDnsName"
+              @alias-change="updateDelegatedAlias"
             />
 
             <div class="form-section form-section--inline">

--- a/src/Acmebot.App/ClientApp/src/components/DelegatedDnsNameEditor.vue
+++ b/src/Acmebot.App/ClientApp/src/components/DelegatedDnsNameEditor.vue
@@ -4,7 +4,7 @@ import { Plus, Trash2 } from 'lucide-vue-next';
 
 import type { SelectableDnsZone } from '@/api/types';
 import { displayDnsName } from '@/utils/certificates';
-import { createDelegatedCnameInstructions, createDelegatedDnsAlias, readDnsNameInput } from '@/utils/dnsNames';
+import { createDelegatedAliasRecordName, createDelegatedCnameInstructions, createManagedDnsName, readDnsNameInput, validateOptionalDnsAlias } from '@/utils/dnsNames';
 
 const props = defineProps<{
   selectedZone: SelectableDnsZone | null;
@@ -15,20 +15,34 @@ const props = defineProps<{
 const emit = defineEmits<{
   'add-dns-name': [dnsName: string, dnsProviderName: string];
   'remove-dns-name': [dnsName: string];
+  'alias-change': [dnsAlias: string, message: string];
 }>();
 
 const recordName = ref('');
 const dnsNameError = ref('');
+const aliasRecordName = ref('');
 
 const requestedDnsName = computed(() => readDnsNameInput(recordName.value, 'DNS Name').value || null);
-const delegatedDnsAlias = computed(() => (props.selectedZone ? createDelegatedDnsAlias(props.dnsNames, props.selectedZone) : ''));
-const delegatedCnameInstructions = computed(() => createDelegatedCnameInstructions(props.dnsNames, delegatedDnsAlias.value));
+const generatedAliasRecordName = computed(() => createDelegatedAliasRecordName(props.dnsNames));
+const customAliasRecordName = computed(() => aliasRecordName.value.trim().replace(/^\.+|\.+$/g, ''));
+const effectiveAliasRecordName = computed(() => customAliasRecordName.value || generatedAliasRecordName.value);
+const delegatedDnsAlias = computed(() => (props.selectedZone && effectiveAliasRecordName.value ? createManagedDnsName(effectiveAliasRecordName.value, props.selectedZone) : ''));
+const aliasError = computed(() => validateOptionalDnsAlias(delegatedDnsAlias.value).message);
+const delegatedCnameInstructions = computed(() => createDelegatedCnameInstructions(props.dnsNames, aliasError.value ? '' : delegatedDnsAlias.value));
 
 watch(
   () => props.selectedZone,
   () => {
     dnsNameError.value = '';
   },
+);
+
+watch(
+  [delegatedDnsAlias, aliasError],
+  ([dnsAlias, message]) => {
+    emit('alias-change', message ? '' : dnsAlias, message);
+  },
+  { immediate: true },
 );
 
 function clearDnsNameError(): void {
@@ -123,10 +137,38 @@ function addDnsName(): void {
       </span>
     </div>
     <div
-      v-if="delegatedDnsAlias"
+      v-if="selectedZone"
       class="delegated-alias"
     >
-      <div class="form-result">
+      <div>
+        <label
+          class="form-label"
+          for="delegated-alias-record-name"
+        >DNS alias record</label>
+        <div class="compound-input compound-input--affixed">
+          <span class="compound-input__prefix">_acme-challenge.</span>
+          <input
+            id="delegated-alias-record-name"
+            v-model="aliasRecordName"
+            type="text"
+            autocomplete="off"
+            spellcheck="false"
+            :placeholder="generatedAliasRecordName || 'contoso-com'"
+            :aria-invalid="aliasError ? 'true' : 'false'"
+          >
+          <span class="compound-input__suffix">.{{ displayDnsName(selectedZone.name) }}</span>
+        </div>
+        <p
+          v-if="aliasError"
+          class="form-error"
+        >
+          {{ aliasError }}
+        </p>
+      </div>
+      <div
+        v-if="delegatedDnsAlias && !aliasError"
+        class="form-result"
+      >
         <span>DNS alias</span>
         <strong>{{ displayDnsName(delegatedDnsAlias) }}</strong>
       </div>

--- a/src/Acmebot.App/ClientApp/src/styles/app.css
+++ b/src/Acmebot.App/ClientApp/src/styles/app.css
@@ -1213,6 +1213,30 @@ button:disabled {
   white-space: nowrap;
 }
 
+.compound-input__prefix {
+  min-height: 38px;
+  max-width: 260px;
+  padding: 0 10px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-muted);
+  border: 1px solid var(--color-border);
+  border-right: 0;
+  border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+  background: var(--color-surface-subtle);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compound-input--affixed input {
+  border-radius: 0;
+}
+
+.compound-input--affixed .compound-input__suffix {
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
 .compound-input .icon-button {
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
@@ -1732,6 +1756,7 @@ button:disabled {
   }
 
   .compound-input input,
+  .compound-input__prefix,
   .compound-input__suffix,
   .compound-input .icon-button {
     width: 100%;

--- a/src/Acmebot.App/ClientApp/src/utils/dnsNames.ts
+++ b/src/Acmebot.App/ClientApp/src/utils/dnsNames.ts
@@ -117,18 +117,12 @@ function toAsciiOrNull(value: string): string | null {
   }
 }
 
-export function createDelegatedDnsAlias(dnsNames: string[], zone: SelectableDnsZone): string {
+export function createDelegatedAliasRecordName(dnsNames: string[]): string {
   if (dnsNames.length === 0) {
     return '';
   }
 
-  const zoneName = toAsciiDnsName(zone.name);
-
-  if (!zoneName) {
-    return '';
-  }
-
-  return `${createAliasRecordName(dnsNames)}.${zoneName}`;
+  return createAliasRecordName(dnsNames);
 }
 
 export function createDelegatedCnameInstructions(dnsNames: string[], dnsAlias: string): CnameInstruction[] {


### PR DESCRIPTION
The dashboard always derived the alias from the certificate DNS names and a hash of them, so the CNAME target changed whenever the DNS names changed. That is unusable when the CNAME records are created by hand in a zone the operator does not control.

Add an optional DNS alias record field in delegated mode. The _acme-challenge. prefix and the alias zone suffix stay fixed and read-only, and an empty field keeps the generated record name, so existing behavior is unchanged.

## Summary

-

## Related Issue

- Closes #1228 

## What Changed

-

## Validation

- [ ] `dotnet build -c Release ./Acmebot.slnx`
- [ ] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx`
- [ ] `az bicep build -f ./deploy/azuredeploy.bicep`
- [ ] Documentation updated if needed

## Notes

-
