### PR TITLE
fix: don't filter pending state out for akamai zones

### DIFF
--- a/src/Acmebot.App/Providers/AkamaiEdgeDnsProvider.cs
+++ b/src/Acmebot.App/Providers/AkamaiEdgeDnsProvider.cs
@@ -84,7 +84,7 @@ public class AkamaiEdgeDnsProvider(AkamaiEdgeDnsOptions options) : IDnsProvider
                     break;
                 }
 
-                foreach (var zone in result.Zones.Where(x => x.ActivationState == "ACTIVE"))
+                foreach (var zone in result.Zones.Where(x => x.ActivationState is "ACTIVE" or "PENDING"))
                 {
                     yield return zone;
                 }


### PR DESCRIPTION
## Summary

- After a successful certificate issuance, reopening the "issue certificate" modal showed an empty DNS zone list for the Akamai DNS provider (`"AkamaiEdgeDns": []`), even though zones existed. It recovered on its own after a short wait and a refresh.
- Root cause: the orchestrator's post-issuance cleanup step deletes the `_acme-challenge` TXT record it created, which flips that Akamai Edge DNS zone's `activationState` from `ACTIVE` to `PENDING` while the change propagates (per Akamai's docs, this can take anywhere from seconds to a couple of minutes). `AkamaiEdgeDnsProvider.ListZonesInternalAsync` filtered zones to `ActivationState == "ACTIVE"` only, so any zone mid-propagation, most often the very zone just used for issuance, dropped out of the list until Akamai finished activating it.

## Changes

- `AkamaiEdgeDnsProvider.cs`: relaxed the zone filter from `ActivationState == "ACTIVE"` to `ActivationState is "ACTIVE" or "PENDING"`. A `PENDING` zone already has working delegation and accepts further record changes. This still excludes [the other Akamai activation states](https://techdocs.akamai.com/edge-dns/reference/activation-state-definitions) (`NEW`, `PENDING_APPROVAL`, `ERROR`, `LOCKED`, `OBSOLETE`, `DELETED`), none of which represent a zone ready to receive new records.

## Test plan

- [x] `dotnet build src/Acmebot.App/Acmebot.App.csproj` — succeeds with 0 warnings/errors
- [x] `dotnet test tests/Acmebot.App.Tests` — 129/129 passing