### PR TITLE
Add read-only ACME account endpoint

### DIFF
--- a/src/Acmebot.App/Functions/Http/GetAccount.cs
+++ b/src/Acmebot.App/Functions/Http/GetAccount.cs
@@ -1,0 +1,47 @@
+using Acmebot.App.Acme;
+using Acmebot.App.Models;
+using Acmebot.App.Options;
+
+using Azure.Functions.Worker.Extensions.HttpApi;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Options;
+
+namespace Acmebot.App.Functions.Http;
+
+public class GetAccount(
+    IHttpContextAccessor httpContextAccessor,
+    AcmeClientFactory acmeClientFactory,
+    IOptions<AcmebotOptions> options) : HttpFunctionBase(httpContextAccessor)
+{
+    private readonly Uri _directoryUrl = options.Value.Endpoint;
+
+    [Function($"{nameof(GetAccount)}_{nameof(HttpStart)}")]
+    public async Task<IActionResult> HttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "api/account")] HttpRequest req)
+    {
+        if (User.Identity?.IsAuthenticated != true)
+        {
+            return Unauthorized();
+        }
+
+        var acmeContext = await acmeClientFactory.CreateClientAsync();
+
+        return Ok(CreateAccountItem(acmeContext, _directoryUrl));
+    }
+
+    internal static AccountItem CreateAccountItem(AcmeClientContext acmeContext, Uri directoryUrl)
+    {
+        ArgumentNullException.ThrowIfNull(acmeContext);
+        ArgumentNullException.ThrowIfNull(directoryUrl);
+
+        return new AccountItem
+        {
+            AccountUri = acmeContext.Account.AccountUrl,
+            DirectoryUrl = directoryUrl,
+            CaaIdentities = acmeContext.Directory.Metadata?.CaaIdentities ?? []
+        };
+    }
+}

--- a/src/Acmebot.App/Functions/Http/GetAccount.cs
+++ b/src/Acmebot.App/Functions/Http/GetAccount.cs
@@ -1,4 +1,4 @@
-using Acmebot.App.Acme;
+﻿using Acmebot.App.Acme;
 using Acmebot.App.Models;
 using Acmebot.App.Options;
 

--- a/src/Acmebot.App/Models/AccountItem.cs
+++ b/src/Acmebot.App/Models/AccountItem.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Acmebot.App.Models;
 

--- a/src/Acmebot.App/Models/AccountItem.cs
+++ b/src/Acmebot.App/Models/AccountItem.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Acmebot.App.Models;
+
+public class AccountItem
+{
+    [JsonPropertyName("accountUri")]
+    public required Uri AccountUri { get; set; }
+
+    [JsonPropertyName("directoryUrl")]
+    public required Uri DirectoryUrl { get; set; }
+
+    [JsonPropertyName("caaIdentities")]
+    public required IReadOnlyList<string> CaaIdentities { get; set; }
+}

--- a/tests/Acmebot.App.Tests/GetAccountTests.cs
+++ b/tests/Acmebot.App.Tests/GetAccountTests.cs
@@ -1,4 +1,4 @@
-using Acmebot.Acme;
+﻿using Acmebot.Acme;
 using Acmebot.Acme.Models;
 using Acmebot.App.Acme;
 using Acmebot.App.Functions.Http;

--- a/tests/Acmebot.App.Tests/GetAccountTests.cs
+++ b/tests/Acmebot.App.Tests/GetAccountTests.cs
@@ -1,0 +1,89 @@
+using Acmebot.Acme;
+using Acmebot.Acme.Models;
+using Acmebot.App.Acme;
+using Acmebot.App.Functions.Http;
+using Acmebot.App.Options;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class GetAccountTests
+{
+    private static readonly Uri s_directoryUrl = new("https://acme.example/directory");
+    private static readonly Uri s_accountUrl = new("https://acme.example/acct/123");
+
+    [Fact]
+    public void CreateAccountItem_ProjectsAccountAndDirectoryMetadata()
+    {
+        using var context = CreateAcmeClientContext(["authority.example", "ca.example.net"]);
+
+        var result = GetAccount.CreateAccountItem(context, s_directoryUrl);
+
+        Assert.Equal(s_accountUrl, result.AccountUri);
+        Assert.Equal(s_directoryUrl, result.DirectoryUrl);
+        Assert.Equal(["authority.example", "ca.example.net"], result.CaaIdentities);
+    }
+
+    [Fact]
+    public void CreateAccountItem_WithoutCaaIdentities_ReturnsEmptyCollection()
+    {
+        using var context = CreateAcmeClientContext([]);
+
+        var result = GetAccount.CreateAccountItem(context, s_directoryUrl);
+
+        Assert.Empty(result.CaaIdentities);
+    }
+
+    [Fact]
+    public async Task HttpStart_WhenUnauthenticated_ReturnsUnauthorized()
+    {
+        var httpContext = new DefaultHttpContext();
+        var function = new GetAccount(
+            new HttpContextAccessor { HttpContext = httpContext },
+            acmeClientFactory: null!,
+            Microsoft.Extensions.Options.Options.Create(new AcmebotOptions
+            {
+                Contacts = "admin@example.com",
+                Endpoint = s_directoryUrl,
+                VaultBaseUrl = "https://vault.example/"
+            }));
+
+        var result = await function.HttpStart(httpContext.Request);
+
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    private static AcmeClientContext CreateAcmeClientContext(IReadOnlyList<string> caaIdentities)
+    {
+        var signer = AcmeSigner.CreateP256();
+
+        return new AcmeClientContext
+        {
+            Client = new AcmeClient(s_directoryUrl),
+            Directory = new AcmeDirectoryResource
+            {
+                NewNonce = new Uri("https://acme.example/new-nonce"),
+                NewAccount = new Uri("https://acme.example/new-account"),
+                NewOrder = new Uri("https://acme.example/new-order"),
+                Metadata = new AcmeDirectoryMetadata
+                {
+                    CaaIdentities = caaIdentities
+                }
+            },
+            Signer = signer,
+            Account = new AcmeAccountHandle
+            {
+                AccountUrl = s_accountUrl,
+                Signer = signer,
+                Account = new AcmeAccountResource
+                {
+                    Status = AcmeAccountStatuses.Valid
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- add an authenticated GET /api/account endpoint
- expose the ACME account URI, directory URL, and CAA identities
- cover account projection, missing CAA identities, and unauthenticated access

## Testing

- dotnet run --project tests/Acmebot.App.Tests/Acmebot.App.Tests.csproj --no-build --no-restore -- -noLogo (129 passed)

Closes #1235