### PR TITLE
Refactor certificate operations to use relative URL paths

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -35,7 +35,7 @@ When app role enforcement is enabled, issue and renew operations require `Acmebo
 
 ## Operation Lifecycle
 
-`POST /api/certificates` and `POST /api/certificates/{certificateName}/renew` return `202 Accepted` with a `Location` header. Poll that URL until it returns:
+`POST /api/certificates` and `POST /api/certificates/{certificateName}/renew` return `202 Accepted` with a `Location` header. The header holds a path relative to the request, so resolve it against the endpoint you called. Poll that URL until it returns:
 
 | Status | Meaning |
 | --- | --- |

--- a/src/Acmebot.App/Functions/Http/AddCertificate.cs
+++ b/src/Acmebot.App/Functions/Http/AddCertificate.cs
@@ -42,7 +42,7 @@ public partial class AddCertificate(IHttpContextAccessor httpContextAccessor, Ap
 
         LogOrchestrationStarted(logger, certificatePolicyItem.CertificateName, instanceId);
 
-        return AcceptedAtFunction($"{nameof(GetOperation)}_{nameof(GetOperation.HttpStart)}", new { instanceId }, null);
+        return Accepted(Url.RouteUrl($"{nameof(GetOperation)}_{nameof(GetOperation.HttpStart)}", new { instanceId }), null);
     }
 
     [LoggerMessage(LogLevel.Information, "Certificate issuance orchestration started. CertificateName: {CertificateName}. InstanceId: {InstanceId}")]

--- a/src/Acmebot.App/Functions/Http/GetOperation.cs
+++ b/src/Acmebot.App/Functions/Http/GetOperation.cs
@@ -33,7 +33,7 @@ public partial class GetOperation(IHttpContextAccessor httpContextAccessor, ILog
         return metadata.RuntimeStatus switch
         {
             OrchestrationRuntimeStatus.Failed => Problem(metadata.FailureDetails?.ErrorMessage, type: metadata.FailureDetails?.ErrorType),
-            OrchestrationRuntimeStatus.Running or OrchestrationRuntimeStatus.Pending => AcceptedAtFunction($"{nameof(GetOperation)}_{nameof(HttpStart)}", new { instanceId }, null),
+            OrchestrationRuntimeStatus.Running or OrchestrationRuntimeStatus.Pending => Accepted(Url.RouteUrl($"{nameof(GetOperation)}_{nameof(HttpStart)}", new { instanceId }), null),
             _ => Ok()
         };
     }

--- a/src/Acmebot.App/Functions/Http/RenewCertificate.cs
+++ b/src/Acmebot.App/Functions/Http/RenewCertificate.cs
@@ -43,7 +43,7 @@ public partial class RenewCertificate(
 
         LogOrchestrationStarted(logger, certificateName, instanceId);
 
-        return AcceptedAtFunction($"{nameof(GetOperation)}_{nameof(GetOperation.HttpStart)}", new { instanceId }, null);
+        return Accepted(Url.RouteUrl($"{nameof(GetOperation)}_{nameof(GetOperation.HttpStart)}", new { instanceId }), null);
     }
 
     [LoggerMessage(LogLevel.Information, "Certificate renewal orchestration started. CertificateName: {CertificateName}. InstanceId: {InstanceId}")]


### PR DESCRIPTION
This pull request updates how HTTP 202 Accepted responses are handled for certificate issuance and renewal operations. The main change is switching from using `AcceptedAtFunction` to `Accepted` with a route URL, and clarifying the documentation about the `Location` header. This ensures that clients receive a fully resolved URL for polling operation status, improving API usability and consistency.

**API Response Handling:**

* Updated `AddCertificate.cs`, `RenewCertificate.cs`, and `GetOperation.cs` to use `Accepted(Url.RouteUrl(...))` instead of `AcceptedAtFunction(...)`, ensuring the `Location` header contains a properly resolved route URL for operation polling. [[1]](diffhunk://#diff-245302b0aa3eb8a885b091657f0ca2faecd13caf26b97dfd9fcb831ce1279eb6L45-R45) [[2]](diffhunk://#diff-73fd550aa1c1486c857bbb4ef616e27cfc3d79217cf3604fa228ecbbb887cb0aL46-R46) [[3]](diffhunk://#diff-fd8bae8dab3fc81777ffb2a7d77198a59930445f3f33b535ef09502e3262b764L36-R36)

**Documentation:**

* Clarified in `docs/reference/api.md` that the `Location` header returned from certificate operations is a relative path and should be resolved against the endpoint called.

Fixes #1227 