### PR TITLE
feat: status updates during issuance process

### DIFF
--- a/src/Acmebot.App/ClientApp/src/App.vue
+++ b/src/Acmebot.App/ClientApp/src/App.vue
@@ -4,7 +4,7 @@ import { Activity, AlertTriangle, BadgeCheck, CircleSlash, ExternalLink, Info, P
 
 import { formatApiError, getAccount, getCertificateRenewals, getCertificates, getDnsZones, issueCertificate, renewCertificate, revokeCertificate } from '@/api/acmebotApi';
 import { getLatestRelease } from '@/api/releases';
-import type { AccountInfo, CertificateItem, CertificatePolicyItem, CertificateRenewalItem, DnsZoneGroup, ReleaseInfo } from '@/api/types';
+import type { AccountInfo, CertificateIssuanceStatus, CertificateItem, CertificatePolicyItem, CertificateRenewalItem, DnsZoneGroup, ReleaseInfo } from '@/api/types';
 import AccountDrawer from '@/components/AccountDrawer.vue';
 import AddCertificateDialog from '@/components/AddCertificateDialog.vue';
 import CertificateTable from '@/components/CertificateTable.vue';
@@ -231,13 +231,19 @@ async function refreshCertificates(): Promise<void> {
   await Promise.all([loadCertificates(), loadRenewals()]);
 }
 
-async function runCertificateOperation(title: string, message: string, action: () => Promise<void>): Promise<void> {
+async function runCertificateOperation(
+  title: string,
+  message: string,
+  action: (onProgress: (status: CertificateIssuanceStatus) => void) => Promise<void>,
+): Promise<void> {
   operation.active = true;
   operation.title = title;
   operation.message = message;
 
   try {
-    await action();
+    await action((status) => {
+      operation.message = status.message;
+    });
     pushToast('success', 'Operation completed', message.replace('...', ' completed.'));
     addDialogOpen.value = false;
     selectedCertificate.value = null;
@@ -250,14 +256,16 @@ async function runCertificateOperation(title: string, message: string, action: (
 }
 
 async function handleIssueCertificate(policy: CertificatePolicyItem): Promise<void> {
-  await runCertificateOperation('Issuing certificate', 'Issuing certificate...', () => issueCertificate(policy));
+  await runCertificateOperation('Issuing certificate', 'Issuing certificate...', (onProgress) => issueCertificate(policy, onProgress));
 }
 
 async function handleRenewCertificate(certificate: CertificateItem): Promise<void> {
   detailsBusy.value = true;
 
   try {
-    await runCertificateOperation('Renewing certificate', `Renewing ${certificate.name}...`, () => renewCertificate(certificate.name));
+    await runCertificateOperation('Renewing certificate', `Renewing ${certificate.name}...`, (onProgress) =>
+      renewCertificate(certificate.name, onProgress),
+    );
   } finally {
     detailsBusy.value = false;
   }

--- a/src/Acmebot.App/ClientApp/src/api/acmebotApi.ts
+++ b/src/Acmebot.App/ClientApp/src/api/acmebotApi.ts
@@ -1,4 +1,12 @@
-import type { AccountInfo, CertificateItem, CertificatePolicyItem, CertificateRenewalItem, DnsZoneGroup, ProblemDetails } from './types';
+import type {
+  AccountInfo,
+  CertificateIssuanceStatus,
+  CertificateItem,
+  CertificatePolicyItem,
+  CertificateRenewalItem,
+  DnsZoneGroup,
+  ProblemDetails,
+} from './types';
 
 const useMockApi = import.meta.env.DEV && import.meta.env.VITE_ACMEBOT_USE_MOCKS === 'true';
 
@@ -81,7 +89,7 @@ async function startOperation(input: RequestInfo | URL, init?: RequestInit): Pro
   return location;
 }
 
-async function pollOperation(location: string): Promise<void> {
+async function pollOperation(location: string, onProgress?: (status: CertificateIssuanceStatus) => void): Promise<void> {
   while (true) {
     await new Promise((resolve) => window.setTimeout(resolve, 3000));
 
@@ -94,6 +102,10 @@ async function pollOperation(location: string): Promise<void> {
 
     if (response.status !== 202) {
       throw new ApiError(getProblemMessage(response.status, body), response.status, body as ProblemDetails);
+    }
+
+    if (onProgress && body && typeof body === 'object') {
+      onProgress(body as CertificateIssuanceStatus);
     }
   }
 }
@@ -136,10 +148,13 @@ export async function getCertificateRenewals(): Promise<CertificateRenewalItem[]
   return requestJson<CertificateRenewalItem[]>('/api/renewals');
 }
 
-export async function issueCertificate(policy: CertificatePolicyItem): Promise<void> {
+export async function issueCertificate(
+  policy: CertificatePolicyItem,
+  onProgress?: (status: CertificateIssuanceStatus) => void,
+): Promise<void> {
   if (useMockApi) {
     const { mockIssueCertificate } = await import('./mockData');
-    await mockIssueCertificate(policy);
+    await mockIssueCertificate(policy, onProgress);
     return;
   }
 
@@ -149,13 +164,16 @@ export async function issueCertificate(policy: CertificatePolicyItem): Promise<v
     body: JSON.stringify(policy),
   });
 
-  await pollOperation(location);
+  await pollOperation(location, onProgress);
 }
 
-export async function renewCertificate(certificateName: string): Promise<void> {
+export async function renewCertificate(
+  certificateName: string,
+  onProgress?: (status: CertificateIssuanceStatus) => void,
+): Promise<void> {
   if (useMockApi) {
     const { mockRenewCertificate } = await import('./mockData');
-    await mockRenewCertificate(certificateName);
+    await mockRenewCertificate(certificateName, onProgress);
     return;
   }
 
@@ -163,7 +181,7 @@ export async function renewCertificate(certificateName: string): Promise<void> {
     method: 'POST',
   });
 
-  await pollOperation(location);
+  await pollOperation(location, onProgress);
 }
 
 export async function revokeCertificate(certificateName: string): Promise<void> {

--- a/src/Acmebot.App/ClientApp/src/api/mockData.ts
+++ b/src/Acmebot.App/ClientApp/src/api/mockData.ts
@@ -1,4 +1,4 @@
-import type { AccountInfo, CertificateItem, CertificatePolicyItem, CertificateRenewalItem, DnsZoneGroup } from './types';
+import type { AccountInfo, CertificateIssuanceStatus, CertificateItem, CertificatePolicyItem, CertificateRenewalItem, DnsZoneGroup } from './types';
 
 const day = 86_400_000;
 
@@ -223,8 +223,11 @@ export async function getMockCertificateRenewals(): Promise<CertificateRenewalIt
   return structuredClone(mockCertificates.map(createMockCertificateRenewal)).toSorted(compareCertificateRenewals);
 }
 
-export async function mockIssueCertificate(policy: CertificatePolicyItem): Promise<void> {
-  await delay(700);
+export async function mockIssueCertificate(
+  policy: CertificatePolicyItem,
+  onProgress?: (status: CertificateIssuanceStatus) => void,
+): Promise<void> {
+  await emitMockProgress(policy.certificateName, onProgress);
 
   mockCertificates = [
     ...mockCertificates,
@@ -250,8 +253,11 @@ export async function mockIssueCertificate(policy: CertificatePolicyItem): Promi
   ];
 }
 
-export async function mockRenewCertificate(certificateName: string): Promise<void> {
-  await delay(650);
+export async function mockRenewCertificate(
+  certificateName: string,
+  onProgress?: (status: CertificateIssuanceStatus) => void,
+): Promise<void> {
+  await emitMockProgress(certificateName, onProgress);
   mockCertificates = mockCertificates.map((certificate) =>
     certificate.name === certificateName
       ? {
@@ -271,6 +277,19 @@ export async function mockRevokeCertificate(certificateName: string): Promise<vo
 
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+}
+
+const mockIssuanceSteps: Pick<CertificateIssuanceStatus, 'step' | 'message'>[] = [
+  { step: 'CreatingOrder', message: 'Creating ACME order...' },
+  { step: 'WaitingForDnsPropagation', message: 'Waiting for DNS propagation...' },
+  { step: 'MergingCertificate', message: 'Saving certificate to Key Vault...' },
+];
+
+async function emitMockProgress(certificateName: string, onProgress?: (status: CertificateIssuanceStatus) => void): Promise<void> {
+  for (const { step, message } of mockIssuanceSteps) {
+    await delay(250);
+    onProgress?.({ certificateName, step, message, updatedAt: new Date().toISOString() });
+  }
 }
 
 function createMockCertificateRenewal(certificate: CertificateItem): CertificateRenewalItem {

--- a/src/Acmebot.App/ClientApp/src/api/types.ts
+++ b/src/Acmebot.App/ClientApp/src/api/types.ts
@@ -67,6 +67,13 @@ export interface CertificateRenewalItem {
   lastCheckedAt?: string | null;
 }
 
+export interface CertificateIssuanceStatus {
+  certificateName: string;
+  step: string;
+  message: string;
+  updatedAt: string;
+}
+
 export interface ProblemDetails {
   title?: string;
   detail?: string;

--- a/src/Acmebot.App/Functions/Http/GetOperation.cs
+++ b/src/Acmebot.App/Functions/Http/GetOperation.cs
@@ -1,4 +1,8 @@
-﻿using Azure.Functions.Worker.Extensions.HttpApi;
+﻿using System.Text.Json;
+
+using Acmebot.App.Models;
+
+using Azure.Functions.Worker.Extensions.HttpApi;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -30,12 +34,36 @@ public partial class GetOperation(IHttpContextAccessor httpContextAccessor, ILog
             return BadRequest();
         }
 
+        var status = ReadIssuanceStatus(metadata);
+
         return metadata.RuntimeStatus switch
         {
-            OrchestrationRuntimeStatus.Failed => Problem(metadata.FailureDetails?.ErrorMessage, type: metadata.FailureDetails?.ErrorType),
-            OrchestrationRuntimeStatus.Running or OrchestrationRuntimeStatus.Pending => Accepted(Url.RouteUrl($"{nameof(GetOperation)}_{nameof(HttpStart)}", new { instanceId }), null),
+            OrchestrationRuntimeStatus.Failed => Problem(detail: BuildFailureDetail(metadata.FailureDetails?.ErrorMessage, status), type: metadata.FailureDetails?.ErrorType),
+            OrchestrationRuntimeStatus.Running or OrchestrationRuntimeStatus.Pending => Accepted(Url.RouteUrl($"{nameof(GetOperation)}_{nameof(HttpStart)}", new { instanceId }), status),
             _ => Ok()
         };
+    }
+
+    internal static string? BuildFailureDetail(string? errorMessage, CertificateIssuanceStatus? status)
+    {
+        return status is not null ? $"{errorMessage} (failed during: {status.Message})" : errorMessage;
+    }
+
+    internal static CertificateIssuanceStatus? ReadIssuanceStatus(OrchestrationMetadata metadata)
+    {
+        if (metadata.SerializedCustomStatus is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return metadata.ReadCustomStatusAs<CertificateIssuanceStatus>();
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     [LoggerMessage(LogLevel.Information, "Instance state lookup returned no result. InstanceId: {InstanceId}")]

--- a/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
+++ b/src/Acmebot.App/Functions/Orchestration/CertificateIssuanceOrchestrator.cs
@@ -19,54 +19,85 @@ public partial class CertificateIssuanceOrchestrator
         try
         {
             // 前提条件をチェック
+            SetIssuanceStatus(context, certificatePolicyItem.CertificateName, "Precondition", "Checking prerequisites...");
             certificatePolicyItem.DnsProviderName = await context.CallDns01PreconditionAsync(certificatePolicyItem);
 
             // 新しく ACME Order を作成する (ARI で更新扱いにする場合は既存証明書の Certificate ID を replaces に指定)
+            SetIssuanceStatus(context, certificatePolicyItem.CertificateName, "CreatingOrder", "Creating ACME order...");
             var orderDetails = await context.CallOrderAsync((certificatePolicyItem.DnsNames, certificatePolicyItem.CertificateId, certificatePolicyItem.Profile));
 
             // 既に確認済みの場合は Challenge をスキップする
             if (orderDetails.Payload.Status != AcmeOrderStatuses.Ready)
             {
                 // ACME DNS-01 Challenge を実行
+                SetIssuanceStatus(context, certificatePolicyItem.CertificateName, "CreatingDnsRecords", "Creating DNS challenge records...");
                 var (challengeResults, propagationSeconds) = await context.CallDns01AuthorizationAsync((certificatePolicyItem.DnsProviderName, certificatePolicyItem.DnsAlias, orderDetails.Payload.Authorizations));
+
+                var dnsChallengeStep = "CreatingDnsRecords";
+                var dnsChallengeMessage = "Creating DNS challenge records...";
+                var dnsChallengeSucceeded = false;
 
                 try
                 {
                     // DNS Provider が指定した分だけ後続の処理を遅延させる
                     LogDnsChallengePropagationDelay(logger, certificatePolicyItem.CertificateName, propagationSeconds);
 
+                    dnsChallengeStep = "WaitingForDnsPropagation";
+                    dnsChallengeMessage = "Waiting for DNS propagation...";
+                    SetIssuanceStatus(context, certificatePolicyItem.CertificateName, dnsChallengeStep, dnsChallengeMessage);
                     await context.CreateTimer(context.CurrentUtcDateTime.AddSeconds(propagationSeconds), CancellationToken.None);
 
                     // 正しく追加した DNS TXT レコードが引けるか確認
+                    dnsChallengeStep = "VerifyingDnsChallenge";
+                    dnsChallengeMessage = "Verifying DNS challenge record...";
+                    SetIssuanceStatus(context, certificatePolicyItem.CertificateName, dnsChallengeStep, dnsChallengeMessage);
                     await context.CallCheckDnsChallengeAsync(challengeResults, TaskOptions.FromRetryPolicy(_retryPolicy));
 
                     // ACME Answer Challenge を実行
+                    dnsChallengeStep = "AnsweringChallenges";
+                    dnsChallengeMessage = "Notifying ACME server...";
+                    SetIssuanceStatus(context, certificatePolicyItem.CertificateName, dnsChallengeStep, dnsChallengeMessage);
                     await context.CallAnswerChallengesAsync(challengeResults);
 
                     // ACME Order のステータスが ready になるまで 60 秒待機
+                    dnsChallengeStep = "WaitingForOrderReady";
+                    dnsChallengeMessage = "Waiting for order to become ready...";
+                    SetIssuanceStatus(context, certificatePolicyItem.CertificateName, dnsChallengeStep, dnsChallengeMessage);
                     await context.CallCheckIsReadyAsync((orderDetails, challengeResults), TaskOptions.FromRetryPolicy(_retryPolicy));
+
+                    dnsChallengeSucceeded = true;
                 }
                 finally
                 {
                     // 作成した DNS レコードを削除
+                    SetIssuanceStatus(context, certificatePolicyItem.CertificateName, "CleaningUpDnsRecords", "Cleaning up DNS challenge records...");
                     await context.CallCleanupDnsChallengeAsync((certificatePolicyItem.DnsProviderName, challengeResults));
+
+                    if (!dnsChallengeSucceeded)
+                    {
+                        SetIssuanceStatus(context, certificatePolicyItem.CertificateName, dnsChallengeStep, dnsChallengeMessage);
+                    }
                 }
             }
 
             // Key Vault で CSR を作成し Finalize を実行
+            SetIssuanceStatus(context, certificatePolicyItem.CertificateName, "FinalizingOrder", "Finalizing order...");
             orderDetails = await context.CallFinalizeOrderAsync((certificatePolicyItem, orderDetails));
 
             // Finalize の時点でステータスが valid の時点はスキップ
             if (orderDetails.Payload.Status != AcmeOrderStatuses.Valid)
             {
                 // Finalize 後のステータスが valid になるまで 60 秒待機
+                SetIssuanceStatus(context, certificatePolicyItem.CertificateName, "WaitingForOrderValid", "Waiting for certificate to be issued...");
                 orderDetails = await context.CallCheckIsValidAsync(orderDetails, TaskOptions.FromRetryPolicy(_retryPolicy));
             }
 
             // 証明書をダウンロードし Key Vault に保存された秘密鍵とマージ
+            SetIssuanceStatus(context, certificatePolicyItem.CertificateName, "MergingCertificate", "Saving certificate to Key Vault...");
             var certificate = await context.CallMergeCertificateAsync((certificatePolicyItem.CertificateName, orderDetails));
 
             // 証明書の更新が完了後に Webhook を送信する
+            SetIssuanceStatus(context, certificatePolicyItem.CertificateName, "SendingCompletedEvent", "Sending completion notification...");
             await context.CallSendCompletedEventAsync((certificate.Name, certificate.ExpiresOn, certificatePolicyItem.DnsNames));
 
             LogCertificateIssuanceCompleted(logger, certificate.Name, certificate.ExpiresOn);
@@ -85,6 +116,17 @@ public partial class CertificateIssuanceOrchestrator
     {
         HandleFailure = taskFailureDetails => taskFailureDetails.IsCausedBy<RetriableActivityException>()
     };
+
+    private static void SetIssuanceStatus(TaskOrchestrationContext context, string certificateName, string step, string message)
+    {
+        context.SetCustomStatus(new CertificateIssuanceStatus
+        {
+            CertificateName = certificateName,
+            Step = step,
+            Message = message,
+            UpdatedAt = context.CurrentUtcDateTime
+        });
+    }
 
     [LoggerMessage(LogLevel.Information, "Certificate issuance orchestration started. CertificateName: {CertificateName}. DnsNames: {DnsNames}")]
     private static partial void LogCertificateIssuanceStarted(ILogger logger, string certificateName, string dnsNames);

--- a/src/Acmebot.App/Models/CertificateIssuanceStatus.cs
+++ b/src/Acmebot.App/Models/CertificateIssuanceStatus.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Acmebot.App.Models;
+
+public sealed record CertificateIssuanceStatus
+{
+    [JsonPropertyName("certificateName")]
+    public required string CertificateName { get; init; }
+
+    [JsonPropertyName("step")]
+    public required string Step { get; init; }
+
+    [JsonPropertyName("message")]
+    public required string Message { get; init; }
+
+    [JsonPropertyName("updatedAt")]
+    public required DateTimeOffset UpdatedAt { get; init; }
+}

--- a/tests/Acmebot.App.Tests/GetOperationTests.cs
+++ b/tests/Acmebot.App.Tests/GetOperationTests.cs
@@ -1,0 +1,94 @@
+﻿using System.Text.Json;
+
+using Acmebot.App.Functions.Http;
+using Acmebot.App.Models;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.DurableTask.Client;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Xunit;
+
+namespace Acmebot.App.Tests;
+
+public sealed class GetOperationTests
+{
+    [Fact]
+    public async Task HttpStart_WhenUnauthenticated_ReturnsUnauthorized()
+    {
+        var httpContext = new DefaultHttpContext();
+        var function = new GetOperation(new HttpContextAccessor { HttpContext = httpContext }, NullLogger<GetOperation>.Instance);
+
+        var result = await function.HttpStart(httpContext.Request, "instance-1", starter: null!);
+
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    [Fact]
+    public void BuildFailureDetail_WithStatus_IncludesStepMessage()
+    {
+        var status = new CertificateIssuanceStatus
+        {
+            CertificateName = "example-com",
+            Step = "MergingCertificate",
+            Message = "Saving certificate to Key Vault...",
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        var detail = GetOperation.BuildFailureDetail("Key Vault request failed.", status);
+
+        Assert.Equal("Key Vault request failed. (failed during: Saving certificate to Key Vault...)", detail);
+    }
+
+    [Fact]
+    public void BuildFailureDetail_WithoutStatus_ReturnsErrorMessageUnchanged()
+    {
+        var detail = GetOperation.BuildFailureDetail("Key Vault request failed.", status: null);
+
+        Assert.Equal("Key Vault request failed.", detail);
+    }
+
+    [Fact]
+    public void ReadIssuanceStatus_WithoutCustomStatus_ReturnsNull()
+    {
+        var metadata = new OrchestrationMetadata("IssueCertificate", "instance-1");
+
+        var status = GetOperation.ReadIssuanceStatus(metadata);
+
+        Assert.Null(status);
+    }
+
+    // OrchestrationMetadata.ReadCustomStatusAs<T>() (used by ReadIssuanceStatus for a non-null
+    // SerializedCustomStatus) throws unless the instance was fetched by the real Durable Task
+    // runtime with getInputsAndOutputs: true; there is no supported way to construct such an
+    // instance from test code. This test instead locks the exact wire contract that
+    // ReadCustomStatusAs relies on, so a property-name/attribute regression is still caught.
+    [Fact]
+    public void CertificateIssuanceStatus_JsonRoundTrip_PreservesAllFieldsWithExpectedPropertyNames()
+    {
+        var updatedAt = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var status = new CertificateIssuanceStatus
+        {
+            CertificateName = "example-com",
+            Step = "MergingCertificate",
+            Message = "Saving certificate to Key Vault...",
+            UpdatedAt = updatedAt
+        };
+
+        var json = JsonSerializer.Serialize(status);
+
+        using (var document = JsonDocument.Parse(json))
+        {
+            var root = document.RootElement;
+            Assert.Equal("example-com", root.GetProperty("certificateName").GetString());
+            Assert.Equal("MergingCertificate", root.GetProperty("step").GetString());
+            Assert.Equal("Saving certificate to Key Vault...", root.GetProperty("message").GetString());
+            Assert.Equal(updatedAt, root.GetProperty("updatedAt").GetDateTimeOffset());
+        }
+
+        var roundTripped = JsonSerializer.Deserialize<CertificateIssuanceStatus>(json);
+
+        Assert.Equal(status, roundTripped);
+    }
+}


### PR DESCRIPTION
### Summary
- While issuing or renewing a certificate, the status endpoint (`GET /api/operations/{instanceId}`) previously returned a bare `202 Accepted` with no body, so the UI showed a static "Issuing certificate..." spinner for the whole duration with no indication of which step (order creation, DNS record setup, propagation wait, challenge verification, finalization, Key Vault merge, etc.) was running.
- `CertificateIssuanceOrchestrator` now reports its current step via `context.SetCustomStatus(...)` at each stage — the same mechanism `CertificateRenewalSchedulerOrchestrator` already uses for the background renewal scheduler — and `GetOperation` surfaces that status in the `202` response body while running, and folds the last known step into the error detail if the orchestration ends in `Failed` (e.g. `"...error... (failed during: Saving certificate to Key Vault...)"`).
- The frontend's polling loop (`pollOperation`) now takes an optional progress callback, wired up in `App.vue` to update the operation overlay's message live instead of showing a fixed string for the whole operation.

### Changes
- `Models/CertificateIssuanceStatus.cs` (new): DTO carrying `certificateName`, `step`, `message`, `updatedAt`.
- `CertificateIssuanceOrchestrator.cs`: sets a custom status before each of the ~9 pipeline steps.
- `GetOperation.cs`: reads the custom status back and includes it in the `202` body; extracted `BuildFailureDetail`/`ReadIssuanceStatus` as `internal static` helpers so the new logic is unit-testable.
- `api/types.ts`, `api/acmebotApi.ts`, `App.vue`, `api/mockData.ts`: thread an optional `onProgress` callback through `issueCertificate`/`renewCertificate` → `pollOperation` → the `OperationOverlay` message, plus a matching simulation in the dev mocks.

### Test plan
- [x] `dotnet build -c Release ./Acmebot.slnx`
- [x] `dotnet format --verify-no-changes --no-restore ./Acmebot.slnx`
- [x] `dotnet test ./Acmebot.slnx` — 133/133 passing (4 new: `GetOperationTests`)
- [x] `bicep build ./deploy/azuredeploy.bicep` (no infra changes in this PR, ran as part of validation)
- [x] `vue-tsc --noEmit` and `eslint .` on the ClientApp