### PR TITLE
feat: allow configuration of order polling

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -114,6 +114,8 @@ If it remains pending longer than expected:
 - Confirm the Function App has not restarted repeatedly.
 - Check whether the selected provider has a long propagation delay.
 - Poll the operation URL again before starting another operation for the same certificate.
+- If the orchestration fails after exhausting retries while waiting for the DNS TXT record to propagate, increase `Acmebot__DnsChallengeCheckMaxAttempts` and/or `Acmebot__DnsChallengeCheckIntervalSeconds` (see [Configuration](../reference/configuration.md#general-settings)) and restart the Function App.
+- If it instead fails while waiting for the ACME CA to mark the order `ready` or `valid`, the CA may be slower to process orders than the default polling window allows. Increase `Acmebot__OrderPollingMaxAttempts` and/or `Acmebot__OrderPollingIntervalSeconds` and restart the Function App.
 
 ## Certificate Issued But Endpoint Still Uses the Old Certificate
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -32,6 +32,10 @@ Acmebot__Endpoint=https://acme-v02.api.letsencrypt.org/directory
 | `Acmebot__PreferredProfile` | Empty | Preferred ACME profile when the CA advertises profiles. |
 | `Acmebot__RenewBeforeExpiry` | `30` | Percentage of certificate lifetime remaining at which scheduled renewal runs, used when ACME renewal information is unavailable for the certificate. Valid range is 0 to 100. |
 | `Acmebot__UseSystemNameServer` | `false` | Use the system DNS resolver instead of Google Public DNS for challenge verification. Enable it when the validation zone is private or outbound DNS policy requires internal resolvers. |
+| `Acmebot__DnsChallengeCheckMaxAttempts` | `12` | Maximum number of attempts (including the first) when verifying that the DNS TXT challenge record has propagated (queried against the resolver `UseSystemNameServer` selects). Valid range is 1 to 60. |
+| `Acmebot__DnsChallengeCheckIntervalSeconds` | `5` | Seconds to wait between DNS propagation check attempts. Increase this if DNS propagation is slow. Valid range is 1 to 300. |
+| `Acmebot__OrderPollingMaxAttempts` | `12` | Maximum number of attempts (including the first) when waiting for the ACME order to become `ready` after answering the challenge, and when waiting for it to become `valid` after finalization. Valid range is 1 to 60. |
+| `Acmebot__OrderPollingIntervalSeconds` | `5` | Seconds to wait between order status check attempts. Increase this if your CA is slow to process orders. Valid range is 1 to 300. |
 | `Acmebot__ManagedIdentityClientId` | Empty | Client ID for the app-wide user-assigned managed identity used for Key Vault certificate operations, Key Vault keys, Azure DNS providers that do not override it, Route 53 web identity federation when `RoleArn` is set, and Google Cloud DNS workload identity federation when `KeyFile64` is empty. When empty, Acmebot uses the system-assigned managed identity. The user-assigned identity must be assigned to the Function App. |
 
 ## Azure Environments

--- a/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
+++ b/src/Acmebot.App/Functions/Orchestration/AcmeOrderActivities.cs
@@ -25,6 +25,19 @@ public partial class AcmeOrderActivities(
 {
     private readonly AcmebotOptions _options = options.Value;
 
+    // Orchestrators must not read configuration directly, since a settings change mid-run could make a
+    // replay compute different retry policies than the ones already recorded in orchestration history.
+    // This activity's result is persisted in history instead, so it stays stable across replays.
+    [Function(nameof(GetCertificateIssuanceRetrySettings))]
+    public Task<CertificateIssuanceRetrySettings> GetCertificateIssuanceRetrySettings([ActivityTrigger] object? input = null) =>
+        Task.FromResult(new CertificateIssuanceRetrySettings
+        {
+            DnsChallengeCheckMaxAttempts = _options.DnsChallengeCheckMaxAttempts,
+            DnsChallengeCheckIntervalSeconds = _options.DnsChallengeCheckIntervalSeconds,
+            OrderPollingMaxAttempts = _options.OrderPollingMaxAttempts,
+            OrderPollingIntervalSeconds = _options.OrderPollingIntervalSeconds
+        });
+
     [Function(nameof(Order))]
     public async Task<OrderDetails> Order([ActivityTrigger] (IReadOnlyList<string>, string?, string?) input)
     {

--- a/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
@@ -18,6 +18,20 @@ public partial class CertificateIssuanceOrchestrator
 
         try
         {
+            // Fetch retry settings through an activity so the values are recorded in orchestration history
+            // and stay stable across replays even if configuration changes while this instance is running.
+            var retrySettings = await context.CallGetCertificateIssuanceRetrySettingsAsync(null);
+
+            var dnsChallengeCheckRetryPolicy = new RetryPolicy(retrySettings.DnsChallengeCheckMaxAttempts, TimeSpan.FromSeconds(retrySettings.DnsChallengeCheckIntervalSeconds))
+            {
+                HandleFailure = taskFailureDetails => taskFailureDetails.IsCausedBy<RetriableActivityException>()
+            };
+
+            var orderPollingRetryPolicy = new RetryPolicy(retrySettings.OrderPollingMaxAttempts, TimeSpan.FromSeconds(retrySettings.OrderPollingIntervalSeconds))
+            {
+                HandleFailure = taskFailureDetails => taskFailureDetails.IsCausedBy<RetriableActivityException>()
+            };
+
             // 前提条件をチェック
             certificatePolicyItem.DnsProviderName = await context.CallDns01PreconditionAsync(certificatePolicyItem);
 
@@ -38,13 +52,13 @@ public partial class CertificateIssuanceOrchestrator
                     await context.CreateTimer(context.CurrentUtcDateTime.AddSeconds(propagationSeconds), CancellationToken.None);
 
                     // 正しく追加した DNS TXT レコードが引けるか確認
-                    await context.CallCheckDnsChallengeAsync(challengeResults, TaskOptions.FromRetryPolicy(_retryPolicy));
+                    await context.CallCheckDnsChallengeAsync(challengeResults, TaskOptions.FromRetryPolicy(dnsChallengeCheckRetryPolicy));
 
                     // ACME Answer Challenge を実行
                     await context.CallAnswerChallengesAsync(challengeResults);
 
-                    // ACME Order のステータスが ready になるまで 60 秒待機
-                    await context.CallCheckIsReadyAsync((orderDetails, challengeResults), TaskOptions.FromRetryPolicy(_retryPolicy));
+                    // Wait for the ACME order to become ready (retry behavior configurable via OrderPollingMaxAttempts / OrderPollingIntervalSeconds)
+                    await context.CallCheckIsReadyAsync((orderDetails, challengeResults), TaskOptions.FromRetryPolicy(orderPollingRetryPolicy));
                 }
                 finally
                 {
@@ -59,8 +73,8 @@ public partial class CertificateIssuanceOrchestrator
             // Finalize の時点でステータスが valid の時点はスキップ
             if (orderDetails.Payload.Status != AcmeOrderStatuses.Valid)
             {
-                // Finalize 後のステータスが valid になるまで 60 秒待機
-                orderDetails = await context.CallCheckIsValidAsync(orderDetails, TaskOptions.FromRetryPolicy(_retryPolicy));
+                // Wait for the order to become valid after finalization (retry behavior configurable via OrderPollingMaxAttempts / OrderPollingIntervalSeconds)
+                orderDetails = await context.CallCheckIsValidAsync(orderDetails, TaskOptions.FromRetryPolicy(orderPollingRetryPolicy));
             }
 
             // 証明書をダウンロードし Key Vault に保存された秘密鍵とマージ
@@ -80,11 +94,6 @@ public partial class CertificateIssuanceOrchestrator
             throw;
         }
     }
-
-    private readonly RetryPolicy _retryPolicy = new(12, TimeSpan.FromSeconds(5))
-    {
-        HandleFailure = taskFailureDetails => taskFailureDetails.IsCausedBy<RetriableActivityException>()
-    };
 
     [LoggerMessage(LogLevel.Information, "Certificate issuance orchestration started. CertificateName: {CertificateName}. DnsNames: {DnsNames}")]
     private static partial void LogCertificateIssuanceStarted(ILogger logger, string certificateName, string dnsNames);

--- a/src/Acmebot.App/Models/CertificateIssuanceRetrySettings.cs
+++ b/src/Acmebot.App/Models/CertificateIssuanceRetrySettings.cs
@@ -1,0 +1,12 @@
+namespace Acmebot.App.Models;
+
+public sealed record CertificateIssuanceRetrySettings
+{
+    public required int DnsChallengeCheckMaxAttempts { get; init; }
+
+    public required int DnsChallengeCheckIntervalSeconds { get; init; }
+
+    public required int OrderPollingMaxAttempts { get; init; }
+
+    public required int OrderPollingIntervalSeconds { get; init; }
+}

--- a/src/Acmebot.App/Options/AcmebotOptions.cs
+++ b/src/Acmebot.App/Options/AcmebotOptions.cs
@@ -22,10 +22,22 @@ public class AcmebotOptions
     [Required]
     public required string Contacts { get; set; }
 
+    [Range(1, 60)]
+    public int DnsChallengeCheckMaxAttempts { get; set; } = 12;
+
+    [Range(1, 300)]
+    public int DnsChallengeCheckIntervalSeconds { get; set; } = 5;
+
     [Required]
     public required Uri Endpoint { get; set; }
 
     public ExternalAccountBindingOptions? ExternalAccountBinding { get; set; }
+
+    [Range(1, 60)]
+    public int OrderPollingMaxAttempts { get; set; } = 12;
+
+    [Range(1, 300)]
+    public int OrderPollingIntervalSeconds { get; set; } = 5;
 
     public string? PreferredChain { get; set; }
 

--- a/tests/Acmebot.App.Tests/AcmeOrderActivitiesTests.cs
+++ b/tests/Acmebot.App.Tests/AcmeOrderActivitiesTests.cs
@@ -8,6 +8,7 @@ using Acmebot.Acme;
 using Acmebot.Acme.Models;
 using Acmebot.App.Acme;
 using Acmebot.App.Functions.Orchestration;
+using Acmebot.App.Options;
 
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -17,6 +18,32 @@ namespace Acmebot.App.Tests;
 
 public sealed class AcmeOrderActivitiesTests
 {
+    [Fact]
+    public async Task GetCertificateIssuanceRetrySettings_ReturnsConfiguredValues()
+    {
+        var activities = new AcmeOrderActivities(
+            acmeClientFactory: null!,
+            certificateClient: null!,
+            Microsoft.Extensions.Options.Options.Create(new AcmebotOptions
+            {
+                Contacts = "admin@example.com",
+                Endpoint = new Uri("https://acme.example/directory"),
+                VaultBaseUrl = "https://vault.example/",
+                DnsChallengeCheckMaxAttempts = 20,
+                DnsChallengeCheckIntervalSeconds = 15,
+                OrderPollingMaxAttempts = 40,
+                OrderPollingIntervalSeconds = 10
+            }),
+            NullLogger<AcmeOrderActivities>.Instance);
+
+        var result = await activities.GetCertificateIssuanceRetrySettings(null);
+
+        Assert.Equal(20, result.DnsChallengeCheckMaxAttempts);
+        Assert.Equal(15, result.DnsChallengeCheckIntervalSeconds);
+        Assert.Equal(40, result.OrderPollingMaxAttempts);
+        Assert.Equal(10, result.OrderPollingIntervalSeconds);
+    }
+
     [Fact]
     public async Task CreateOrderAsync_WithAlreadyReplacedProblem_RetriesWithoutReplaces()
     {

--- a/tests/Acmebot.App.Tests/AcmebotOptionsTests.cs
+++ b/tests/Acmebot.App.Tests/AcmebotOptionsTests.cs
@@ -1,0 +1,81 @@
+using System.ComponentModel.DataAnnotations;
+
+using Acmebot.App.Options;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class AcmebotOptionsTests
+{
+    [Fact]
+    public void Validate_WithDefaultValues_Succeeds()
+    {
+        Assert.True(TryValidate(CreateValidOptions(), out _));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(61)]
+    public void Validate_WithOutOfRangeDnsChallengeCheckMaxAttempts_Fails(int value)
+    {
+        var options = CreateValidOptions();
+        options.DnsChallengeCheckMaxAttempts = value;
+
+        Assert.False(TryValidate(options, out var results));
+        Assert.Contains(results, x => x.MemberNames.Contains(nameof(AcmebotOptions.DnsChallengeCheckMaxAttempts)));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(301)]
+    public void Validate_WithOutOfRangeDnsChallengeCheckIntervalSeconds_Fails(int value)
+    {
+        var options = CreateValidOptions();
+        options.DnsChallengeCheckIntervalSeconds = value;
+
+        Assert.False(TryValidate(options, out var results));
+        Assert.Contains(results, x => x.MemberNames.Contains(nameof(AcmebotOptions.DnsChallengeCheckIntervalSeconds)));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(61)]
+    public void Validate_WithOutOfRangeOrderPollingMaxAttempts_Fails(int value)
+    {
+        var options = CreateValidOptions();
+        options.OrderPollingMaxAttempts = value;
+
+        Assert.False(TryValidate(options, out var results));
+        Assert.Contains(results, x => x.MemberNames.Contains(nameof(AcmebotOptions.OrderPollingMaxAttempts)));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(301)]
+    public void Validate_WithOutOfRangeOrderPollingIntervalSeconds_Fails(int value)
+    {
+        var options = CreateValidOptions();
+        options.OrderPollingIntervalSeconds = value;
+
+        Assert.False(TryValidate(options, out var results));
+        Assert.Contains(results, x => x.MemberNames.Contains(nameof(AcmebotOptions.OrderPollingIntervalSeconds)));
+    }
+
+    private static AcmebotOptions CreateValidOptions()
+    {
+        return new AcmebotOptions
+        {
+            Contacts = "admin@example.com",
+            Endpoint = new Uri("https://acme.example/directory"),
+            VaultBaseUrl = "https://vault.example/"
+        };
+    }
+
+    private static bool TryValidate(AcmebotOptions options, out List<ValidationResult> results)
+    {
+        results = [];
+
+        return Validator.TryValidateObject(options, new ValidationContext(options), results, validateAllProperties: true);
+    }
+}


### PR DESCRIPTION
## Summary

- Some ACME CAs can take longer than the ~60 second default window to move an order to `ready` or `valid`, or longer than expected for a DNS TXT challenge record to propagate. Both windows were previously fixed via a hardcoded `RetryPolicy` in `CertificateIssuanceOrchestrator`, so a slow CA or slow DNS propagation would cause issuance/renewal to fail with no way to work around it short of a code change.
- Added four app settings so both retry windows are independently configurable per deployment:
  - `Acmebot__DnsChallengeCheckMaxAttempts` (default `12`) / `Acmebot__DnsChallengeCheckIntervalSeconds` (default `5`), governs waiting for the DNS TXT challenge record to propagate.
  - `Acmebot__OrderPollingMaxAttempts` (default `12`) / `Acmebot__OrderPollingIntervalSeconds` (default `5`), governs waiting for the ACME order to become `ready` and, after finalization, `valid`.
  - Defaults preserve current behavior (~60s per window).

## Test plan

- [x] `dotnet build src/Acmebot.App/Acmebot.App.csproj` — succeeds with 0 warnings/errors
- [x] `dotnet test tests/Acmebot.App.Tests` — 139/139 passing