### PR TITLE
Improve issue and pull request labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,7 +2,7 @@ name: Bug report
 description: Create a report to help us improve
 title: "[Bug]: "
 labels:
-  - bug
+  - "status: needs-triage"
 type: Bug
 assignees:
   - shibayan

--- a/.github/ISSUE_TEMPLATE/dns_provider_request.yml
+++ b/.github/ISSUE_TEMPLATE/dns_provider_request.yml
@@ -2,7 +2,8 @@ name: DNS Provider request
 description: Request support for a new DNS provider
 title: "[DNS Provider]: "
 labels:
-  - enhancement
+  - "area: dns-provider"
+  - "status: needs-triage"
 type: Feature
 assignees:
   - shibayan

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@ name: Feature request
 description: Suggest an idea for this project
 title: "[Feature]: "
 labels:
-  - enhancement
+  - "status: needs-triage"
 type: Feature
 assignees:
   - shibayan

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,63 @@
+documentation:
+  - changed-files:
+      - any-glob-to-all-files:
+          - "{docs/**,README.md,**/README.md,CONTRIBUTING.md,CODE_OF_CONDUCT.md,SECURITY.md,SUPPORT.md}"
+
+"area: docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - README.md
+          - "**/README.md"
+          - CONTRIBUTING.md
+          - CODE_OF_CONDUCT.md
+          - SECURITY.md
+          - SUPPORT.md
+
+"area: acme":
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/Acmebot.Acme/**
+          - tests/Acmebot.Acme.Tests/**
+
+"area: backend":
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/Acmebot.App/*
+          - src/Acmebot.App/Acme/**
+          - src/Acmebot.App/Extensions/**
+          - src/Acmebot.App/Functions/**
+          - src/Acmebot.App/Infrastructure/**
+          - src/Acmebot.App/Models/**
+          - src/Acmebot.App/Notifications/**
+          - src/Acmebot.App/Options/**
+          - src/Acmebot.App/Properties/**
+          - src/Acmebot.App/Providers/**
+          - src/Acmebot.App/Services/**
+          - src/Acmebot.App/wwwroot/**
+          - tests/Acmebot.App.Tests/**
+
+"area: dashboard":
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/Acmebot.App/ClientApp/**
+
+"area: cli":
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/Acmebot.Cli/**
+          - tests/Acmebot.Cli.Tests/**
+
+"area: deployment":
+  - changed-files:
+      - any-glob-to-any-file:
+          - deploy/**
+
+"area: dns-provider":
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/Acmebot.App/Providers/**
+          - src/Acmebot.App/Options/*Dns*
+          - src/Acmebot.App/Extensions/Dns*
+          - src/Acmebot.App/Services/Dns*
+          - tests/Acmebot.App.Tests/*Dns*

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,6 +9,9 @@ changelog:
       - question
       - wontfix
   categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
     - title: New Features
       labels:
         - enhancement
@@ -21,6 +24,9 @@ changelog:
     - title: Dependency Updates
       labels:
         - dependencies
+    - title: Maintenance
+      labels:
+        - maintenance
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,21 @@
+name: Pull request labeler
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions: {}
+
+jobs:
+  label:
+    name: Add pull request labels
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Add labels from changed files
+        uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
+        with:
+          sync-labels: false

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: Pull request labeler
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, synchronize, ready_for_review]
 
 permissions: {}
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   label:
     name: Add pull request labels
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,26 @@ These commands cover the contributor-facing validation checks.
 - Avoid unrelated refactoring in the same pull request.
 - Do not commit secrets, certificates, or populated `local.settings.json` values.
 
+## Issue and Pull Request Classification
+
+Issues use GitHub Issue Types as their primary classification:
+
+- `Bug` for unexpected behavior
+- `Feature` for requests, ideas, or new functionality
+- `Task` for a specific piece of implementation or documentation work
+
+Maintainers assign the organization-level `Priority` issue field during triage. An unset priority means the issue has not been prioritized yet. Labels beginning with `area:` identify affected components, and labels beginning with `status:` describe the current triage state.
+
+Pull requests use exactly one release category label:
+
+- `bug`
+- `enhancement`
+- `documentation`
+- `dependencies`
+- `maintenance`
+
+These release category labels are reserved for pull requests. The official GitHub pull request labeler adds `documentation` and `area:` labels from changed paths. It only adds labels and does not remove manually assigned labels. Maintainers assign `bug`, `enhancement`, `maintenance`, and `breaking-change` when applicable, while Dependabot applies dependency labels through its repository configuration. Pull request priority is inherited from its linked issue rather than represented by a label.
+
 ## Release Publishing
 
 The `Publish` workflow runs for version tags such as `v5.0.0`. Before pushing the tag, create a matching draft GitHub Release. The workflow uploads the Function App package, publishes the CLI package to NuGet, and then publishes the draft release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Pull requests use exactly one release category label:
 - `dependencies`
 - `maintenance`
 
-These release category labels are reserved for pull requests. The official GitHub pull request labeler adds `documentation` and `area:` labels from changed paths. It only adds labels and does not remove manually assigned labels. Maintainers assign `bug`, `enhancement`, `maintenance`, and `breaking-change` when applicable, while Dependabot applies dependency labels through its repository configuration. Pull request priority is inherited from its linked issue rather than represented by a label.
+These release category labels are reserved for pull requests. For pull requests whose branch is in this repository, the official GitHub pull request labeler adds `documentation` and `area:` labels from changed paths. It only adds labels and does not remove manually assigned labels. Maintainers label pull requests from forks and assign `bug`, `enhancement`, `maintenance`, and `breaking-change` when applicable, while Dependabot applies dependency labels through its repository configuration. Pull request priority is inherited from its linked issue rather than represented by a label.
 
 ## Release Publishing
 


### PR DESCRIPTION
## Summary

- use Issue Types and the organization Priority field as the primary Issue classification
- reserve release category labels for pull requests
- add path-based `documentation` and `area:*` labeling with the official GitHub labeler action
- add breaking-change and maintenance release-note categories
- document the Issue and pull request classification policy

## Why

Issue Types and Issue fields provide structured Issue metadata, while pull requests still need labels for release-note categorization. Separating those responsibilities avoids duplicate classification and keeps labels useful for automation.

## Impact

New Issue forms apply `status: needs-triage` instead of pull-request release labels. DNS provider requests also receive `area: dns-provider`. Pull requests from branches in this repository receive additive path-based labels; manually assigned labels are not removed. Pull requests from forks are labeled manually so the workflow can use the safer `pull_request` event without granting write access to untrusted contributions.

## Validation

- `git diff --check`
- verified the pinned `actions/labeler` commit corresponds to v6.2.0
- reviewed the labeler configuration against the repository paths
- restricted the write-enabled labeler job to same-repository pull requests