### PR TITLE
Fix IONOS DNS record creation request format

### DIFF
--- a/deploy/uiFormDefinition.json
+++ b/deploy/uiFormDefinition.json
@@ -989,7 +989,7 @@
                     "password": "API key",
                     "confirmPassword": "Confirm API key"
                   },
-                  "toolTip": "IONOS DNS API key.",
+                  "toolTip": "IONOS DNS API key in public-prefix.secret format.",
                   "constraints": {
                     "required": true
                   },

--- a/docs/guide/dns-providers.md
+++ b/docs/guide/dns-providers.md
@@ -268,14 +268,14 @@ https://www.googleapis.com/auth/ndev.clouddns.readwrite
 
 ## IONOS DNS
 
-Use an IONOS DNS API key that can list zones and manage DNS records.
+Create an API key as described in the [IONOS API getting started guide](https://developer.hosting.ionos.com/docs/getstarted). The value consists of the public prefix and secret joined by a period. Acmebot uses the [IONOS DNS API](https://developer.hosting.ionos.com/docs/dns) to list zones and manage DNS records.
 
 | Option | Description |
 | --- | --- |
-| `ApiKey` | IONOS DNS API key sent in the `X-API-Key` header. |
+| `ApiKey` | IONOS DNS API key in `<public-prefix>.<secret>` format, sent in the `X-API-Key` header. |
 
 ```text
-Acmebot__IonosDns__ApiKey=<api-key>
+Acmebot__IonosDns__ApiKey=<public-prefix>.<secret>
 ```
 
 ## OVH

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -138,7 +138,7 @@ Acmebot uses the Google Cloud DNS read/write OAuth scope and ignores private man
 
 | Setting | Description |
 | --- | --- |
-| `Acmebot__IonosDns__ApiKey` | IONOS DNS API key sent in the `X-API-Key` header. |
+| `Acmebot__IonosDns__ApiKey` | IONOS DNS API key in `<public-prefix>.<secret>` format, sent in the `X-API-Key` header. See the [IONOS API getting started guide](https://developer.hosting.ionos.com/docs/getstarted). |
 
 ### OVH
 

--- a/src/Acmebot.App/Providers/IonosDnsProvider.cs
+++ b/src/Acmebot.App/Providers/IonosDnsProvider.cs
@@ -32,17 +32,17 @@ public class IonosDnsProvider(IonosDnsOptions options) : IDnsProvider
     {
         var recordName = DnsRecordName.ToFqdn(zone.Name, relativeRecordName);
 
-        foreach (var value in values)
+        var records = values.Select(value => new RecordParam
         {
-            var record = new RecordParam
-            {
-                Name = recordName,
-                Type = "TXT",
-                Content = value,
-                Ttl = 60
-            };
+            Name = recordName,
+            Type = "TXT",
+            Content = value,
+            Ttl = 60
+        }).ToArray();
 
-            await _ionosDnsClient.CreateRecordAsync(zone.Id, record, cancellationToken);
+        if (records.Length != 0)
+        {
+            await _ionosDnsClient.CreateRecordsAsync(zone.Id, records, cancellationToken);
         }
     }
 
@@ -97,21 +97,28 @@ public class IonosDnsProvider(IonosDnsOptions options) : IDnsProvider
 
         public async Task<IReadOnlyList<Record>> ListRecordsAsync(string zoneId, string recordName, CancellationToken cancellationToken = default)
         {
-            var result = await _httpClient.GetFromJsonAsync<Zone>($"zones/{zoneId}?recordName={recordName}&recordType=TXT", cancellationToken);
+            var result = await _httpClient.GetFromJsonAsync<Zone>(
+                $"zones/{zoneId}?recordName={recordName}&recordType=TXT",
+                cancellationToken);
 
             return result?.Records ?? [];
         }
 
-        public async Task CreateRecordAsync(string zoneId, RecordParam record, CancellationToken cancellationToken = default)
+        public async Task CreateRecordsAsync(string zoneId, RecordParam[] records, CancellationToken cancellationToken = default)
         {
-            var response = await _httpClient.PostAsJsonAsync($"zones/{zoneId}/records", record, cancellationToken);
+            using var response = await _httpClient.PostAsJsonAsync(
+                $"zones/{zoneId}/records",
+                records,
+                cancellationToken);
 
             response.EnsureSuccessStatusCode();
         }
 
         public async Task DeleteRecordAsync(string zoneId, string recordId, CancellationToken cancellationToken = default)
         {
-            var response = await _httpClient.DeleteAsync($"zones/{zoneId}/records/{recordId}", cancellationToken);
+            using var response = await _httpClient.DeleteAsync(
+                $"zones/{zoneId}/records/{recordId}",
+                cancellationToken);
 
             response.EnsureSuccessStatusCode();
         }


### PR DESCRIPTION
## Summary

- send IONOS DNS record creation payloads as the array required by the API
- create multiple ACME TXT values in a single request and skip empty value sets
- document the IONOS API key format and link to the official API guidance

## Root cause

`POST /zones/{zoneId}/records` received a single record object even though the IONOS DNS API expects an array, causing certificate issuance to fail with HTTP 400.

## Impact

This restores DNS-01 certificate issuance for IONOS users and avoids partial updates when a challenge requires multiple TXT values.

## Validation

- `dotnet test Acmebot.slnx --no-restore` (218 tests passed)
- `dotnet format Acmebot.slnx --verify-no-changes --no-restore`

Closes #1242
