### PR TITLE
Configure issue types for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,7 @@ description: Create a report to help us improve
 title: "[Bug]: "
 labels:
   - bug
+type: Bug
 assignees:
   - shibayan
 body:

--- a/.github/ISSUE_TEMPLATE/dns_provider_request.yml
+++ b/.github/ISSUE_TEMPLATE/dns_provider_request.yml
@@ -3,6 +3,7 @@ description: Request support for a new DNS provider
 title: "[DNS Provider]: "
 labels:
   - enhancement
+type: Feature
 assignees:
   - shibayan
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,6 +3,7 @@ description: Suggest an idea for this project
 title: "[Feature]: "
 labels:
   - enhancement
+type: Feature
 assignees:
   - shibayan
 body:


### PR DESCRIPTION
## Summary

- assign the `Bug` issue type to the bug report form
- assign the `Feature` issue type to the DNS provider and feature request forms
- preserve the existing labels and assignees

## Why

Issues created from the repository forms should be classified automatically using the organization's issue types.

## Impact

New issues created from these forms will receive the appropriate issue type without maintainer intervention.

## Validation

- `git diff --cached --check`
- verified the organization defines the `Bug` and `Feature` issue types with `gh api graphql`
