### PR TITLE
Surface ACME account information in dashboard

### DIFF
--- a/src/Acmebot.App/ClientApp/src/App.vue
+++ b/src/Acmebot.App/ClientApp/src/App.vue
@@ -319,6 +319,7 @@ async function confirmRevokeCertificate(): Promise<void> {
             class="header-status header-status--button"
             type="button"
             aria-haspopup="dialog"
+            :aria-expanded="accountDrawerOpen"
             @click="openAccountDrawer"
           >
             <UserRound

--- a/src/Acmebot.App/ClientApp/src/App.vue
+++ b/src/Acmebot.App/ClientApp/src/App.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue';
-import { Activity, AlertTriangle, BadgeCheck, CircleSlash, ExternalLink, Info, PowerOff, Shield, ShieldAlert, ShieldCheck, X } from 'lucide-vue-next';
+import { Activity, AlertTriangle, BadgeCheck, CircleSlash, ExternalLink, Info, PowerOff, Shield, ShieldAlert, ShieldCheck, UserRound, X } from 'lucide-vue-next';
 
-import { formatApiError, getCertificateRenewals, getCertificates, getDnsZones, issueCertificate, renewCertificate, revokeCertificate } from '@/api/acmebotApi';
+import { formatApiError, getAccount, getCertificateRenewals, getCertificates, getDnsZones, issueCertificate, renewCertificate, revokeCertificate } from '@/api/acmebotApi';
 import { getLatestRelease } from '@/api/releases';
-import type { CertificateItem, CertificatePolicyItem, CertificateRenewalItem, DnsZoneGroup, ReleaseInfo } from '@/api/types';
+import type { AccountInfo, CertificateItem, CertificatePolicyItem, CertificateRenewalItem, DnsZoneGroup, ReleaseInfo } from '@/api/types';
+import AccountDrawer from '@/components/AccountDrawer.vue';
 import AddCertificateDialog from '@/components/AddCertificateDialog.vue';
 import CertificateTable from '@/components/CertificateTable.vue';
 import ConfirmRevokeDialog from '@/components/ConfirmRevokeDialog.vue';
@@ -17,8 +18,10 @@ import { isNewerVersion, isVersionLike } from '@/utils/versions';
 const certificates = ref<CertificateItem[]>([]);
 const dnsZoneGroups = ref<DnsZoneGroup[]>([]);
 const renewals = ref<CertificateRenewalItem[]>([]);
+const accountInfo = ref<AccountInfo | null>(null);
 const selectedCertificate = ref<CertificateItem | null>(null);
 const pendingRevokeCertificate = ref<CertificateItem | null>(null);
+const accountDrawerOpen = ref(false);
 const addDialogOpen = ref(false);
 const detailsBusy = ref(false);
 const toasts = ref<ToastMessage[]>([]);
@@ -30,6 +33,11 @@ const acmebotRepositoryUrl = 'https://github.com/polymind-inc/acmebot';
 const dismissedUpgradeStorageKey = 'acmebot.dismissedUpgradeVersion';
 
 const certificateState = reactive({
+  loading: false,
+  error: '',
+});
+
+const accountState = reactive({
   loading: false,
   error: '',
 });
@@ -147,6 +155,32 @@ function pushToast(type: ToastMessage['type'], title: string, message: string): 
 
 function dismissToast(id: number): void {
   toasts.value = toasts.value.filter((message) => message.id !== id);
+}
+
+async function openAccountDrawer(): Promise<void> {
+  accountDrawerOpen.value = true;
+
+  if (!accountInfo.value) {
+    await loadAccount();
+  }
+}
+
+async function loadAccount(): Promise<void> {
+  if (accountState.loading) {
+    return;
+  }
+
+  accountState.loading = true;
+  accountState.error = '';
+
+  try {
+    accountInfo.value = await getAccount();
+  } catch (error) {
+    accountState.error = formatApiError(error);
+    pushToast('error', 'Failed to load account information', accountState.error);
+  } finally {
+    accountState.loading = false;
+  }
 }
 
 async function loadCertificates(): Promise<void> {
@@ -280,12 +314,26 @@ async function confirmRevokeCertificate(): Promise<void> {
             </div>
           </div>
         </div>
-        <div class="header-status">
-          <Activity
-            :size="16"
-            aria-hidden="true"
-          />
-          <span>{{ summary.total }} certificates</span>
+        <div class="header-actions">
+          <button
+            class="header-status header-status--button"
+            type="button"
+            aria-haspopup="dialog"
+            @click="openAccountDrawer"
+          >
+            <UserRound
+              :size="16"
+              aria-hidden="true"
+            />
+            <span>Account</span>
+          </button>
+          <div class="header-status">
+            <Activity
+              :size="16"
+              aria-hidden="true"
+            />
+            <span>{{ summary.total }} certificates</span>
+          </div>
         </div>
       </div>
     </header>
@@ -460,6 +508,16 @@ async function confirmRevokeCertificate(): Promise<void> {
       @close="addDialogOpen = false"
       @load-zones="loadDnsZones"
       @submit="handleIssueCertificate"
+    />
+
+    <AccountDrawer
+      :open="accountDrawerOpen"
+      :account="accountInfo"
+      :loading="accountState.loading"
+      :error="accountState.error"
+      @close="accountDrawerOpen = false"
+      @copy="handleCopy"
+      @retry="loadAccount"
     />
 
     <DetailsDrawer

--- a/src/Acmebot.App/ClientApp/src/api/acmebotApi.ts
+++ b/src/Acmebot.App/ClientApp/src/api/acmebotApi.ts
@@ -1,4 +1,4 @@
-import type { CertificateItem, CertificatePolicyItem, CertificateRenewalItem, DnsZoneGroup, ProblemDetails } from './types';
+import type { AccountInfo, CertificateItem, CertificatePolicyItem, CertificateRenewalItem, DnsZoneGroup, ProblemDetails } from './types';
 
 const useMockApi = import.meta.env.DEV && import.meta.env.VITE_ACMEBOT_USE_MOCKS === 'true';
 
@@ -96,6 +96,15 @@ async function pollOperation(location: string): Promise<void> {
       throw new ApiError(getProblemMessage(response.status, body), response.status, body as ProblemDetails);
     }
   }
+}
+
+export async function getAccount(): Promise<AccountInfo> {
+  if (useMockApi) {
+    const { getMockAccount } = await import('./mockData');
+    return getMockAccount();
+  }
+
+  return requestJson<AccountInfo>('/api/account');
 }
 
 export async function getCertificates(): Promise<CertificateItem[]> {

--- a/src/Acmebot.App/ClientApp/src/api/mockData.ts
+++ b/src/Acmebot.App/ClientApp/src/api/mockData.ts
@@ -1,6 +1,12 @@
-import type { CertificateItem, CertificatePolicyItem, CertificateRenewalItem, DnsZoneGroup } from './types';
+import type { AccountInfo, CertificateItem, CertificatePolicyItem, CertificateRenewalItem, DnsZoneGroup } from './types';
 
 const day = 86_400_000;
+
+const mockAccount: AccountInfo = {
+  accountUri: 'https://acme-v02.api.letsencrypt.org/acme/acct/1234567890',
+  directoryUrl: 'https://acme-v02.api.letsencrypt.org/directory',
+  caaIdentities: ['letsencrypt.org'],
+};
 
 function dateFromNow(days: number): string {
   return new Date(Date.now() + days * day).toISOString();
@@ -196,6 +202,11 @@ const mockRenewalSchedules: Record<string, Partial<CertificateRenewalItem>> = {
     lastCheckedAt: dateBefore(0.1),
   },
 };
+
+export async function getMockAccount(): Promise<AccountInfo> {
+  await delay(250);
+  return structuredClone(mockAccount);
+}
 
 export async function getMockCertificates(): Promise<CertificateItem[]> {
   await delay(250);

--- a/src/Acmebot.App/ClientApp/src/api/types.ts
+++ b/src/Acmebot.App/ClientApp/src/api/types.ts
@@ -3,6 +3,12 @@ export type KeyCurveName = 'P-256' | 'P-384' | 'P-521' | 'P-256K';
 export type CertificateCategory = 'managed' | 'other-ca' | 'unmanaged';
 export type CertificateStatusKind = 'valid' | 'warning' | 'expired' | 'disabled';
 
+export interface AccountInfo {
+  accountUri: string;
+  directoryUrl: string;
+  caaIdentities: string[];
+}
+
 export interface CertificateItem {
   id: string;
   name: string;

--- a/src/Acmebot.App/ClientApp/src/components/AccountDrawer.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AccountDrawer.vue
@@ -1,0 +1,206 @@
+<script setup lang="ts">
+import { AlertTriangle, Copy, Info, LoaderCircle, RefreshCw, ShieldCheck, X } from 'lucide-vue-next';
+
+import type { AccountInfo } from '@/api/types';
+
+defineProps<{
+  account: AccountInfo | null;
+  open: boolean;
+  loading: boolean;
+  error: string;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  copy: [label: string, value: string];
+  retry: [];
+}>();
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="drawer-shell"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="account-details-heading"
+    >
+      <button
+        class="drawer-scrim"
+        type="button"
+        title="Close account information"
+        @click="emit('close')"
+      />
+      <aside class="drawer">
+        <header class="drawer__header">
+          <div>
+            <div class="eyebrow">
+              ACME
+            </div>
+            <h2 id="account-details-heading">
+              Account information
+            </h2>
+          </div>
+          <button
+            class="icon-only-button"
+            type="button"
+            title="Close account information"
+            @click="emit('close')"
+          >
+            <X
+              :size="18"
+              aria-hidden="true"
+            />
+          </button>
+        </header>
+
+        <div class="drawer__status-line">
+          <ShieldCheck
+            :size="16"
+            aria-hidden="true"
+          />
+          <span>Read-only account and issuer metadata</span>
+        </div>
+
+        <section
+          v-if="loading && !account"
+          class="drawer-state"
+          role="status"
+        >
+          <LoaderCircle
+            class="spin"
+            :size="24"
+            aria-hidden="true"
+          />
+          <div>
+            <strong>Loading account information</strong>
+            <p>The ACME account is being prepared.</p>
+          </div>
+        </section>
+
+        <section
+          v-else-if="error && !account"
+          class="drawer-state drawer-state--error"
+          role="alert"
+        >
+          <AlertTriangle
+            :size="24"
+            aria-hidden="true"
+          />
+          <div>
+            <strong>Failed to load account information</strong>
+            <p>{{ error }}</p>
+            <button
+              class="secondary-button"
+              type="button"
+              @click="emit('retry')"
+            >
+              <RefreshCw
+                :size="16"
+                aria-hidden="true"
+              />
+              Retry
+            </button>
+          </div>
+        </section>
+
+        <template v-else-if="account">
+          <section class="detail-section">
+            <h3>Account</h3>
+            <dl class="metadata-list">
+              <div class="metadata-row metadata-row--stacked">
+                <dt>Account URI</dt>
+                <dd class="metadata-value-line">
+                  <span class="metadata-value metadata-value--mono">{{ account.accountUri }}</span>
+                  <button
+                    class="copy-button"
+                    type="button"
+                    title="Copy account URI"
+                    @click="emit('copy', 'Account URI', account.accountUri)"
+                  >
+                    <Copy
+                      :size="15"
+                      aria-hidden="true"
+                    />
+                  </button>
+                </dd>
+              </div>
+              <div class="metadata-row metadata-row--stacked">
+                <dt>Directory URL</dt>
+                <dd class="metadata-value-line">
+                  <span class="metadata-value metadata-value--mono">{{ account.directoryUrl }}</span>
+                  <button
+                    class="copy-button"
+                    type="button"
+                    title="Copy directory URL"
+                    @click="emit('copy', 'Directory URL', account.directoryUrl)"
+                  >
+                    <Copy
+                      :size="15"
+                      aria-hidden="true"
+                    />
+                  </button>
+                </dd>
+              </div>
+            </dl>
+          </section>
+
+          <section class="detail-section">
+            <h3>CAA identities</h3>
+            <div
+              v-if="account.caaIdentities.length === 0"
+              class="drawer-empty"
+            >
+              <Info
+                :size="20"
+                aria-hidden="true"
+              />
+              <div>
+                <strong>No CAA identities advertised</strong>
+                <p>The ACME directory did not provide any issuer domain names.</p>
+              </div>
+            </div>
+            <ul
+              v-else
+              class="account-identity-list"
+            >
+              <li
+                v-for="(identity, index) in account.caaIdentities"
+                :key="`${identity}-${index}`"
+                class="account-identity-row"
+              >
+                <span class="metadata-value metadata-value--mono">{{ identity }}</span>
+                <button
+                  class="copy-button"
+                  type="button"
+                  :title="`Copy CAA identity ${identity}`"
+                  @click="emit('copy', 'CAA identity', identity)"
+                >
+                  <Copy
+                    :size="15"
+                    aria-hidden="true"
+                  />
+                </button>
+              </li>
+            </ul>
+          </section>
+
+          <section class="detail-section account-drawer__note">
+            Values are shown exactly as advertised by the ACME server.
+          </section>
+        </template>
+
+        <footer class="drawer__footer">
+          <button
+            class="secondary-button"
+            type="button"
+            @click="emit('close')"
+          >
+            Close
+          </button>
+        </footer>
+      </aside>
+    </div>
+  </Teleport>
+</template>

--- a/src/Acmebot.App/ClientApp/src/components/AccountDrawer.vue
+++ b/src/Acmebot.App/ClientApp/src/components/AccountDrawer.vue
@@ -30,6 +30,7 @@ const emit = defineEmits<{
         class="drawer-scrim"
         type="button"
         title="Close account information"
+        aria-label="Close account information"
         @click="emit('close')"
       />
       <aside class="drawer">
@@ -46,6 +47,7 @@ const emit = defineEmits<{
             class="icon-only-button"
             type="button"
             title="Close account information"
+            aria-label="Close account information"
             @click="emit('close')"
           >
             <X
@@ -117,6 +119,7 @@ const emit = defineEmits<{
                     class="copy-button"
                     type="button"
                     title="Copy account URI"
+                    aria-label="Copy account URI"
                     @click="emit('copy', 'Account URI', account.accountUri)"
                   >
                     <Copy
@@ -134,6 +137,7 @@ const emit = defineEmits<{
                     class="copy-button"
                     type="button"
                     title="Copy directory URL"
+                    aria-label="Copy directory URL"
                     @click="emit('copy', 'Directory URL', account.directoryUrl)"
                   >
                     <Copy
@@ -175,6 +179,7 @@ const emit = defineEmits<{
                   class="copy-button"
                   type="button"
                   :title="`Copy CAA identity ${identity}`"
+                  :aria-label="`Copy CAA identity ${identity}`"
                   @click="emit('copy', 'CAA identity', identity)"
                 >
                   <Copy

--- a/src/Acmebot.App/ClientApp/src/styles/app.css
+++ b/src/Acmebot.App/ClientApp/src/styles/app.css
@@ -25,6 +25,7 @@
 }
 
 .brand-lockup,
+.header-actions,
 .header-status,
 .table-toolbar__actions,
 .table-controls,
@@ -90,6 +91,20 @@
   border-radius: var(--radius-sm);
   background: var(--color-surface);
   white-space: nowrap;
+}
+
+.header-actions {
+  gap: 8px;
+}
+
+.header-status--button {
+  cursor: pointer;
+}
+
+.header-status--button:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-strong);
+  background: var(--color-surface-subtle);
 }
 
 .app-main {
@@ -970,6 +985,7 @@ button:disabled {
   min-width: 0;
   display: flex;
   align-items: center;
+  gap: 8px;
 }
 
 .metadata-value {
@@ -1022,6 +1038,86 @@ button:disabled {
   flex-wrap: wrap;
   border-top: 1px solid var(--color-border);
   background: var(--color-surface-subtle);
+}
+
+.drawer-state {
+  min-height: 240px;
+  padding: 40px 24px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 12px;
+  color: var(--color-muted);
+  text-align: center;
+}
+
+.drawer-state > svg {
+  color: var(--color-accent);
+}
+
+.drawer-state strong,
+.drawer-empty strong {
+  display: block;
+  color: var(--color-text);
+  font-size: 0.92rem;
+}
+
+.drawer-state p,
+.drawer-empty p {
+  margin-top: 4px;
+  color: var(--color-muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.drawer-state .secondary-button {
+  margin: 14px auto 0;
+}
+
+.drawer-state--error > svg {
+  color: var(--color-danger);
+}
+
+.drawer-empty {
+  margin-top: 10px;
+  padding: 14px;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  color: var(--color-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-subtle);
+}
+
+.account-identity-list {
+  margin: 10px 0 0;
+  padding: 0;
+  display: grid;
+  overflow: hidden;
+  list-style: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-subtle);
+}
+
+.account-identity-row {
+  min-width: 0;
+  padding: 9px 10px 9px 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-top: 1px solid var(--color-border);
+}
+
+.account-identity-row:first-child {
+  border-top: 0;
+}
+
+.account-drawer__note {
+  color: var(--color-muted);
+  font-size: 0.82rem;
+  line-height: 1.5;
 }
 
 .drawer__hint {
@@ -1688,6 +1784,10 @@ button:disabled {
     padding-bottom: 10px;
   }
 
+  .header-actions {
+    align-self: center;
+  }
+
   .table-toolbar,
   .app-footer__inner {
     align-items: stretch;
@@ -1888,6 +1988,16 @@ button:disabled {
 }
 
 @media (max-width: 520px) {
+  .app-header__inner {
+    flex-direction: column;
+  }
+
+  .header-actions {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .header-status {
     justify-content: center;
   }


### PR DESCRIPTION
## Summary

- add a header entry and lazy-loaded drawer for ACME account information
- display and copy the account URI, directory URL, and CAA identities
- add loading, retry, empty, responsive, and mock-data states

## Testing

- npm run lint
- npm run build

Closes #1236