### PR TITLE
Add anonymous health check endpoint to prevent stuck worker instances

### DIFF
--- a/deploy/azuredeploy.bicep
+++ b/deploy/azuredeploy.bicep
@@ -467,6 +467,7 @@ resource functionApp 'Microsoft.Web/sites@2025-03-01' = {
     siteConfig: {
       appSettings: acmebotAppSettings
       minTlsVersion: '1.2'
+      healthCheckPath: '/api/ping'
       cors: {
         allowedOrigins: ['https://portal.azure.com']
         supportCredentials: false

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "7475699352632478067"
+      "templateHash": "2054629406973803945"
     }
   },
   "definitions": {
@@ -368,6 +368,7 @@
         "siteConfig": {
           "appSettings": "[concat(createArray(createObject('name', 'APPLICATIONINSIGHTS_CONNECTION_STRING', 'value', reference('appInsights').ConnectionString), createObject('name', 'AzureWebJobsStorage', 'value', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix={2}', variables('storageAccountName'), listKeys('storageAccount', '2025-06-01').keys[0].value, environment().suffixes.storage)), createObject('name', 'DEPLOYMENT_STORAGE_CONNECTION_STRING', 'value', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix={2}', variables('storageAccountName'), listKeys('storageAccount', '2025-06-01').keys[0].value, environment().suffixes.storage)), createObject('name', 'Acmebot__Contacts', 'value', coalesce(tryGet(parameters('acme'), 'contacts'), '')), createObject('name', 'Acmebot__Endpoint', 'value', variables('acmeEndpoint')), createObject('name', 'Acmebot__VaultBaseUrl', 'value', variables('keyVaultBaseUrl')), createObject('name', 'Acmebot__Environment', 'value', environment().name)), variables('eabAppSettings'), variables('dnsProviderAppSettings'), if(variables('useUserAssignedIdentity'), createArray(createObject('name', 'Acmebot__ManagedIdentityClientId', 'value', coalesce(coalesce(tryGet(parameters('managedIdentity'), 'clientId'), tryGet(if(variables('useUserAssignedIdentity'), reference('userAssignedIdentity', '2023-01-31', 'full'), null()), 'properties', 'clientId')), ''))), createArray()), parameters('additionalAppSettings'))]",
           "minTlsVersion": "1.2",
+          "healthCheckPath": "/api/ping",
           "cors": {
             "allowedOrigins": [
               "https://portal.azure.com"

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -85,6 +85,14 @@ The HTTP triggers use anonymous trigger authorization so App Service Authenticat
 
 If `az account get-access-token` fails before the HTTP request is sent, fix Microsoft Entra consent first. In the Acmebot application registration, go to **Expose an API** > **Authorized client applications**, add `04b07795-8ddb-461a-bbee-02f9e1bf7b46`, and select `user_impersonation`. If App Service Authentication is configured to allow only specific client applications, add the same client ID to that allow list as well.
 
+## Dashboard Returns 500 on the First Request After Idle
+
+Typical symptom: the very first `GET /` after a sign-in redirect fails with a Functions host timeout (a `System.TimeoutException` waiting for the worker to start the invocation), while later requests succeed immediately.
+
+App Service Authentication handles the unauthenticated redirect and the `/.auth/login/aad/callback` exchange entirely at the platform layer; neither request reaches the .NET isolated worker. As a result, an instance can be running and even configured for Always Ready without ever having dispatched a single invocation to the worker. The first real invocation, the authenticated `GET /` that renders the dashboard, is then the first time that instance's worker executes application code, and it can occasionally exceed the platform's fixed startup wait.
+
+`healthCheckPath` in `deploy/azuredeploy.bicep` points at `GET /api/ping`, an anonymous endpoint that returns `200` without checking authentication. Azure's health check probe bypasses App Service Authentication and invokes it directly, which keeps the worker's request pipeline warm on every instance, including ones provisioned through Always Ready, without depending on a real user request. Do not repoint `healthCheckPath` at an authenticated route: unauthenticated probes would receive `401`, which the platform treats as unhealthy and can cause repeated instance recycling instead of preventing it.
+
 ## Renewal Does Not Run
 
 Typical causes:

--- a/src/Acmebot.App/Functions/Http/Ping.cs
+++ b/src/Acmebot.App/Functions/Http/Ping.cs
@@ -1,0 +1,20 @@
+using Azure.Functions.Worker.Extensions.HttpApi;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+namespace Acmebot.App.Functions.Http;
+
+public class Ping(IHttpContextAccessor httpContextAccessor) : HttpFunctionBase(httpContextAccessor)
+{
+    // Anonymous and unauthenticated on purpose: this is the target for healthCheckPath, so the
+    // Flex Consumption platform can invoke real worker code on every always ready instance
+    // without ever going through App Service Authentication.
+    [Function($"{nameof(Ping)}_{nameof(Get)}")]
+    public IActionResult Get(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "api/ping")] HttpRequest req)
+    {
+        return Ok();
+    }
+}

--- a/tests/Acmebot.App.Tests/PingTests.cs
+++ b/tests/Acmebot.App.Tests/PingTests.cs
@@ -1,0 +1,22 @@
+using Acmebot.App.Functions.Http;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class PingTests
+{
+    [Fact]
+    public void Get_WithoutAuthentication_ReturnsOk()
+    {
+        var httpContext = new DefaultHttpContext();
+        var function = new Ping(new HttpContextAccessor { HttpContext = httpContext });
+
+        var result = function.Get(httpContext.Request);
+
+        Assert.IsType<OkResult>(result);
+    }
+}


### PR DESCRIPTION
## Problem

The dashboard occasionally returns `500` on the first page load after signing in, with a `System.TimeoutException` in `DefaultHttpCoordinator.SetFunctionContextAsync` (~15s) in Application Insights. This can repeat on the same instance for every subsequent user until an unrelated scaling event replaces it, since nothing currently signals to the platform that the instance's worker stopped responding.

Root cause: `StaticPage_Serve` (the catch-all `GET {*path}` route that renders the dashboard) is the first invocation ever dispatched to a given instance's isolated worker. App Service Authentication handles the unauthenticated redirect (`GET /` → `302`) and the `/.auth/login/aad/callback` exchange entirely at the platform layer, without invoking any worker code. So an instance can be running, and even provisioned through Flex Consumption's Always Ready, while its worker has never executed a single invocation. If that first genuine invocation hangs, the instance keeps receiving new requests and can fail repeatedly, because there is no health signal telling the platform to replace it.

## Fix

- Add `GET /api/ping`, a new anonymous endpoint (`src/Acmebot.App/Functions/Http/Ping.cs`) that returns `200` unconditionally, without checking `User.Identity.IsAuthenticated`.
- Wire it up as `healthCheckPath` in `deploy/azuredeploy.bicep`, so the Flex Consumption platform's own health probe periodically invokes real worker code on every instance (including Always Ready ones) and can detect and replace an instance whose worker has stopped responding, instead of leaving it to serve repeated failures to users.
- Document the mechanism and the reasoning in `docs/guide/troubleshooting.md` under a new "Dashboard Returns 500 on the First Request After Idle" section, including why `healthCheckPath` must stay pointed at an unauthenticated route (pointing it at an authenticated route would make every instance look unhealthy to the probe, since anonymous probes would always receive `401`).

## Why an anonymous, unauthenticated endpoint

All other HTTP triggers use anonymous trigger authorization but require an authenticated principal in the function body (see `docs/reference/architecture.md`). `/api/ping` is intentionally the one exception: its only purpose is to exercise the isolated worker's request pipeline for the platform's health probe, which runs without a signed-in identity. It does not read or expose any application state.

## Testing

- `dotnet build -c Release ./Acmebot.slnx`
- `dotnet format --verify-no-changes --no-restore ./Acmebot.slnx`
- `dotnet test ./tests/Acmebot.App.Tests/Acmebot.App.Tests.csproj -c Release` (includes new `PingTests`)
- `az bicep build -f ./deploy/azuredeploy.bicep`

## Notes for reviewers

This was diagnosed from a production incident: Application Insights showed a single Flex Consumption instance failing every real invocation for over 20 minutes, affecting three different users with an identical ~15s timeout, before the instance stopped receiving traffic. A manual restart resolved the immediate incident; this PR addresses the underlying gap so the platform can self-heal instead of requiring manual intervention.
