### PR TITLE
Send a User-Agent from every DNS provider HTTP client

### DIFF
--- a/src/Acmebot.App/Providers/AkamaiEdgeDnsProvider.cs
+++ b/src/Acmebot.App/Providers/AkamaiEdgeDnsProvider.cs
@@ -65,6 +65,8 @@ public class AkamaiEdgeDnsProvider(AkamaiEdgeDnsOptions options) : IDnsProvider
             _httpClient = EdgeGridSigner.CreateHttpClient(new EdgeGridCredentials(host, clientToken, clientSecret, accessToken));
 
             _httpClient.BaseAddress = new Uri($"https://{host}/config-dns/v2/");
+
+            DnsProviderHttpClient.AddUserAgent(_httpClient);
         }
 
         private readonly HttpClient _httpClient;

--- a/src/Acmebot.App/Providers/CloudflareProvider.cs
+++ b/src/Acmebot.App/Providers/CloudflareProvider.cs
@@ -69,12 +69,8 @@ public class CloudflareProvider(CloudflareOptions options) : IDnsProvider
     {
         public CloudflareClient(string apiToken)
         {
-            _httpClient = new HttpClient
-            {
-                BaseAddress = new Uri("https://api.cloudflare.com/client/v4/")
-            };
+            _httpClient = DnsProviderHttpClient.Create("https://api.cloudflare.com/client/v4/");
 
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiToken);
         }
 

--- a/src/Acmebot.App/Providers/CustomDnsProvider.cs
+++ b/src/Acmebot.App/Providers/CustomDnsProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
@@ -60,12 +59,8 @@ public class CustomDnsProvider(CustomDnsOptions options) : IDnsProvider
     {
         public CustomDnsClient(string endpoint, string apiKey, string apiKeyHeaderName)
         {
-            _httpClient = new HttpClient
-            {
-                BaseAddress = new Uri(endpoint)
-            };
+            _httpClient = DnsProviderHttpClient.Create(endpoint);
 
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation(apiKeyHeaderName, apiKey);
         }
 

--- a/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
+++ b/src/Acmebot.App/Providers/DnsMadeEasyProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
@@ -67,12 +66,7 @@ public class DnsMadeEasyProvider(DnsMadeEasyOptions options) : IDnsProvider
     {
         public DnsMadeEasyClient(string apiKey, string secretKey)
         {
-            _httpClient = new HttpClient(new ApiKeyHandler(apiKey, secretKey))
-            {
-                BaseAddress = new Uri("https://api.dnsmadeeasy.com/V2.0/dns/")
-            };
-
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _httpClient = DnsProviderHttpClient.Create("https://api.dnsmadeeasy.com/V2.0/dns/", new ApiKeyHandler(apiKey, secretKey));
         }
 
         private readonly HttpClient _httpClient;

--- a/src/Acmebot.App/Providers/DnsProviderHttpClient.cs
+++ b/src/Acmebot.App/Providers/DnsProviderHttpClient.cs
@@ -1,0 +1,36 @@
+﻿using System.Net.Http.Headers;
+
+using Acmebot.App.Infrastructure;
+
+namespace Acmebot.App.Providers;
+
+/// <summary>
+/// Creates the <see cref="HttpClient"/> instances that DNS providers use to talk to their REST APIs.
+/// A User-Agent is required in practice: some provider edges (IONOS is one) reject requests without one
+/// with a 5xx before authentication is even attempted, and the resulting failure surfaces only as an
+/// empty zone list. Centralizing the defaults here keeps the header from being forgotten by a provider.
+/// </summary>
+internal static class DnsProviderHttpClient
+{
+    private static readonly ProductInfoHeaderValue s_userAgent = new("Acmebot", Constants.ApplicationVersion);
+
+    public static HttpClient Create(string baseAddress, HttpMessageHandler? handler = null) => Create(new Uri(baseAddress), handler);
+
+    public static HttpClient Create(Uri baseAddress, HttpMessageHandler? handler = null)
+    {
+        var httpClient = handler is null ? new HttpClient() : new HttpClient(handler);
+
+        httpClient.BaseAddress = baseAddress;
+
+        httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        AddUserAgent(httpClient);
+
+        return httpClient;
+    }
+
+    /// <summary>
+    /// Applies the User-Agent to a client that was created elsewhere, such as by a provider SDK.
+    /// </summary>
+    public static void AddUserAgent(HttpClient httpClient) => httpClient.DefaultRequestHeaders.UserAgent.Add(s_userAgent);
+}

--- a/src/Acmebot.App/Providers/GandiLiveDnsProvider.cs
+++ b/src/Acmebot.App/Providers/GandiLiveDnsProvider.cs
@@ -56,12 +56,8 @@ public class GandiLiveDnsProvider(GandiLiveDnsOptions options) : IDnsProvider
     {
         public GandiLiveDnsClient(string apiKey)
         {
-            _httpClient = new HttpClient
-            {
-                BaseAddress = new Uri("https://api.gandi.net/v5/")
-            };
+            _httpClient = DnsProviderHttpClient.Create("https://api.gandi.net/v5/");
 
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
         }
 

--- a/src/Acmebot.App/Providers/GoDaddyProvider.cs
+++ b/src/Acmebot.App/Providers/GoDaddyProvider.cs
@@ -51,12 +51,8 @@ public class GoDaddyProvider(GoDaddyOptions options) : IDnsProvider
     {
         public GoDaddyClient(string apiKey, string apiSecret)
         {
-            _httpClient = new HttpClient
-            {
-                BaseAddress = new Uri("https://api.godaddy.com/v1/")
-            };
+            _httpClient = DnsProviderHttpClient.Create("https://api.godaddy.com/v1/");
 
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("sso-key", $"{apiKey}:{apiSecret}");
         }
 

--- a/src/Acmebot.App/Providers/IonosDnsProvider.cs
+++ b/src/Acmebot.App/Providers/IonosDnsProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
@@ -69,12 +68,8 @@ public class IonosDnsProvider(IonosDnsOptions options) : IDnsProvider
     {
         public IonosDnsClient(string apiKey)
         {
-            _httpClient = new HttpClient
-            {
-                BaseAddress = new Uri("https://api.hosting.ionos.com/dns/v1/")
-            };
+            _httpClient = DnsProviderHttpClient.Create("https://api.hosting.ionos.com/dns/v1/");
 
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("X-API-Key", apiKey);
         }
 

--- a/src/Acmebot.App/Providers/OvhProvider.cs
+++ b/src/Acmebot.App/Providers/OvhProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
@@ -69,12 +68,7 @@ public class OvhProvider(OvhOptions options) : IDnsProvider
         public OvhClient(string endpoint, string applicationKey, string applicationSecret, string consumerKey)
         {
             // DNS providers in this project own their API clients; this one is constructed once by the singleton provider.
-            _httpClient = new HttpClient(new ApiKeyHandler(applicationKey, applicationSecret, consumerKey))
-            {
-                BaseAddress = new Uri(NormalizeEndpoint(endpoint))
-            };
-
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _httpClient = DnsProviderHttpClient.Create(NormalizeEndpoint(endpoint), new ApiKeyHandler(applicationKey, applicationSecret, consumerKey));
         }
 
         private readonly HttpClient _httpClient;

--- a/src/Acmebot.App/Providers/PowerDnsProvider.cs
+++ b/src/Acmebot.App/Providers/PowerDnsProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 
@@ -70,12 +69,8 @@ public class PowerDnsProvider(PowerDnsOptions options) : IDnsProvider
 
             var baseAddress = endpoint.AbsoluteUri.EndsWith('/') ? endpoint : new Uri(endpoint.AbsoluteUri + "/");
 
-            _httpClient = new HttpClient
-            {
-                BaseAddress = baseAddress
-            };
+            _httpClient = DnsProviderHttpClient.Create(baseAddress);
 
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("X-API-Key", apiKey);
 
             _serverId = Uri.EscapeDataString(serverId);

--- a/src/Acmebot.App/Providers/RegfishProvider.cs
+++ b/src/Acmebot.App/Providers/RegfishProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 
@@ -90,12 +89,8 @@ public class RegfishProvider(RegfishOptions options) : IDnsProvider
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
 
-            _httpClient = new HttpClient
-            {
-                BaseAddress = new Uri("https://api.regfish.com/")
-            };
+            _httpClient = DnsProviderHttpClient.Create("https://api.regfish.com/");
 
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("x-api-key", apiKey);
         }
 

--- a/src/Acmebot.App/Providers/TransIpProvider.cs
+++ b/src/Acmebot.App/Providers/TransIpProvider.cs
@@ -76,12 +76,7 @@ public class TransIpProvider : IDnsProvider
     {
         public TransIpClient(string customerName, CryptographyClient cryptoClient)
         {
-            _httpClient = new HttpClient(new TransIpSignHandler(customerName, cryptoClient))
-            {
-                BaseAddress = new Uri("https://api.transip.nl/v6/")
-            };
-
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _httpClient = DnsProviderHttpClient.Create("https://api.transip.nl/v6/", new TransIpSignHandler(customerName, cryptoClient));
         }
 
         private readonly HttpClient _httpClient;
@@ -127,7 +122,7 @@ public class TransIpProvider : IDnsProvider
 
     private class TransIpSignHandler(string customerName, CryptographyClient cryptoClient) : DelegatingHandler(new HttpClientHandler())
     {
-        private readonly HttpClient _httpClient = new() { BaseAddress = new Uri("https://api.transip.nl/v6/") };
+        private readonly HttpClient _httpClient = DnsProviderHttpClient.Create("https://api.transip.nl/v6/");
 
         private TransIpToken? _token;
 

--- a/src/Acmebot.App/Providers/UnitedDomainsProvider.cs
+++ b/src/Acmebot.App/Providers/UnitedDomainsProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 
@@ -60,14 +59,9 @@ public class UnitedDomainsProvider(UnitedDomainsOptions options) : IDnsProvider
     {
         public UnitedDomainsClient(string apiKey)
         {
-            _httpClient = new HttpClient
-            {
-                BaseAddress = new Uri("https://dnsapi.united-domains.de/dns/")
-            };
+            _httpClient = DnsProviderHttpClient.Create("https://dnsapi.united-domains.de/dns/");
 
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _httpClient.DefaultRequestHeaders.Add("X-API-Key", apiKey);
-            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("acmebot");
         }
 
         private readonly HttpClient _httpClient;

--- a/tests/Acmebot.App.Tests/DnsProviderHttpClientTests.cs
+++ b/tests/Acmebot.App.Tests/DnsProviderHttpClientTests.cs
@@ -1,0 +1,46 @@
+﻿using Acmebot.App.Providers;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class DnsProviderHttpClientTests
+{
+    [Fact]
+    public void Create_SetsBaseAddressAndJsonAccept()
+    {
+        using var httpClient = DnsProviderHttpClient.Create("https://api.example.com/v1/");
+
+        Assert.Equal(new Uri("https://api.example.com/v1/"), httpClient.BaseAddress);
+        Assert.Contains(httpClient.DefaultRequestHeaders.Accept, x => x.MediaType == "application/json");
+    }
+
+    [Fact]
+    public void Create_SendsAcmebotUserAgent()
+    {
+        using var httpClient = DnsProviderHttpClient.Create("https://api.example.com/v1/");
+
+        var userAgent = Assert.Single(httpClient.DefaultRequestHeaders.UserAgent);
+
+        Assert.Equal("Acmebot", userAgent.Product?.Name);
+        Assert.False(string.IsNullOrEmpty(userAgent.Product?.Version));
+    }
+
+    [Fact]
+    public void Create_WithHandler_SendsAcmebotUserAgent()
+    {
+        using var httpClient = DnsProviderHttpClient.Create("https://api.example.com/v1/", new HttpClientHandler());
+
+        Assert.Contains(httpClient.DefaultRequestHeaders.UserAgent, x => x.Product?.Name == "Acmebot");
+    }
+
+    [Fact]
+    public void AddUserAgent_AppliesToClientCreatedElsewhere()
+    {
+        using var httpClient = new HttpClient();
+
+        DnsProviderHttpClient.AddUserAgent(httpClient);
+
+        Assert.Contains(httpClient.DefaultRequestHeaders.UserAgent, x => x.Product?.Name == "Acmebot");
+    }
+}


### PR DESCRIPTION
## Summary

- DNS providers that build an `HttpClient` directly sent no `User-Agent`, which the IONOS API edge rejects with a `503` before authentication. Add a shared factory so every provider identifies itself as `Acmebot/{version}`.

## Related Issue

- Closes #1230

## What Changed

- Added `DnsProviderHttpClient`, a shared factory that sets the base address, the `application/json` Accept header, and a `User-Agent` of `Acmebot/{Constants.ApplicationVersion}` — the same form `AcmeClientFactory` already sends to ACME endpoints.
- Switched the eleven providers that constructed `HttpClient` inline over to the factory: Cloudflare, Custom DNS, DNS Made Easy, Gandi LiveDNS, GoDaddy, IONOS, OVH, PowerDNS, Regfish, TransIP, UnitedDomains. Each dropped its own `BaseAddress` + `Accept` setup; auth headers are unchanged.
- Akamai Edge DNS receives its client from `EdgeGridSigner.CreateHttpClient()`, so the header is applied to that instance with `DnsProviderHttpClient.AddUserAgent()`. The library sets no `User-Agent` of its own, so nothing is appended to an existing value.
- The TransIP token-acquisition client inside `TransIpSignHandler` is covered as well.
- `UnitedDomainsProvider` previously sent the bare string `acmebot` with no version; it now uses the shared versioned value.
- Removed the `using System.Net.Http.Headers;` directive that became unused in seven files.
- Added `DnsProviderHttpClientTests` covering the base address, the Accept header, and the `User-Agent` on all three creation paths.

Azure DNS, Azure Private DNS, Route 53 and Google Cloud DNS are untouched — their SDKs send their own `User-Agent`.

## Validation

- [x] `dotnet build -c Release ./Acmebot.slnx` — 0 warnings, 0 errors
- [x] `dotnet format --verify-no-changes --verbosity detailed --no-restore ./Acmebot.slnx`
- [x] `dotnet test` — 126 passed, 0 failed
- [ ] `az bicep build -f ./deploy/azuredeploy.bicep` — not run; no Bicep or deployment files changed
- [x] Documentation updated if needed — no user-facing configuration change, so no docs update

## Notes

Reproduced and confirmed against the live IONOS endpoint with a deliberately invalid key, matching the report in #1230:

```
no UA         : ServiceUnavailable   (503, rejected at the edge)
Acmebot/5.1.2 : Unauthorized         (401, reached authentication)
```

Two adjacent observations left out of scope:

- `WebhookInvoker` uses `IHttpClientFactory` and still sends no `User-Agent`. It is not a DNS provider, but the same class of rejection could affect notification endpoints.
- #1230 also notes that the failure is invisible because the zone query swallows the exception. `DnsZoneQueryService` does log it via `LogDnsZoneListingFailed`, so it is not entirely silent, but it still returns an empty list to the caller. Worth deciding on separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
